### PR TITLE
Remove stray YAML nits to make cleaner YAML files for the CI flavor collapse work

### DIFF
--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/hammerdb/internal_data/mariadb_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/hammerdb/internal_data/mariadb_ephemeral_template.yaml
@@ -88,4 +88,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/hammerdb/internal_data/mssql_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/hammerdb/internal_data/mssql_ephemeral_template.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -60,4 +59,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/func_ci/hammerdb/internal_data/postgres_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/func_ci/hammerdb/internal_data/postgres_ephemeral_template.yaml
@@ -82,4 +82,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/hammerdb/internal_data/mariadb_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/hammerdb/internal_data/mariadb_ephemeral_template.yaml
@@ -88,4 +88,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/hammerdb/internal_data/mssql_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/hammerdb/internal_data/mssql_ephemeral_template.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -60,4 +59,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/hammerdb/internal_data/postgres_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/perf_ci/hammerdb/internal_data/postgres_ephemeral_template.yaml
@@ -82,4 +82,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/hammerdb/internal_data/mariadb_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/hammerdb/internal_data/mariadb_ephemeral_template.yaml
@@ -88,4 +88,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/hammerdb/internal_data/mssql_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/hammerdb/internal_data/mssql_ephemeral_template.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -60,4 +59,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/benchmark_runner/benchmark_operator/workload_flavors/test_ci/hammerdb/internal_data/postgres_ephemeral_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/test_ci/hammerdb/internal_data/postgres_ephemeral_template.yaml
@@ -82,4 +82,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_kata_mariadb_OCS_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_kata_mariadb_OCS_PVC_False/mariadb.yaml
@@ -85,4 +85,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_kata_mssql_OCS_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_kata_mssql_OCS_PVC_False/mssql.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -57,4 +56,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_kata_postgres_OCS_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_kata_postgres_OCS_PVC_False/postgres.yaml
@@ -79,4 +79,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_pod_mariadb_OCS_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_pod_mariadb_OCS_PVC_False/mariadb.yaml
@@ -84,4 +84,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_pod_mssql_OCS_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_pod_mssql_OCS_PVC_False/mssql.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -56,4 +55,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_pod_postgres_OCS_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_hammerdb_pod_postgres_OCS_PVC_False/postgres.yaml
@@ -78,4 +78,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_kata_mariadb_OCS_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_kata_mariadb_OCS_PVC_False/mariadb.yaml
@@ -85,4 +85,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_kata_mssql_OCS_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_kata_mssql_OCS_PVC_False/mssql.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -57,4 +56,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_kata_postgres_OCS_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_kata_postgres_OCS_PVC_False/postgres.yaml
@@ -79,4 +79,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_pod_mariadb_OCS_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_pod_mariadb_OCS_PVC_False/mariadb.yaml
@@ -84,4 +84,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_pod_mssql_OCS_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_pod_mssql_OCS_PVC_False/mssql.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -56,4 +55,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_pod_postgres_OCS_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_hammerdb_pod_postgres_OCS_PVC_False/postgres.yaml
@@ -78,4 +78,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_kata_mariadb_OCS_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_kata_mariadb_OCS_PVC_False/mariadb.yaml
@@ -85,4 +85,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_kata_mssql_OCS_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_kata_mssql_OCS_PVC_False/mssql.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -57,4 +56,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_kata_postgres_OCS_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_kata_postgres_OCS_PVC_False/postgres.yaml
@@ -79,4 +79,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_pod_mariadb_OCS_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_pod_mariadb_OCS_PVC_False/mariadb.yaml
@@ -84,4 +84,3 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_pod_mssql_OCS_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_pod_mssql_OCS_PVC_False/mssql.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -56,4 +55,3 @@ spec:
     - protocol: TCP
       port: 1433
       targetPort: 1433
----

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_pod_postgres_OCS_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_hammerdb_pod_postgres_OCS_PVC_False/postgres.yaml
@@ -78,4 +78,3 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
----


### PR DESCRIPTION
A lot of the YAML templates had unnecessary `---` lines at the top or bottom that make the CI flavor collapse work more difficult because they generate spurious changes.  This removes them.  Currently in testing on func.