### PR TITLE
Wait for CRD to exist rather than named deployment for kata install

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -859,10 +859,9 @@ class OC(SSH):
                 self._create_async(yaml=os.path.join(path, resource))
                 # for first script wait for virt-operator
                 if '01_operator.yaml' == resource:
-                    # Wait that cnv operator will be created
+                    # Wait for kataconfig CRD to exist
                     self.wait_for_ocp_resource_create(resource='kata',
-                                                      verify_cmd='oc -n openshift-sandboxed-containers-operator wait deployment/sandboxed-containers-operator-controller-manager --for=condition=Available',
-                                                      status='deployment.apps/sandboxed-containers-operator-controller-manager condition met')
+                                                      verify_cmd='oc get crd kataconfigs.kataconfiguration.openshift.io')
                 # for second script wait for kataconfig installation to no longer be in progress
                 elif '02_config.yaml' == resource:
                     self.wait_for_ocp_resource_create(resource='kata',


### PR DESCRIPTION
Rather than waiting for a deployment name that may change across releases, wait for the kataconfigs CRD to exist before attempting to create the kataconfig.