### PR TITLE
Ignore current_run directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ tests/results.xml
 */tests/results.xml
 results.xml
 
+#Runtime
+**/current_run/
 
 # Translations
 *.mo


### PR DESCRIPTION
Ignore the current_run directories, which contain runtime files that should never be committed.