### PR TITLE
Install kata workaround for OCP 4.8

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -666,13 +666,13 @@ class OC(SSH):
             logger.info(f'run {resource}')
             self._create_async(yaml=os.path.join(path, resource))
             # for first script wait for virt-operator
-            if '01_operator.yaml' in resource:
+            if '01_operator.yaml' == resource:
                 # Wait that cnv operator will be created
                 self.wait_for_ocp_resource_create(resource='kata',
                                                   verify_cmd='oc -n openshift-sandboxed-containers-operator wait deployment/controller-manager --for=condition=Available',
                                                   status='deployment.apps/controller-manager condition met')
             # for second script wait for kataconfig installation to no longer be in progress
-            else:
+            elif '02_config.yaml' == resource:
                 self.wait_for_ocp_resource_create(resource='kata',
                                                   verify_cmd="oc get kataconfig -ojsonpath='{.items[0].status.installationStatus.IsInProgress}'",
                                                   status='false')
@@ -680,4 +680,7 @@ class OC(SSH):
                 completedNodesCount = self.run(cmd="oc get kataconfig -ojsonpath='{.items[0].status.installationStatus.completed.completedNodesCount}'")
                 if totalNodesCount != completedNodesCount:
                     raise KataInstallationFailed(f'not all nodes installed successfully total {totalNodesCount} != completed {completedNodesCount}')
+            # 
+            elif '03_ocp48_patch.sh' == resource:
+                self.run(cmd=f'chmod +x {os.path.join(path, resource)}; {path}/./{resource}')
         return True

--- a/benchmark_runner/common/ocp_resources/kata/template/03_ocp48_patch_template.sh
+++ b/benchmark_runner/common/ocp_resources/kata/template/03_ocp48_patch_template.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+CMDFILE=$(cat <<'EOF'
+#!/bin/bash
+set -e
+if [[ -f /usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh ]] ; then
+    sudo mount -o rw,remount /usr
+    grep cpu /usr/lib/udev/rules.d/40-redhat.rules
+    sudo sed -i  's/^SUBSYSTEM=="cpu"/#SUBSYSTEM=="cpu"/' /usr/lib/udev/rules.d/40-redhat.rules
+    grep cpu /usr/lib/udev/rules.d/40-redhat.rules
+    sudo /usr/libexec/kata-containers/osbuilder/kata-osbuilder.sh
+    sudo mount -o ro,remount /usr
+    grep cpu /usr/lib/udev/rules.d/40-redhat.rules
+else
+    echo "Kata does not appear to be installed on $(hostname)"
+    exit 1
+fi
+EOF
+)
+
+declare -a oc_version
+IFS=. read -r -a oc_version <<< "$(oc version -ojson |jq -r .openshiftVersion)"
+
+if ((oc_version[0] > 4 || (oc_version[0] == 4 && oc_version[1] != 8) )) ; then
+    echo "Openshift version ${oc_version[0]}.${oc_version[1]}.${oc_version[2]} does not need Kata workaround" 1>&2
+elif [[ -z "$(oc get ns openshift-sandboxed-containers-operator -oname)" ]] ; then
+    echo "openshift-sandboxed-containers-operator is not installed" 1>&2
+elif [[ -z "$(oc get kataconfig 2>/dev/null)" ]] ; then
+    echo "No Kata configuration available!" 1>&2
+else
+    for node in $(oc get node -lnode-role.kubernetes.io/worker= -oname --no-headers); do
+	oc debug -T "$node" -- chroot /host sh -c 'cat > /tmp/fix-kata; chmod +x /tmp/fix-kata; /tmp/fix-kata; rm -f /tmp/fix-kata' <<< "$CMDFILE"
+    done
+fi


### PR DESCRIPTION
Install the workaround required to allow use of >1 CPU on Kata VMs in OCP 4.8