### PR TITLE
update fedora image to 34

### DIFF
--- a/benchmark_runner/benchmark_operator/benchmark_operator_workloads.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_workloads.py
@@ -259,8 +259,12 @@ class BenchmarkOperatorWorkloads:
                     'version': int(self.__runner_version.split('.')[-1]),
                     'ci_date': datetime.datetime.now().strftime(date_format)}
         if kind:
-            metadata.update({'kind': kind,
-                             'vm_os_version': 'centos8'})
+            metadata.update({'kind': kind})
+        if database:
+            metadata.update({'vm_os_version': 'centos8'})
+        else:
+            metadata.update({'vm_os_version': 'fedora34'})
+
         # for hammerdb
         if database == 'mssql':
             metadata.update({'db_version': 2019})

--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/stressng/internal_data/stressng_vm_template.yaml
@@ -39,7 +39,7 @@ spec:
         sockets: 1
         cores: {{ cores }}
         threads: 1
-        image: kubevirt/fedora-cloud-container-disk-demo:latest
+        image: quay.io/kubevirt/fedora-container-disk-images:34
         limits:
           memory: {{ limits_memory_GB }}Gi
         requests:

--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/uperf/internal_data/uperf_vm_template.yaml
@@ -50,7 +50,7 @@ spec:
        sockets: 1
        cores: {{ server_cores }}
        threads: 1
-       image: kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
+       image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
          memory: {{ server_limits_memory_GB }}Gi
        requests:
@@ -68,7 +68,7 @@ spec:
        sockets: 1
        cores: {{ client_cores }}
        threads: 1
-       image: kubevirt/fedora-cloud-container-disk-demo:latest
+       image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
          memory: {{ client_limits_memory_GB }}Gi
        requests:

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/stressng/internal_data/stressng_vm_template.yaml
@@ -39,7 +39,7 @@ spec:
         sockets: 1
         cores: {{ cores }}
         threads: 1
-        image: kubevirt/fedora-cloud-container-disk-demo:latest
+        image: quay.io/kubevirt/fedora-container-disk-images:34
         limits:
           memory: {{ limits_memory_GB }}Gi
         requests:

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/uperf/internal_data/uperf_vm_template.yaml
@@ -49,7 +49,7 @@ spec:
        sockets: {{ server_sockets }}
        cores: 1
        threads: 1
-       image: quay.io/kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
+       image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
          memory: {{ server_memory_GB }}Gi
        requests:
@@ -67,7 +67,7 @@ spec:
        sockets: {{ client_sockets }}
        cores: 1
        threads: 1
-       image: quay.io/kubevirt/fedora-cloud-container-disk-demo:latest
+       image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
          memory: {{ client_memory_GB }}Gi
        requests:

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/stressng/internal_data/stressng_vm_template.yaml
@@ -39,7 +39,7 @@ spec:
         sockets: 1
         cores: {{ cores }}
         threads: 1
-        image: kubevirt/fedora-cloud-container-disk-demo:latest
+        image: quay.io/kubevirt/fedora-container-disk-images:34
         limits:
           memory: {{ limits_memory_GB }}Gi
         requests:

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/uperf/internal_data/uperf_vm_template.yaml
@@ -50,7 +50,7 @@ spec:
        sockets: 1
        cores: {{ server_cores }}
        threads: 1
-       image: kubevirt/fedora-cloud-container-disk-demo:latest # your image must've ethtool installed if enabling multiqueue
+       image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
          memory: {{ server_limits_memory_GB }}Gi
        requests:
@@ -68,7 +68,7 @@ spec:
        sockets: 1
        cores: {{ client_cores }}
        threads: 1
-       image: kubevirt/fedora-cloud-container-disk-demo:latest
+       image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
          memory: {{ client_limits_memory_GB }}Gi
        requests:

--- a/tests/integration/benchmark_runner/templates/stressng_vm_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_vm_template.yaml
@@ -39,13 +39,13 @@ spec:
         sockets: 1
         cores: 2
         threads: 1
-        image: kubevirt/fedora-cloud-container-disk-demo:latest
+        image: quay.io/kubevirt/fedora-container-disk-images:34
         limits:
           memory: 16Gi
         requests:
           memory: 10Mi
         network:
-          front_end: bridge # or masquerade
+          front_end: masquerade
           multiqueue:
             enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
             queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed


### PR DESCRIPTION
Description: updated the fedora image to 34

Fedora 32 is no longer support.
Get the following error:
``Nov 10 21:14:38 uperf-client-10 cloud-init[841]: Fedora 32 openh264 (From Cisco) - x86_64        0.0  B/s |   0  B     00:42
Nov 10 21:14:38 uperf-client-10 cloud-init[841]: Errors during downloading metadata for repository 'fedora-cisco-openh264':
Nov 10 21:14:38 uperf-client-10 cloud-init[841]:   - Curl error (6): Couldn't resolve host name for https://codecs.fedoraproject.org//openh264/32/x86_64/os/repodata/repomd.xml [Could not resolve host: codecs.fedoraproject.org]
Nov 10 21:14:38 uperf-client-10 cloud-init[841]: Error: Failed to download metadata for repo 'fedora-cisco-openh264': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried