### PR TITLE
If kubeadmin password is not provided, assume that the cluster is already logged in

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -167,12 +167,11 @@ class OC(SSH):
         """
 
         try:
-            if self.__kubeadmin_password:
-                return self.run(f'oc login -u kubeadmin -p {self.__kubeadmin_password}', is_check=True)
-            else:
-                raise LoginFailed
+            if self.__kubeadmin_password and self.__kubeadmin_password != '':
+                self.run(f'oc login -u kubeadmin -p {self.__kubeadmin_password}', is_check=True)
         except Exception as err:
             raise LoginFailed
+        return True
 
     @logger_time_stamp
     def get_pods(self):

--- a/benchmark_runner/common/ssh/ssh.py
+++ b/benchmark_runner/common/ssh/ssh.py
@@ -30,7 +30,7 @@ class SSH:
                 output = subprocess.getoutput(cmd)
             return output
         except subprocess.CalledProcessError as err:
-            logger.error("subprocess Status : FAIL", err.returncode, err.output)
+            logger.error(f'subprocess Status : FAIL: {err.returncode} {err.output}')
             raise SSHSubprocessError()
         except Exception as err:
              raise err


### PR DESCRIPTION
* If the kubeconfig is already logged in, it's not necessary to `oc login`, and that may fail on clusters provisioned on bare metal.
* Ensure that tests for timeout failures actually do time out, even if the underlying operation completes very quickly.
* Fix incorrect arguments to logging in ssh.py.