### PR TITLE
Net_queues for uperf VMs

### DIFF
--- a/benchmark_runner/benchmark_operator/workload_flavors/templates/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/templates/uperf/internal_data/uperf_vm_template.yaml
@@ -61,8 +61,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: {{ net_queues }} # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -77,14 +77,10 @@ spec:
        requests:
          memory: {{ requests_memory }}
        network:
-         {% if run_type == 'perf_ci' -%}
          front_end: masquerade
-         {% else -%}
-         front_end: bridge # or masquerade
-         {% endif -%}
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: {{ net_queues }} # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough

--- a/benchmark_runner/benchmark_operator/workload_flavors/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/benchmark_operator/workload_flavors/templates/uperf/uperf_data_template.yaml
@@ -43,11 +43,13 @@ kind_data:
         cores: 1
         limits_memory: 8Gi
         requests_memory: 8Gi
+        net_queues: 8
       default:
         sockets: 1
         cores: 4
         limits_memory: 16Gi
         requests_memory: 10Mi
+        net_queues: 4
   default:
     run_type_data:
       perf_ci:

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_uperf_vm_OCS_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_uperf_vm_OCS_PVC_False/uperf_vm.yaml
@@ -58,8 +58,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -74,10 +74,10 @@ spec:
        requests:
          memory: 10Mi
        network:
-         front_end: bridge # or masquerade
+         front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough

--- a/tests/unittest/benchmark_runner/regression/golden_files/func_ci_uperf_vm_OCS_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/func_ci_uperf_vm_OCS_PVC_True/uperf_vm.yaml
@@ -58,8 +58,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -74,10 +74,10 @@ spec:
        requests:
          memory: 10Mi
        network:
-         front_end: bridge # or masquerade
+         front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_uperf_vm_OCS_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_uperf_vm_OCS_PVC_False/uperf_vm.yaml
@@ -57,8 +57,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -75,8 +75,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough

--- a/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_uperf_vm_OCS_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/perf_ci_uperf_vm_OCS_PVC_True/uperf_vm.yaml
@@ -57,8 +57,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -75,8 +75,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_uperf_vm_OCS_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_uperf_vm_OCS_PVC_False/uperf_vm.yaml
@@ -58,8 +58,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -74,10 +74,10 @@ spec:
        requests:
          memory: 10Mi
        network:
-         front_end: bridge # or masquerade
+         front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough

--- a/tests/unittest/benchmark_runner/regression/golden_files/test_ci_uperf_vm_OCS_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/regression/golden_files/test_ci_uperf_vm_OCS_PVC_True/uperf_vm.yaml
@@ -58,8 +58,8 @@ spec:
        network:
          front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough
@@ -74,10 +74,10 @@ spec:
        requests:
          memory: 10Mi
        network:
-         front_end: bridge # or masquerade
+         front_end: masquerade
          multiqueue:
-           enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-           queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
+           enabled: true
+           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
        extra_options:
          - none
          #- hostpassthrough


### PR DESCRIPTION
Enable network multiqueue for VMs:
 - Set num queues to total vcpus (this is the default for CNV VM templates)
 - Removed the note about SElinux since I did not see any issues with nodes set to 'Enforcing'
Also a small fix to switch one last 'bridge' net type (no longer supported) to masquerade.