### PR TITLE
Merge hammerdb and other workload template generation

### DIFF
--- a/benchmark_runner/benchmark_operator/benchmark_operator_workloads.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_workloads.py
@@ -633,16 +633,15 @@ class BenchmarkOperatorWorkloads:
         self.remove_if_exist_run_yaml()
         workload_name = workload_full_name.split('_')
 
+        self.__template.generate_yamls(workload=workload_full_name)
         if 'hammerdb' in workload_full_name:
             # check if ocs is installed
             if self.__environment_variables_dict.get('ocs_pvc', '') == 'True':
                 if not self.__oc.is_ocs_installed():
                     raise OCSNonInstalled()
-            self.__template.generate_hammerdb_yamls(workload=f'{workload_name[0]}_{workload_name[1]}', database=workload_name[2])
             class_method = getattr(BenchmarkOperatorWorkloads, f'{workload_name[0]}_{workload_name[1]}')
             class_method(self, workload_name[2])
         else:
-            self.__template.generate_workload_yamls(workload=workload_full_name)
             class_method = getattr(BenchmarkOperatorWorkloads, workload_full_name)
             class_method(self)
         # remove workload yaml at the end of run

--- a/benchmark_runner/benchmark_operator/workload_flavors/generate_yaml_from_workload_flavors.py
+++ b/benchmark_runner/benchmark_operator/workload_flavors/generate_yaml_from_workload_flavors.py
@@ -18,8 +18,6 @@ class TemplateOperations:
         self.__run_type = self.__environment_variables_dict.get('run_type', '')
         self.__dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates')
         self.__current_run_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'current_run')
-        self.__hammerdb_dir_path = os.path.join(self.__dir_path, f'hammerdb')
-        self.__hammerdb__internal_dir_path = os.path.join(self.__dir_path, f'hammerdb', 'internal_data')
         if self.__run_type == 'test_ci':
             self.__environment_variables_dict['es_suffix'] = '-test-ci'
         else:
@@ -30,6 +28,122 @@ class TemplateOperations:
         else:
             self.__storage_type = 'ephemeral'
 
+    def __get_workload_name(self, workload: str):
+        return workload.split('_')[0]
+
+    def __get_workload_kind(self, workload: str):
+        return workload.split('_')[1]
+
+    def __get_workload_extra(self, workload: str):
+        return '_'.join(workload.split('_')[2:])
+
+    def __get_workload_template_kind(self, workload: str):
+        """
+        Kata shares templates with pod
+        """
+        kind = self.__get_workload_kind(workload)
+        if kind == 'kata' or kind == 'pod':
+            return 'pod'
+        elif kind == 'vm':
+            return 'vm'
+        else:
+            return None
+
+    def __get_yaml_template_by_workload(self, workload: str, extension='.yaml', skip: str = 'data'):
+        """
+        This method return yaml names in benchmark_operator folder
+        :return:
+        """
+        # Kata reuses the pod templates
+        kind = self.__get_workload_template_kind(workload)
+        base_workload = self.__get_workload_name(workload)
+        full_workload = f'{base_workload}_{kind}'
+        if not full_workload:
+            return None
+
+        for filename in os.listdir(os.path.join(self.__dir_path, base_workload, 'internal_data')):
+            if filename.endswith(extension):
+                if filename.startswith(full_workload) and skip not in filename:
+                    return os.path.splitext(filename)[0]
+
+    def __get_subdict(self, dictionary: dict, key: str, value: str):
+        if key in dictionary:
+            subdict = dictionary[key]
+            if value in subdict:
+                return subdict[value]
+            elif 'default' in subdict:
+                return subdict['default']
+        return dict()
+
+    @logger_time_stamp
+    def generate_yamls_internal(self, workload: str):
+        """
+        Generate required .yaml files as a dictionary of file names and contents
+        :return: Dictionary <filename:contents>
+        """
+        workload_template = self.__get_yaml_template_by_workload(workload=workload)
+        workload_name = self.__get_workload_name(workload)
+        workload_dir_path = os.path.join(self.__dir_path, workload_name)
+        self.__environment_variables_dict['workload_name'] = workload_name
+        common_data = yaml.load(render_yaml_file(self.__dir_path, 'common.yaml', self.__environment_variables_dict), Loader=yaml.FullLoader)['common_data']
+        common_data = {**self.__environment_variables_dict, **common_data}
+        workload_data = yaml.load(render_yaml_file(workload_dir_path, f'{workload_name}_data_template.yaml', common_data), Loader=yaml.FullLoader)
+        render_data = workload_data['shared_data']
+
+        kind = self.__get_workload_kind(workload)
+        render_data['kind'] = kind
+        render_data['workload_name'] = workload_name
+        kind_data = self.__get_subdict(workload_data, 'kind_data', kind)
+        run_type_data = self.__get_subdict(workload_data, 'run_type_data', self.__run_type)
+        kind_runtype_data = self.__get_subdict(kind_data, 'run_type_data', self.__run_type)
+
+        render_data = {**common_data, **render_data,
+                       **kind_data, **run_type_data, **kind_runtype_data}
+        workload_file_suffix=''
+
+        answer = {}
+        if workload_name == 'hammerdb':
+            database = self.__get_workload_extra(workload)
+            database_data = self.__get_subdict(workload_data, 'database_data', database)
+
+            database_kind_data = self.__get_subdict(database_data, 'kind_data', kind)
+            database_runtype_data = self.__get_subdict(database_data, 'run_type_data', self.__run_type)
+            render_data = {**render_data, **database_data, **database_kind_data, **database_runtype_data}
+            workload_file_suffix=f'_{database}'
+
+            # Jinja render database pod yaml
+            if kind == 'pod' or kind == 'kata':
+                # Override any more generic data
+                database_name = f'{database}_template.yaml'
+                with open(os.path.join(workload_dir_path, 'internal_data', database_name)) as f:
+                    database_template = Template(f.read())
+                answer[f'{database}.yaml'] = database_template.render(render_data)
+
+        # Jinja render workload yaml
+        with open(os.path.join(workload_dir_path, 'internal_data', f'{workload_template}.yaml')) as f:
+            tm = Template(f.read())
+        workload_file_name = workload_template.replace('_template', '')
+        answer[f'{workload_file_name}{workload_file_suffix}.yaml'] = tm.render(render_data)
+
+        return answer
+
+    @logger_time_stamp
+    def generate_files(self, data_files: dict):
+        for filename, data in data_files.items():
+            with open(os.path.join(self.__current_run_path, filename), 'w') as f:
+                f.write(data)
+
+    @logger_time_stamp
+    def generate_yamls(self, workload: str):
+        """
+        This method generate workload yaml from template
+        :return:
+        """
+
+        self.generate_files(self.generate_yamls_internal(workload=workload))
+
+    # The following routines are for testing purposes,
+    # in particular to allow a known environment to be set up for golden file testing
     def initialize_environment(self, environment: dict = environment_variables.environment_variables_dict):
         self.__environment_variables_dict = environment
         self.__initialize_dependent_variables__()
