### PR TITLE
benchmark_runner/workloads/workloads_operations.py: fix typo introduced in #394

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.313
+current_version = 1.0.314
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -54,7 +54,7 @@ class WorkloadsOperations:
                                                            es_port=self._es_port,
                                                            es_user=self._es_user,
                                                            es_password=self._es_password,
-                                                           es_url_protocol=self.es_url_protocol,
+                                                           es_url_protocol=self._es_url_protocol,
                                                            timeout=self._timeout)
         # Generate templates class
         self._template = TemplateOperations(workload=self._workload)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.313'
+__version__ = '1.0.314'
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
```
  File "/usr/local/lib/python3.9/site-packages/benchmark_runner/workloads/workloads_operations.py", line 57, in __init__
    es_url_protocol=self.es_url_protocol,
AttributeError: 'Workloads' object has no attribute 'es_url_protocol'
```

