### PR TITLE
Remove unused variable

### DIFF
--- a/benchmark_runner/benchmark_operator/workload_flavors/generate_yaml_from_workload_flavors.py
+++ b/benchmark_runner/benchmark_operator/workload_flavors/generate_yaml_from_workload_flavors.py
@@ -22,11 +22,6 @@ class TemplateOperations:
             self.__environment_variables_dict['es_suffix'] = '-test-ci'
         else:
             self.__environment_variables_dict['es_suffix'] = ''
-        # hammerdb storage
-        if self.__environment_variables_dict.get('ocs_pvc', '') == 'True':
-            self.__storage_type = 'ocs_pvc'
-        else:
-            self.__storage_type = 'ephemeral'
 
     def __get_workload_name(self, workload: str):
         return workload.split('_')[0]


### PR DESCRIPTION
The conditional code uses a different mechanism (testing the value of `ocs_pvc`), so this code is dead.

* Verified by `grep -r storage_type` that nothing uses it
* Passed golden file check