@@ -48,140 +162,3 @@ class TemplateOperations:
 
     def get_current_run_path(self):
         return self.__current_run_path
-
-    @logger_time_stamp
-    def __get_yaml_template_by_workload(self, workload: str, extension='.yaml', skip: str = 'data'):
-        """
-        This method return yaml names in benchmark_operator folder
-        :return:
-        """
-        # Kata reuses the pod templates
-        if '_kata' in workload:
-            workload = f'{workload[:-len("_kata")]}_pod'
-
-        for file in os.listdir(os.path.join(self.__dir_path, workload.split('_')[0], 'internal_data')):
-            if file.endswith(extension):
-                if workload and workload in file and skip not in file:
-                    return os.path.splitext(file)[0]
-
-    @logger_time_stamp
-    def generate_files(self, data_files: dict):
-        for filename, data in data_files.items():
-            with open(os.path.join(self.__current_run_path, filename), 'w') as f:
-                f.write(data)
-
-    def __get_workload_keys(self, workload: str):
-        """
-        Compute kind and data key from workload name
-        """
-        if '_pod' in workload:
-            return 'pod'
-        elif '_kata' in workload:
-            return 'kata'
-        elif '_vm' in workload:
-            return 'vm'
-        else:
-            return None
-
-    def __get_subdict(self, dictionary: dict, key: str, value: str):
-        if key in dictionary:
-            subdict = dictionary[key]
-            if value in subdict:
-                return subdict[value]
-            elif 'default' in subdict:
-                return subdict['default']
-        return dict()
-
-    @logger_time_stamp
-    def generate_hammerdb_yamls_internal(self, workload: str, database: str):
-        """
-        Generate required .yaml files as a dictionary of file names and contents
-        :return: Dictionary <filename:contents>
-        """
-        # Get hammerdb data
-        hammerdb_template = self.__get_yaml_template_by_workload(workload=workload)
-        self.__environment_variables_dict['workload_name'] = 'hammerdb'
-        common_data = yaml.load(render_yaml_file(self.__dir_path, 'common.yaml', self.__environment_variables_dict), Loader=yaml.FullLoader)['common_data']
-        common_data = {**self.__environment_variables_dict, **common_data}
-        hammerdb_data = yaml.load(render_yaml_file(self.__hammerdb_dir_path, 'hammerdb_data_template.yaml', common_data), Loader=yaml.FullLoader)
-        render_data = hammerdb_data['shared_data']
-
-        kind = self.__get_workload_keys(workload)
-        render_data['kind'] = kind
-        database_data = self.__get_subdict(hammerdb_data, 'database_data', database)
-        kind_data = self.__get_subdict(hammerdb_data, 'kind_data', kind)
-        run_type_data = self.__get_subdict(hammerdb_data, 'run_type_data', self.__run_type)
-
-        database_kind_data = self.__get_subdict(database_data, 'kind_data', kind)
-        database_runtype_data = self.__get_subdict(database_data, 'run_type_data', self.__run_type)
-
-        kind_runtype_data = self.__get_subdict(kind_data, 'run_type_data', self.__run_type)
-        render_data = {**common_data, **render_data,
-                       **kind_data, **database_data, **run_type_data,
-                       **database_kind_data, **database_runtype_data,
-                       **kind_runtype_data}
-
-        # Jinja render hammerdb yaml
-        with open(os.path.join(self.__hammerdb_dir_path, 'internal_data', f'{hammerdb_template}.yaml')) as f:
-            tm = Template(f.read())
-        hammerdb_name = hammerdb_template.replace('template', '')
-        answer = {}
-        answer[f'{hammerdb_name}{database}.yaml'] = tm.render(render_data)
-
-        # Jinja render database pod yaml
-        if 'pod' in workload or 'kata' in workload:
-            # replace parameter from hammerdb_data
-            database_name = f'{database}_template.yaml'
-            with open(os.path.join(self.__hammerdb__internal_dir_path, database_name)) as f:
-                database_template = Template(f.read())
-            answer[f'{database}.yaml'] = database_template.render(render_data)
-
-        return answer
-
-    @logger_time_stamp
-    def generate_hammerdb_yamls(self, workload: str, database: str):
-        """
-        This method generate hammerdb yaml from workload_flavors,
-        special generator for 2 yaml file: database and workload
-        :return:
-        """
-        self.generate_files(self.generate_hammerdb_yamls_internal(workload=workload, database=database))
-
-    @logger_time_stamp
-    def generate_workload_yamls_internal(self, workload: str):
-        """
-        This method generate workload yaml from template
-        :return: Dictionary <filename:contents>
-        """
-
-        workload_template = self.__get_yaml_template_by_workload(workload=workload)
-        workload_name = workload.split('_')[0]
-        workload_dir_path = os.path.join(self.__dir_path, workload_name)
-        self.__environment_variables_dict['workload_name'] = workload_name
-        common_data = yaml.load(render_yaml_file(self.__dir_path, 'common.yaml', self.__environment_variables_dict), Loader=yaml.FullLoader)['common_data']
-        common_data = {**self.__environment_variables_dict, **common_data}
-        workload_data = yaml.load(render_yaml_file(workload_dir_path, f'{workload_name}_data_template.yaml', common_data), Loader=yaml.FullLoader)
-        render_data = workload_data['shared_data']
-
-        kind = self.__get_workload_keys(workload)
-        render_data['kind'] = kind
-        render_data['workload_name'] = workload_name
-        kind_data = self.__get_subdict(workload_data, 'kind_data', kind)
-        run_type_data = self.__get_subdict(workload_data, 'run_type_data', self.__run_type)
-
-        kind_runtype_data = self.__get_subdict(kind_data, 'run_type_data', self.__run_type)
-        render_data = {**common_data, **render_data,
-                       **kind_data, **run_type_data, **kind_runtype_data}
-
-        with open(os.path.join(f'{workload_dir_path}', 'internal_data', f'{workload_template}.yaml')) as f:
-            tm = Template(f.read())
-        workload_file_name = workload_template.replace('_template', '')
-        return {f'{workload_file_name}.yaml': tm.render(render_data)}
-
-    @logger_time_stamp
-    def generate_workload_yamls(self, workload: str):
-        """
-        This method generate workload yaml from template
-        :return:
-        """
-        self.generate_files(self.generate_workload_yamls_internal(workload=workload))

