### PR TITLE
Change VM vcpu topology from cores to sockets 

### DIFF
--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/uperf/internal_data/uperf_vm_template.yaml
@@ -47,8 +47,8 @@ spec:
      kind: vm
      server_vm:
        dedicatedcpuplacement: false
-       sockets: 1
-       cores: {{ server_cores }}
+       sockets: {{ server_sockets }}
+       cores: 1
        threads: 1
        image: kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
        limits:
@@ -65,8 +65,8 @@ spec:
          #- hostpassthrough
      client_vm:
        dedicatedcpuplacement: false
-       sockets: 1
-       cores: {{ client_cores }}
+       sockets: {{ client_sockets }}
+       cores: 1
        threads: 1
        image: kubevirt/fedora-cloud-container-disk-demo:latest
        limits:

--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/uperf/uperf_data_template.yaml
@@ -36,7 +36,7 @@ pod:
   server_limits_memory_GB: 16
 vm:
   es_kind: vm
-  server_cores: 4
+  server_sockets: 4
   server_limits_memory_GB: 16
-  client_cores: 4
+  client_sockets: 4
   client_limits_memory_GB: 16

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/uperf/internal_data/uperf_vm_template.yaml
@@ -47,8 +47,8 @@ spec:
      kind: vm
      server_vm:
        dedicatedcpuplacement: false
-       sockets: 1
-       cores: {{ server_cores }}
+       sockets: {{ server_sockets }}
+       cores: 1
        threads: 1
        image: kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
        limits:
@@ -65,8 +65,8 @@ spec:
          #- hostpassthrough
      client_vm:
        dedicatedcpuplacement: false
-       sockets: 1
-       cores: {{ client_cores }}
+       sockets: {{ client_sockets }}
+       cores: 1
        threads: 1
        image: kubevirt/fedora-cloud-container-disk-demo:latest
        limits:

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/uperf/uperf_data_template.yaml
@@ -36,7 +36,7 @@ pod:
   server_limits_memory_GB: 16
 vm:
   es_kind: vm
-  server_cores: 4
+  server_sockets: 4
   server_limits_memory_GB: 16
-  client_cores: 4
+  client_sockets: 4
   client_limits_memory_GB: 16


### PR DESCRIPTION
"Sockets" are the default vcpu topology in KVM for perf reasons (uses a scheduler sync_wake hint that helps certain types of workloads)