### PR TITLE
move benchmark operator to tmp directory

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.221
+current_version = 1.0.222
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN mkdir -p ~/.kube
 # Create folder for provision private key file (ssh)
 RUN mkdir -p ~/.ssh/
 
-# download benchmark-operator
-RUN git clone https://github.com/cloud-bulldozer/benchmark-operator
+# download benchmark-operator to /tmp default path
+RUN git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp
 
 # Add main
 COPY benchmark_runner/main/main.py /benchmark_runner/main/main.py

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.221'
+__version__ = '1.0.222'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Small fix to place benchmark-operator in tmp folder inside benchmark-runner container