--- a/tests/unittest/benchmark_runner/regression/golden_files.py
+++ b/tests/unittest/benchmark_runner/regression/golden_files.py
@@ -54,16 +54,11 @@ class GoldenFiles:
             for run_type in environment_variables.run_types_list:
                 environment_variables.environment_variables_dict['run_type'] = run_type
                 for workload in environment_variables.workloads_list:
-                    workload_components = workload.split('_')
-                    base_workload = f'{workload_components[0]}_{workload_components[1]}'
                     t = TemplateOperations()
                     srcdir = t.get_current_run_path()
                     self.__clear_directory_yaml(srcdir)
                     destdir = self.__generate_yaml_dir_name(run_type=run_type, workload=workload, ocs_pvc=ocs_pvc, dest=dest)
-                    if workload_components[0] == 'hammerdb':
-                        t.generate_hammerdb_yamls(base_workload, workload_components[2])
-                    else:
-                        t.generate_workload_yamls(base_workload)
+                    t.generate_yamls(workload)
                     self.__copy_yaml_files_to_dir(src=srcdir, dest=destdir)
                     self.__clear_directory_yaml(srcdir)
 


### PR DESCRIPTION
Simplify the YAML generation by merging the hammerdb and other YAML generators into one routine.  Intent is that this will help simplify the process of writing other workloads in the future.

Passes golden file testing.  Currently testing on func_ci environment.