### PR TITLE
Uperf PerfCI conf changes

### DIFF
--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/internal_data/uperf_pod_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/internal_data/uperf_pod_template.yaml
@@ -22,15 +22,15 @@ spec:
     args:
       client_resources:
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: {{ client_limits_cpu }}
+          memory: {{ client_limits_memory_GB }}Gi
         limits:
           cpu: {{ client_limits_cpu }}
           memory: {{ client_limits_memory_GB }}Gi
       server_resources:
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: {{ server_limits_cpu }}
+          memory: {{ server_limits_memory_GB }}Gi
         limits:
           cpu: {{ server_limits_cpu }}
           memory: {{ server_limits_memory_GB }}Gi
@@ -45,15 +45,14 @@ spec:
       samples: {{ samples }}
       pair: {{ pair }}
       test_types:
-        - {{ test_type }}
+        - {{ test_type1 }}
+        - {{ test_type2 }}
       protos:
         - {{ proto }}
       sizes:
         - {{ size1 }}
         - {{ size2 }}
         - {{ size3 }}
-        - {{ size4 }}
-        - {{ size5 }}
       nthrs:
         - {{ nthr1 }}
         - {{ nthr2 }}

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/internal_data/uperf_vm_template.yaml
@@ -31,15 +31,14 @@ spec:
      samples: {{ samples }}
      pair: {{ pair }}
      test_types:
-       - {{ test_type }}
+       - {{ test_type1 }}
+       - {{ test_type2 }}
      protos:
        - {{ proto }}
      sizes:
        - {{ size1 }}
        - {{ size2 }}
        - {{ size3 }}
-       - {{ size4 }}
-       - {{ size5 }}
      nthrs:
        - {{ nthr1 }}
        - {{ nthr2 }}
@@ -47,16 +46,16 @@ spec:
      kind: vm
      server_vm:
        dedicatedcpuplacement: false
-       sockets: 1
-       cores: {{ server_cores }}
+       sockets: {{ server_sockets }}
+       cores: 1
        threads: 1
-       image: kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
+       image: quay.io/kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
        limits:
-         memory: {{ server_limits_memory_GB }}Gi
+         memory: {{ server_memory_GB }}Gi
        requests:
-         memory: 10Mi
+         memory: {{ server_memory_GB }}Gi
        network:
-         front_end: bridge # or masquerade
+         front_end: masquerade
          multiqueue:
            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
@@ -65,14 +64,14 @@ spec:
          #- hostpassthrough
      client_vm:
        dedicatedcpuplacement: false
-       sockets: 1
-       cores: {{ client_cores }}
+       sockets: {{ client_sockets }}
+       cores: 1
        threads: 1
-       image: kubevirt/fedora-cloud-container-disk-demo:latest
+       image: quay.io/kubevirt/fedora-cloud-container-disk-demo:latest
        limits:
-         memory: {{ client_limits_memory_GB }}Gi
+         memory: {{ client_memory_GB }}Gi
        requests:
-         memory: 10Mi
+         memory: {{ client_memory_GB }}Gi
        network:
          front_end: masquerade
          multiqueue:

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/uperf_data_template.yaml
@@ -11,16 +11,15 @@ shared_data:
   multus: false
   samples: 1
   pair: 1
-  test_type: stream
+  test_type1: stream
+  test_type2: rr
   proto: tcp
   size1: 64
-  size2: 256
-  size3: 1024
-  size4: 4096
-  size5: 16384
+  size2: 1024
+  size3: 8192
   nthr1: 1
-  nthr2: 2
-  runtime: 30
+  nthr2: 8
+  runtime: 60
   # enable/disable system metrics
   system_metrics: {{ system_metrics }}
   prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
@@ -30,13 +29,13 @@ shared_data:
   #metrics_profile: https://raw.githubusercontent.com/cloud-bulldozer/benchmark-operator/master/roles/kube-burner/files/metrics.yaml
 pod:
   es_kind: {{ kind }}
-  client_limits_cpu: 4
-  client_limits_memory_GB: 16
-  server_limits_cpu: 4
-  server_limits_memory_GB: 16
+  client_limits_cpu: 8
+  client_limits_memory_GB: 8
+  server_limits_cpu: 8
+  server_limits_memory_GB: 8
 vm:
   es_kind: vm
-  server_cores: 4
-  server_limits_memory_GB: 16
-  client_cores: 4
-  client_limits_memory_GB: 16
+  server_sockets: 8
+  server_memory_GB: 8
+  client_sockets: 8
+  client_memory_GB: 8


### PR DESCRIPTION
Adjusting uperf params as agreed to in the scaling review.
Moving VM cpus to sockets instead of cores since that is the default vcpu topology (for perf reasons).
Setting net type to masquerade since bridge is not officially supported. 