### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM quay.io/centos/centos:stream8
 # benchmark-runner latest version
 ARG VERSION
 
-# Update
-RUN dnf update -y
+# Update and use not only best candidate packages (avoiding failures)
+RUN dnf update -y --nobest
 
 # install make
 Run dnf group install -y "Development Tools"

--- a/grafana/regression-summary.json
+++ b/grafana/regression-summary.json
@@ -22,7 +22,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 16,
-  "iteration": 1647504665723,
+  "iteration": 1648536002150,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -125,12 +125,20 @@
                   "text": "4.8.8"
                 },
                 "4102": {
-                  "index": 20,
+                  "index": 22,
                   "text": "4.10.2"
                 },
                 "4104": {
-                  "index": 21,
+                  "index": 23,
                   "text": "4.10.4"
+                },
+                "4105": {
+                  "index": 24,
+                  "text": "4.10.5"
+                },
+                "4106": {
+                  "index": 25,
+                  "text": "4.10.6"
                 },
                 "4814": {
                   "index": 6,
@@ -145,20 +153,28 @@
                   "text": "4.9.4-7"
                 },
                 "41002": {
-                  "index": 17,
+                  "index": 19,
                   "text": "4.10.0-rc.2"
                 },
                 "41003": {
-                  "index": 18,
+                  "index": 20,
                   "text": "4.10.0-rc.3"
                 },
                 "41007": {
-                  "index": 19,
+                  "index": 21,
                   "text": "4.10.0-rc.7"
+                },
+                "41016": {
+                  "index": 17,
+                  "text": "4.10.1-6"
                 },
                 "49211": {
                   "index": 7,
                   "text": "4.9.2-11"
+                },
+                "410129": {
+                  "index": 18,
+                  "text": "4.10.1-29"
                 },
                 "4100683": {
                   "index": 13,
@@ -1442,6 +1458,6 @@
   "timezone": "",
   "title": "regression-summary",
   "uid": "T4775LKnzzmichey",
-  "version": 20,
+  "version": 22,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR fix Dockerfile issue:
update -y --nobest => adding --nobest  to use not only best candidate packages (avoiding failures)

Solve the following issue:
```
 Problem: package centos-stream-repos-8-4.el8.noarch requires centos-gpg-keys = 1:8-4.el8, but none of the providers can be installed
  - cannot install both centos-gpg-keys-1:8-5.el8.noarch and centos-gpg-keys-1:8-4.el8.noarch
  - cannot install the best update candidate for package centos-stream-repos-8-4.el8.noarch
  - cannot install the best update candidate for package centos-gpg-keys-1:8-4.el8.noarch
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
Error: error building at STEP "RUN dnf update -y": error while running runtime: exit status 1

```