### PR TITLE
Stressng sequential change

### DIFF
--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -3,7 +3,7 @@ metadata:
 template_data:
   shared:
     pin_node: {{ pin_node1 }}
-    runtype: parallel
+    runtype: sequential
     instances: 1
     # cpu stressor options
     cpu_percentage: 100
@@ -14,7 +14,7 @@ template_data:
     resources: true
   run_type:
     perf_ci:
-      timeout: 300
+      timeout: 120
       cpu_stressors: 60
       vm_bytes: 60G
       limits_cpu: 60

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -28,7 +28,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -28,7 +28,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -27,7 +27,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -27,7 +27,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -22,7 +22,7 @@ spec:
       pin: True # enable for nodeSelector
       pin_node: "pin-node-1"
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -22,7 +22,7 @@ spec:
       pin: True # enable for nodeSelector
       pin_node: "pin-node-1"
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -28,8 +28,8 @@ spec:
       limits_cpu: 60
       limits_memory: 75Gi
       # general options
-      runtype: "parallel"
-      timeout: "300"
+      runtype: "sequential"
+      timeout: "120"
       instances: 1
       # cpu stressor options
       cpu_stressors: "60"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -28,8 +28,8 @@ spec:
       limits_cpu: 60
       limits_memory: 75Gi
       # general options
-      runtype: "parallel"
-      timeout: "300"
+      runtype: "sequential"
+      timeout: "120"
       instances: 1
       # cpu stressor options
       cpu_stressors: "60"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -27,8 +27,8 @@ spec:
       limits_cpu: 60
       limits_memory: 75Gi
       # general options
-      runtype: "parallel"
-      timeout: "300"
+      runtype: "sequential"
+      timeout: "120"
       instances: 1
       # cpu stressor options
       cpu_stressors: "60"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -27,8 +27,8 @@ spec:
       limits_cpu: 60
       limits_memory: 75Gi
       # general options
-      runtype: "parallel"
-      timeout: "300"
+      runtype: "sequential"
+      timeout: "120"
       instances: 1
       # cpu stressor options
       cpu_stressors: "60"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -22,8 +22,8 @@ spec:
       pin: True # enable for nodeSelector
       pin_node: "pin-node-1"
       # general options
-      runtype: "parallel"
-      timeout: "300"
+      runtype: "sequential"
+      timeout: "120"
       instances: 1
       # cpu stressor options
       cpu_stressors: "60"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -22,8 +22,8 @@ spec:
       pin: True # enable for nodeSelector
       pin_node: "pin-node-1"
       # general options
-      runtype: "parallel"
-      timeout: "300"
+      runtype: "sequential"
+      timeout: "120"
       instances: 1
       # cpu stressor options
       cpu_stressors: "60"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -28,7 +28,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -28,7 +28,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -27,7 +27,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -27,7 +27,7 @@ spec:
       limits_cpu: 4
       limits_memory: 16Gi
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -22,7 +22,7 @@ spec:
       pin: True # enable for nodeSelector
       pin_node: "pin-node-1"
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -22,7 +22,7 @@ spec:
       pin: True # enable for nodeSelector
       pin_node: "pin-node-1"
       # general options
-      runtype: "parallel"
+      runtype: "sequential"
       timeout: "30"
       instances: 1
       # cpu stressor options


### PR DESCRIPTION
Changing run type to sequential instead of parallel, tests have proven results are much more stable using this mode.
Also reduced the runtime after confirming memory allocation and run variance looks fine for a 2min run for each test type.