### PR TITLE
add scale support for vdbench pod and vm

### DIFF
--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -51,7 +51,7 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix: 
-          workload: [ 'stressng_pod', 'stressng_kata', 'stressng_vm', 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm']
+          workload: [ 'stressng_pod', 'stressng_kata', 'stressng_vm', 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
@@ -110,12 +110,20 @@ jobs:
         IBM_BUCKET: ${{ secrets.IBM_BUCKET }}
         IBM_KEY: ${{ secrets.IBM_KEY }}
         FUNC_RUN_ARTIFACTS_URL: ${{ secrets.FUNC_RUN_ARTIFACTS_URL }}
+        FUNC_SCALE_NODES: ${{ secrets.FUNC_SCALE_NODES }}
+        FUNC_REDIS: ${{ secrets.FUNC_REDISL }}
+        SCALE: "2"
       run: |
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Start E2E workload: ${{ matrix.workload }} >>>>>>>>>>>>>>>>>>>>>>>>>>'
         scp -r "$RUNNER_PATH/.kube/config" provision:"$CONTAINER_KUBECONFIG_PATH"
-        ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e FUNC_RUN_ARTIFACTS_URL='$FUNC_RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='func_ci' -e KATA_CPUOFFLINE_WORKAROUND='True' -e FUNC_TIMEOUT='2000' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+        if [[ '${{ matrix.workload }}' == 'vdbench_pod_scale' ] || [ '${{ matrix.workload }}' == 'vdbench_kata_scale' || [ '${{ matrix.workload }}' == 'vdbench_vm_scale' ]]
+            then
+                ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e SCALE='$SCALE' -e SCALE_NODES='$FUNC_SCALE_NODES' -e REDIS='$FUNC_REDIS' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e FUNC_RUN_ARTIFACTS_URL='$FUNC_RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='func_ci' -e KATA_CPUOFFLINE_WORKAROUND='True' -e FUNC_TIMEOUT='2000' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+            else
+                ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e FUNC_RUN_ARTIFACTS_URL='$FUNC_RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='func_ci' -e KATA_CPUOFFLINE_WORKAROUND='True' -e FUNC_TIMEOUT='2000' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+        fi
         ssh -t provision "podman rmi -f 'quay.io/ebattat/benchmark-runner:latest'"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> End E2E workload: ${{ matrix.workload }} >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
     - id: job_step

--- a/.github/workflows/Weekly_Func_Env_IPI_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_IPI_CI.yml
@@ -1,7 +1,7 @@
 # Nightly CI https://github.com/marketplace/actions/deploy-nightly
 # https://crontab.guru/
 # This is a nightly CI Pipeline against Performance environment using IPI installer - run on Sunday
-name: Deploy IPI FUNC Env Weekly CI
+name: Deploy IPI Func Env Weekly CI
 
 on:
   schedule:

--- a/.github/workflows/Weekly_Func_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Operator_CI.yml
@@ -2,12 +2,12 @@
 # https://crontab.guru/
 # This is a nightly CI Pipeline against Performance environment using IPI installer - run on Sunday
 # GitHub Actions is limited 6 hours for each job
-name: Deploy Operator FUNC Env Weekly CI
+name: Deploy Operator Func Env Weekly CI
 # Only trigger, when the build workflow succeeded
 
 on:
   workflow_run:
-    workflows: ["Deploy IPI FUNC Env Weekly CI"]
+    workflows: ["Deploy IPI Func Env Weekly CI"]
     types:
       - completed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN dnf install -y python3.9 \
 RUN python3.9 -m pip --no-cache-dir install --upgrade pip && pip --no-cache-dir install benchmark-runner --upgrade
 
 # install oc/kubectl client tools for OpenShift/Kubernetes
-ARG oc_version=4.9.0-0.okd-2022-01-29-035536
+ARG oc_version=4.10.0-0.okd-2022-04-23-131357
 RUN  curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o  ~/openshift-client-linux-${oc_version}.tar.gz \
      && tar -xzvf  ~/openshift-client-linux-${oc_version}.tar.gz -C  ~/ \
      && rm -rf ~/openshift-client-linux-${oc_version}.tar.gz \
@@ -32,7 +32,7 @@ RUN  curl -L https://github.com/openshift/okd/releases/download/${oc_version}/op
      && rm -rf ~/oc
 
 # install virtctl for VNC
-ARG virtctl_version=0.48.1
+ARG virtctl_version=0.52.0
 RUN curl -L https://github.com/kubevirt/kubevirt/releases/download/v${virtctl_version}/virtctl-v${virtctl_version}-linux-amd64 -o  ~/virtctl \
     && chmod +x ~/virtctl \
     && cp ~/virtctl /usr/local/bin/virtctl \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,7 +12,8 @@ include benchmark_runner/common/template_operations/templates/stressng/internal_
 include benchmark_runner/common/template_operations/templates/uperf/*.yaml
 include benchmark_runner/common/template_operations/templates/uperf/internal_data/*.yaml
 
-# benchmark runner templates (custom workloads)
+# benchmark runner templates (embedded workloads)
+include benchmark_runner/common/template_operations/templates/scale/*.yaml
 include benchmark_runner/common/template_operations/templates/vdbench/*.yaml
 include benchmark_runner/common/template_operations/templates/vdbench/internal_data/*.yaml
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 -----------------
 
 # Benchmark-Runner: Running benchmarks
-[![PyPI Latest Release](https://img.shields.io/pypi/v/benchmark-runner.svg)](https://pypi.org/project/benchmark-runner/)
 [![Actions Status](https://github.com/redhat-performance/benchmark-runner/workflows/CI/badge.svg)](https://github.com/redhat-performance/benchmark-runner/actions)
+[![PyPI Latest Release](https://img.shields.io/pypi/v/benchmark-runner.svg)](https://pypi.org/project/benchmark-runner/)
+[![Container Repository on Quay](https://quay.io/repository/projectquay/quay/status "Container Repository on Quay")](https://quay.io/repository/ebattat/benchmark-runner?tab=tags)
 [![Coverage Status](https://coveralls.io/repos/github/redhat-performance/benchmark-runner/badge.svg?branch=main)](https://coveralls.io/github/redhat-performance/benchmark-runner?branch=main&kill_cache=1)
 [![Documentation Status](https://readthedocs.org/projects/benchmark-runner/badge/?version=latest)](https://benchmark-runner.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/pypi/l/benchmark-runner.svg)](https://github.com/redhat-performance/benchmark-runner/blob/main/LICENSE)
@@ -83,8 +84,11 @@ Choose one from the following list:
 ```sh
 podman run --rm -e WORKLOAD=$WORKLOAD -e KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD -e PIN_NODE_BENCHMARK_OPERATOR=$PIN_NODE_BENCHMARK_OPERATOR -e PIN_NODE1=$PIN_NODE1 -e PIN_NODE2=$PIN_NODE2 -e ELASTICSEARCH=$ELASTICSEARCH -e ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT -e log_level=INFO -v $KUBECONFIG:/root/.kube/config --privileged quay.io/ebattat/benchmark-runner:latest
 ```
-
-![](media/demo.gif)
+SAVE ARTIFACTS LOCAL: 
+1. add "-e SAVE_ARTIFACTS_LOCAL='True'"
+2. add "-v /tmp:/tmp" 
+3. git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
+![](media/benchmark-runner-demo.gif)
 
 ## Run workload in Pod using Kubernetes or OpenShift
 

--- a/benchmark_runner/benchmark_operator/benchmark_operator_exceptions.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_exceptions.py
@@ -14,15 +14,6 @@ class ODFNonInstalled(BenchmarkOperatorError):
         super(ODFNonInstalled, self).__init__(self.message)
 
 
-class SystemMetricsRequiredElasticSearch(BenchmarkOperatorError):
-    """
-    This class for raise error when running system metrics without ElasticSearch
-    """
-    def __init__(self):
-        self.message = "System metrics is required ElasticSearch, set 'SYSTEM_METRICS' to False"
-        super(SystemMetricsRequiredElasticSearch, self).__init__(self.message)
-
-
 class PrometheusSnapshotFailed(BenchmarkOperatorError):
     """
     Prometheus snapshot failed

--- a/benchmark_runner/benchmark_operator/benchmark_operator_workloads_operations.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_workloads_operations.py
@@ -11,7 +11,7 @@ from benchmark_runner.common.oc.oc import OC
 from benchmark_runner.common.template_operations.template_operations import TemplateOperations
 from benchmark_runner.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
 from benchmark_runner.common.ssh.ssh import SSH
-from benchmark_runner.benchmark_operator.benchmark_operator_exceptions import ODFNonInstalled, SystemMetricsRequiredElasticSearch
+from benchmark_runner.benchmark_operator.benchmark_operator_exceptions import ODFNonInstalled
 from benchmark_runner.main.environment_variables import environment_variables
 from benchmark_runner.common.clouds.shared.s3.s3_operations import S3Operations
 from benchmark_runner.common.prometheus.prometheus_snapshot import PrometheusSnapshot
@@ -79,15 +79,6 @@ class BenchmarkOperatorWorkloadsOperations:
         self._oc = OC(kubeadmin_password=kubeadmin_password)
         self._oc.login()
         return self._oc
-
-    def __check_elasticsearch_exist_for_system_metrics(self):
-        """
-        This method check if elasticsearch exist for system metrics
-        :return:
-        """
-        if self._system_metrics == 'True':
-            if not self._elasticsearch:
-                raise SystemMetricsRequiredElasticSearch()
 
     @logger_time_stamp
     def update_node_selector(self, runner_path: str = environment_variables.environment_variables_dict['runner_path'], yaml_path: str = '', pin_node: str = ''):
@@ -395,14 +386,13 @@ class BenchmarkOperatorWorkloadsOperations:
         tar_run_artifacts_path = self.__make_run_artifacts_tarfile(workload)
         run_artifacts_hierarchy = self._get_run_artifacts_hierarchy(workload_name=workload)
         # Upload when endpoint_url is not None
-        if self._endpoint_url:
-            s3operations = S3Operations()
-            # change workload to key convention
-            upload_file = f"{workload}-{self._time_stamp_format}.tar.gz"
-            s3operations.upload_file(file_name_path=tar_run_artifacts_path,
-                                     bucket=self._environment_variables_dict.get('bucket', ''),
-                                     key=run_artifacts_hierarchy,
-                                     upload_file=upload_file)
+        s3operations = S3Operations()
+        # change workload to key convention
+        upload_file = f"{workload}-{self._time_stamp_format}.tar.gz"
+        s3operations.upload_file(file_name_path=tar_run_artifacts_path,
+                                 bucket=self._environment_variables_dict.get('bucket', ''),
+                                 key=run_artifacts_hierarchy,
+                                 upload_file=upload_file)
         # remove local run artifacts workload folder
         # verify that its not empty path
         if len(self._run_artifacts_path) > 3 and self._run_artifacts_path != '/' and self._run_artifacts_path and tar_run_artifacts_path and os.path.isfile(tar_run_artifacts_path) and not self._save_artifacts_local:
@@ -446,7 +436,7 @@ class BenchmarkOperatorWorkloadsOperations:
         :return:
         """
         workload_name = self._workload.split('_')
-        if self._odf_pvc == 'True' and workload_name[0] in self._workloads_odf_pvc:
+        if workload_name[0] in self._workloads_odf_pvc:
             if not self._oc.is_odf_installed():
                 raise ODFNonInstalled()
 
@@ -459,7 +449,14 @@ class BenchmarkOperatorWorkloadsOperations:
         # make undeploy benchmark controller manager if exist
         self.make_undeploy_benchmark_controller_manager_if_exist(runner_path=environment_variables.environment_variables_dict['runner_path'])
         if 'hammerdb' in self._workload:
-            self._oc.delete_all_resources(resources=['deployments', 'services', 'pvc'], namespace=f"{self._workload.split('_')[2]}-db")
+            self._oc.delete_namespace(namespace=f"{self._workload.split('_')[2]}-db")
+
+    @logger_time_stamp
+    def clear_nodes_cache(self):
+        """
+        This method clear nodes cache
+        """
+        self._oc.clear_node_caches()
 
     def initialize_workload(self):
         """
@@ -467,20 +464,22 @@ class BenchmarkOperatorWorkloadsOperations:
         :return:
         """
         self.delete_all()
-        self._oc.clear_nodes_cache()
-        # check that there is elasticsearch when system metric is True
-        self.__check_elasticsearch_exist_for_system_metrics()
+        self.clear_nodes_cache()
         # make deploy benchmark controller manager
         self.make_deploy_benchmark_controller_manager(runner_path=environment_variables.environment_variables_dict['runner_path'])
-        self.odf_pvc_verification()
+        if self._odf_pvc == 'True':
+            self.odf_pvc_verification()
         self._template.generate_yamls()
-        self.start_prometheus()
+        if self._enable_prometheus_snapshot:
+            self.start_prometheus()
 
     def finalize_workload(self):
         """
         This method includes all the finalization of workload
         :return:
         """
-        self.end_prometheus()
-        self.upload_run_artifacts_to_s3()
+        if self._enable_prometheus_snapshot:
+            self.end_prometheus()
+        if self._endpoint_url:
+            self.upload_run_artifacts_to_s3()
         self.delete_all()

--- a/benchmark_runner/benchmark_operator/hammerdb_pod.py
+++ b/benchmark_runner/benchmark_operator/hammerdb_pod.py
@@ -100,13 +100,14 @@ class HammerdbPod(BenchmarkOperatorWorkloadsOperations):
                 self._create_pod_log(label=f'{self.__workload_name}-workload')
             full_name = f'{self.__workload_name}-{self.__database}'
             run_artifacts_url = os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=full_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
-            if ids:
-                for id in ids:
-                    self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
-            else:
-                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, database=self.__database, uuid=self._uuid)
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
+                if ids:
+                    for id in ids:
+                        self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
+                else:
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, database=self.__database, uuid=self._uuid)
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             # delete hammerdb
             self.tear_down_pod_after_error(yaml=os.path.join(f'{self._run_artifacts_path}',  f'{self.__name}_{self.__database}.yaml'),
                                            pod_name=f'{self.__workload_name}-creator')

--- a/benchmark_runner/benchmark_operator/hammerdb_vm.py
+++ b/benchmark_runner/benchmark_operator/hammerdb_vm.py
@@ -71,13 +71,14 @@ class HammerdbVM(BenchmarkOperatorWorkloadsOperations):
                 self._create_pod_log(label='benchmark-controller-manager')
             full_name = f'{self.__workload_name}-{self.__database}'
             run_artifacts_url = os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=full_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
-            if ids:
-                for id in ids:
-                    self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, database=self.__database)
-            else:
-                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, database=self.__database, uuid=self._uuid)
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
+                if ids:
+                    for id in ids:
+                        self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, database=self.__database)
+                else:
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, database=self.__database, uuid=self._uuid)
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             # delete hammerdb
             self.tear_down_vm_after_error(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{self.__database}.yaml'),
                                           vm_name=f'{self.__workload_name}-workload')

--- a/benchmark_runner/benchmark_operator/stressng_pod.py
+++ b/benchmark_runner/benchmark_operator/stressng_pod.py
@@ -72,13 +72,14 @@ class StressngPod(BenchmarkOperatorWorkloadsOperations):
             if self._oc._is_pod_exist(pod_name=self.__workload_name):
                 self._create_pod_log(label=self.__workload_name)
             run_artifacts_url = os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
-            if ids:
-                for id in ids:
-                    self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
-            else:
-                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
+                if ids:
+                    for id in ids:
+                        self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
+                else:
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             self.tear_down_pod_after_error(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
                                            pod_name=f'{self.__workload_name}-workload')
             raise err

--- a/benchmark_runner/benchmark_operator/stressng_vm.py
+++ b/benchmark_runner/benchmark_operator/stressng_vm.py
@@ -66,13 +66,14 @@ class StressngVM(BenchmarkOperatorWorkloadsOperations):
             if self._oc._is_pod_exist(pod_name='benchmark-controller-manager'):
                 self._create_pod_log(label='benchmark-controller-manager')
             run_artifacts_url = os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
-            if ids:
-                for id in ids:
-                    self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
-            else:
-                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
+                if ids:
+                    for id in ids:
+                        self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
+                else:
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             self.tear_down_vm_after_error(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
                                           vm_name=f'{self.__workload_name}-workload')
             raise err

--- a/benchmark_runner/benchmark_operator/uperf_pod.py
+++ b/benchmark_runner/benchmark_operator/uperf_pod.py
@@ -89,12 +89,13 @@ class UperfPod(BenchmarkOperatorWorkloadsOperations):
             if self._oc._is_pod_exist(pod_name='uperf-client'):
                 self._create_pod_log(label='uperf-client')
             run_artifacts_url = os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
-            if ids:
-                for id in ids:
-                    self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
-            else:
-                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
+                if ids:
+                    for id in ids:
+                        self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
+                else:
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             self.tear_down_pod_after_error(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), pod_name=f'uperf-client')
             raise err

--- a/benchmark_runner/benchmark_operator/uperf_vm.py
+++ b/benchmark_runner/benchmark_operator/uperf_vm.py
@@ -70,12 +70,13 @@ class UperfVM(BenchmarkOperatorWorkloadsOperations):
             if self._oc._is_pod_exist(pod_name='benchmark-controller-manager'):
                 self._create_pod_log(label='benchmark-controller-manager')
             run_artifacts_url = os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
-            if ids:
-                for id in ids:
-                    self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
-            else:
-                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._oc.get_long_uuid(workload=self.__workload_name), timeout=3)
+                if ids:
+                    for id in ids:
+                        self._update_elasticsearch_index(index=self.__es_index, id=id, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url)
+                else:
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', run_artifacts_url=run_artifacts_url, uuid=self._uuid)
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             self.tear_down_vm_after_error(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name='uperf-server')
             raise err

--- a/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
+++ b/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
@@ -84,12 +84,8 @@ class ElasticSearchOperations:
         # https://github.com/elastic/elasticsearch-dsl-py/issues/49
         self.__es.indices.refresh(index=index)
         # timestamp name in Elasticsearch is different
-        if 'uperf' in workload:
-            search = Search(using=self.__es, index=index).filter('range', uperf_ts={
-                'gte': f'now-{self.ES_FETCH_MIN_TIME}m', 'lt': 'now'})
-        else:
-            search = Search(using=self.__es, index=index).filter('range', timestamp={
-                'gte': f'now-{self.ES_FETCH_MIN_TIME}m', 'lt': 'now'})
+        search = Search(using=self.__es, index=index).filter('range', timestamp={
+            'gte': f'now-{self.ES_FETCH_MIN_TIME}m', 'lt': 'now'})
         # reduce the search result
         if fast_check:
             search = search[0:self.MIN_SEARCH_RESULTS]
@@ -169,10 +165,7 @@ class ElasticSearchOperations:
                 data[key] = value
 
         # utcnow - solve timestamp issue
-        if 'uperf' in index:
-            data['uperf_ts'] = datetime.utcnow()  # datetime.now()
-        else:
-            data['timestamp'] = datetime.utcnow()  # datetime.now()
+        data['timestamp'] = datetime.utcnow()  # datetime.now()
 
         # Upload data to elastic search server
         try:

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -148,7 +148,7 @@ class OC(SSH):
         """
         return self.run(r""" oc get nodes -l node-role.kubernetes.io/worker= -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" """)
 
-    def clear_nodes_cache(self):
+    def clear_node_caches(self):
         """
         This method clears the node's buffer cache
         """
@@ -297,7 +297,7 @@ class OC(SSH):
                 is_check=True).rstrip().decode('ascii')
         else:
             return self.run(
-                "oc get pods -n " + environment_variables.environment_variables_dict['namespace'] + " --no-headers | awk '{ print $1; }' | grep " + label,
+                "oc get pods -n " + environment_variables.environment_variables_dict['namespace'] + " --no-headers | awk '{ print $1; }' | grep -w " + label,
                 is_check=True).rstrip().decode('ascii')
 
     @typechecked
@@ -310,7 +310,7 @@ class OC(SSH):
         """
         if label:
             return self.run(
-                cmd="oc get vmi -n " + namespace + " --no-headers | awk '{ print $1; }' | grep " + label,
+                cmd="oc get vmi -n " + namespace + " --no-headers | awk '{ print $1; }' | grep -w " + label,
                 is_check=True).rstrip().decode('ascii')
         else:
             return self.run('oc get vmi', is_check=True)
@@ -525,15 +525,13 @@ class OC(SSH):
             return False
 
     @typechecked
-    def delete_all_resources(self, resources: list, namespace: str = environment_variables.environment_variables_dict['namespace']):
+    def delete_namespace(self, namespace: str = environment_variables.environment_variables_dict['namespace']):
         """
-        This method delete all resources in namespace
-        :param resources: default list = ('pods', 'pvc')
+        This method delete namespace
         :param namespace:
         :return:
         """
-        for resource in resources:
-            self.run(f'oc delete -n {namespace} --all {resource}')
+        self.run(f'oc delete ns {namespace}')
 
     @typechecked
     @logger_time_stamp

--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -2,9 +2,10 @@
 import os
 import yaml
 import sys
+import benchmark_runner
+from multiprocessing import Process
 
 from jinja2 import Template
-import benchmark_runner
 from benchmark_runner.common.template_operations.render_yaml_from_template import render_yaml_file
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.main.environment_variables import environment_variables
@@ -39,51 +40,53 @@ class TemplateOperations:
         else:
             return None
 
+    @staticmethod
+    def __get_sub_dict(dictionary: dict, key: str, value: str):
+        """
+        Return a sub-dictionary of input dictionary as specified below.
+        If dictionary[key][value] exists, return that.
+        If dictionary[key][value] does not exist, but dictionary[key]['default'] exists, return
+           dictionary[key]['default']
+        Otherwise return an empty dictionary.
+        :param dictionary: dictionary to be searched
+        :param key: key to search for in dictionary
+        :param value: value to be searched for under key
+        :return: dictionary[key][value] if that exists, dictionary[key]['default'] if that exists, otherwise empty dictionary.
+        """
+        if key in dictionary:
+            subdict = dictionary[key]
+            if value in subdict:
+                return subdict[value]
+            elif 'default' in subdict:
+                return subdict['default']
+        return dict()
+
+    def __build_template_data(self, previous_data: dict, template_root_data: dict):
+        """
+        Build data dictionary for rendering from template data.
+        """
+        template_data = template_root_data.get('template_data')
+        shared_data = template_data.get('shared')
+        if shared_data is None:
+            shared_data = {}
+        kind_data = self.__get_sub_dict(template_data, 'kind', self.__workload_kind)
+        run_type_data = self.__get_sub_dict(template_data, 'run_type', self.__run_type)
+        kind_runtype_data = self.__get_sub_dict(kind_data, 'run_type', self.__run_type)
+        extra_data = self.__get_sub_dict(template_data, 'extra', self.__workload_extra_name)
+        extra_kind_data = self.__get_sub_dict(extra_data, 'kind', self.__workload_kind)
+        extra_runtype_data = self.__get_sub_dict(extra_data, 'run_type', self.__run_type)
+        extra_kind_runtype_data = self.__get_sub_dict(extra_kind_data, 'run_type', self.__run_type)
+
+        return {**previous_data, **shared_data,
+                **kind_data, **run_type_data, **kind_runtype_data,
+                **extra_data, **extra_kind_data, **extra_runtype_data, **extra_kind_runtype_data}
+
     @logger_time_stamp
-    def generate_yamls_internal(self):
+    def generate_yamls_internal(self, scale: str = None, scale_node: str = None):
         """
         Generate required .yaml files as a dictionary of file names and contents
         :return: Dictionary <filename:contents>
         """
-        def build_template_data(previous_data: dict, template_root_data: dict):
-            """
-            Build data dictionary for rendering from template data.
-            """
-            def get_sub_dict(dictionary: dict, key: str, value: str):
-                """
-                Return a sub-dictionary of input dictionary as specified below.
-                If dictionary[key][value] exists, return that.
-                If dictionary[key][value] does not exist, but dictionary[key]['default'] exists, return
-                   dictionary[key]['default']
-                Otherwise return an empty dictionary.
-                :param dictionary: dictionary to be searched
-                :param key: key to search for in dictionary
-                :param value: value to be searched for under key
-                :return: dictionary[key][value] if that exists, dictionary[key]['default'] if that exists, otherwise empty dictionary.
-                """
-                if key in dictionary:
-                    subdict = dictionary[key]
-                    if value in subdict:
-                        return subdict[value]
-                    elif 'default' in subdict:
-                        return subdict['default']
-                return dict()
-            template_data = template_root_data.get('template_data')
-            shared_data = template_data.get('shared')
-            if shared_data is None:
-                shared_data = {}
-            kind_data = get_sub_dict(template_data, 'kind', self.__workload_kind)
-            run_type_data = get_sub_dict(template_data, 'run_type', self.__run_type)
-            kind_runtype_data = get_sub_dict(kind_data, 'run_type', self.__run_type)
-            extra_data = get_sub_dict(template_data, 'extra', self.__workload_extra_name)
-            extra_kind_data = get_sub_dict(extra_data, 'kind', self.__workload_kind)
-            extra_runtype_data = get_sub_dict(extra_data, 'run_type', self.__run_type)
-            extra_kind_runtype_data = get_sub_dict(extra_kind_data, 'run_type', self.__run_type)
-
-            return {**previous_data, **shared_data,
-                    **kind_data, **run_type_data, **kind_runtype_data,
-                    **extra_data, **extra_kind_data, **extra_runtype_data, **extra_kind_runtype_data}
-
         # This really belongs in __init__, but some of the tests rely on
         # being able to create this without an actual workload.
         self.__workload_name = self.__workload.split('_')[0]
@@ -93,13 +96,14 @@ class TemplateOperations:
         if self.__workload_extra_name:
             self.__standard_output_file = f"{'_'.join([self.__workload_name, self.__workload_template_kind, self.__workload_extra_name])}.yaml"
         else:
-            self.__standard_output_file = f"{'_'.join([self.__workload_name, self.__workload_template_kind])}.yaml"
+            if scale:
+                self.__standard_output_file = f"{'_'.join([self.__workload_name, self.__workload_template_kind, scale])}.yaml"
+            else:
+                self.__standard_output_file = f"{'_'.join([self.__workload_name, self.__workload_template_kind])}.yaml"
         self.__standard_template_file = f"{'_'.join([self.__workload_name, self.__workload_template_kind])}_template.yaml"
         workload_dir_path = os.path.join((os.path.dirname(benchmark_runner.__file__)), "workloads", self.__workload, "template") \
             if self.__environment_variables_dict['template_in_workload_dir'] \
                else os.path.join(self.__dir_path, self.__workload_name)
-
-
         template_render_data = {
             'kind': self.__workload_kind,
             'workload_name': self.__workload_name,
@@ -107,9 +111,14 @@ class TemplateOperations:
             'workload_extra_name': self.__workload_extra_name,
             'standard_output_file': self.__standard_output_file,
             'standard_template_file': self.__standard_template_file,
+            'scale': scale,
+            'scale_node': scale_node
             }
         self.__environment_variables_dict = {**self.__environment_variables_dict, **template_render_data}
-        common_data = yaml.load(render_yaml_file(self.__dir_path, 'common.yaml', self.__environment_variables_dict), Loader=yaml.FullLoader)['common_data']
+        common_data = yaml.load(render_yaml_file(dir_path=self.__dir_path, yaml_file='common.yaml', environment_variable_dict=self.__environment_variables_dict), Loader=yaml.FullLoader)['common_data']
+        if scale:
+            render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='redis.yaml', environment_variable_dict=self.__environment_variables_dict)
+            render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='state_signals_exporter_pod.yaml', environment_variable_dict=self.__environment_variables_dict)
         template_render_data = {**self.__environment_variables_dict, **common_data}
 
         workload_data = yaml.load(render_yaml_file(workload_dir_path, f'{self.__workload_name}_data_template.yaml', template_render_data), Loader=yaml.FullLoader)
@@ -118,7 +127,7 @@ class TemplateOperations:
             config = dict([kv.split("=") for kv in sys.argv[1:]])
             workload_data["template_data"]["run_type"]["default"] = config
 
-        render_data = build_template_data(template_render_data, workload_data)
+        render_data = self.__build_template_data(template_render_data, workload_data)
 
         answer = {}
         out_files = [{'name': self.__standard_output_file, 'template': self.__standard_template_file}]
@@ -134,6 +143,9 @@ class TemplateOperations:
             with open(os.path.join(workload_dir_path, 'internal_data', template_file)) as f:
                 template = Template(f.read())
             answer[filename] = f"{template.render(render_data)}\n"
+            if scale:
+                answer['redis.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='redis.yaml', environment_variable_dict=self.__environment_variables_dict)
+                answer['state_signals_exporter_pod.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='state_signals_exporter_pod.yaml', environment_variable_dict=self.__environment_variables_dict)
         return answer
 
     @logger_time_stamp
@@ -143,12 +155,29 @@ class TemplateOperations:
                 f.write(data)
 
     @logger_time_stamp
-    def generate_yamls(self):
+    def generate_yamls(self, scale: str = '', scale_nodes: list = []):
         """
         This method generate workload yaml from template
         :return:
         """
-        self.generate_files(self.generate_yamls_internal())
+        if not scale:
+            self.generate_files(self.generate_yamls_internal())
+        else:
+            proc = []
+            scale = int(scale)
+            # Verify that the scale number is equal to the nodes list
+            if scale != len(scale_nodes):
+                raise Exception(f'Incorrect scale nodes number, scale: {scale} != scale_nodes: {len(scale_nodes)}')
+            if scale_nodes:
+                for scale_num in range(scale):
+                    p = Process(target=self.generate_files, args=(self.generate_yamls_internal(scale=str(scale_num+1), scale_node=scale_nodes[scale_num]), ))
+                    p.start()
+                    proc.append(p)
+                for p in proc:
+                    p.join()
+            else:
+                for scale_num in range(scale):
+                    self.generate_files(self.generate_yamls_internal(scale=str(scale_num+1)))
 
     # The following routines are for testing purposes,
     # in particular to allow a known environment to be set up for golden file testing

--- a/benchmark_runner/common/template_operations/templates/scale/redis.yaml
+++ b/benchmark_runner/common/template_operations/templates/scale/redis.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  namespace: {{ namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      {%- if pin_node1 %}
+      nodeSelector:
+        kubernetes.io/hostname: {{ pin_node1 }}
+      {%- endif %}
+      containers:
+        - name: master
+          image: k8s.gcr.io/redis:e2e  # or just image: redis
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-deployment
+  namespace: {{ namespace }}
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+  type: ClusterIP
+

--- a/benchmark_runner/common/template_operations/templates/scale/state_signals_exporter_pod.yaml
+++ b/benchmark_runner/common/template_operations/templates/scale/state_signals_exporter_pod.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: state-signals-exporter
+  namespace: {{ namespace }}
+  labels:
+    app: state-signals-exporter
+    type: state-signals-exporter
+    benchmark-uuid: {{ uuid }}
+spec:
+  selector:
+    matchLabels:
+      app: state-signals-exporter
+  {%- if pin_node1 %}
+  nodeSelector:
+    kubernetes.io/hostname: {{ pin_node1 }}
+  {%- endif %}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10Mi
+    limits:
+      cpu: 2
+      memory: 2Gi
+  containers:
+    - name: state-signals-exporter-pod
+      namespace: {{ namespace }}
+      image: quay.io/ebattat/state-signals-exporter:v1.0.6
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: REDIS_HOST
+          value: "{{ redis }}"
+        - name: SCALE_NUM
+          value: "{{ scale }}"
+        - name: TIMEOUT
+          value: "{{ timeout }}"
+      command: ["/bin/bash"]
+      args: ["-c", "python3.9 /state_signals_exporter.py '$REDIS_HOST' '$SCALE_NUM' '$TIMEOUT'"]
+  restartPolicy: "Never"

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -1,13 +1,19 @@
+{% if not scale %}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ namespace }}
+{%- endif %}
 {%- if odf_pvc == True %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {% if not scale -%}
   name: vdbench-pod-pvc-claim
+  {%- else -%}
+  name: vdbench-pod-pvc-claim-{{ scale }}
+  {%- endif %}
   namespace: {{ namespace }}
 spec:
   storageClassName: ocs-storagecluster-ceph-rbd
@@ -21,20 +27,33 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  {% if not scale -%}
   name: vdbench-{{ kind }}-{{ trunc_uuid }}
+  {%- else -%}
+  name: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+  {%- endif %}
   namespace: {{ namespace }}
   labels:
+    {% if not scale -%}
     app: vdbench-{{ trunc_uuid }}
     type: vdbench-{{ kind }}-{{ trunc_uuid }}
+    {%- else -%}
+    app: vdbench-{{ trunc_uuid }}-{{ scale }}
+    type: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+    {%- endif %}
     benchmark-uuid: {{ uuid }}
     benchmark-runner-workload: vdbench
 spec:
   selector:
     matchLabels:
       app: vdbench
-  {%- if pin_node != '' %}
+  {%- if pin_node1 or scale_node %}
   nodeSelector:
+    {% if not scale -%}
     kubernetes.io/hostname: {{ pin_node1 }}
+    {%- else -%}
+    kubernetes.io/hostname: {{ scale_node }}
+    {%- endif %}
   {%- endif %}
   {%- if kind == 'kata' %}
   runtimeClassName: kata
@@ -49,11 +68,15 @@ spec:
   containers:
     - name: vdbench-pod
       namespace: {{ namespace }}
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       {%- if odf_pvc == True %}
       volumeMounts:
+        {% if not scale -%}
         - name: vdbench-pod-pvc-claim
+        {%- else -%}
+        - name: vdbench-pod-pvc-claim-{{ scale }}
+        {%- endif %}
           mountPath: "/workload"
       {%- endif %}
       env:
@@ -89,8 +112,19 @@ spec:
           value: "{{ FILES_PER_DIRECTORY }}"
         - name: SIZE_PER_FILE # size in MB
           value: "{{ SIZE_PER_FILE }}"
+        #state-signals
+        - name: REDIS_HOST
+          value: "{{ redis }}"
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "{{ timeout }}"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      {% if not scale -%}
+      args: ["-c", "$WORKLOAD_METHOD"]
+      {%- else -%}
+      args: ["-c", "python3.9 /state_signals_responder.py '$REDIS_HOST' '$WORKLOAD_METHOD' '$TIMEOUT'"]
+      {%- endif %}
   restartPolicy: "Never"
   spec:
     pvc:
@@ -105,9 +139,16 @@ spec:
       blank: {}
   {%- if odf_pvc == True %}
   volumes:
+    {% if not scale -%}
     - name: vdbench-pod-pvc-claim
       namespace: {{ namespace }}
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
+    {%- else -%}
+    - name: vdbench-pod-pvc-claim-{{ scale }}
+      namespace: {{ namespace }}
+      persistentVolumeClaim:
+        claimName: vdbench-pod-pvc-claim-{{ scale }}
+    {%- endif %}
   {%- endif %}
 

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -1,13 +1,19 @@
+{% if not scale %}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ namespace }}
+{%- endif %}
 {%- if odf_pvc == True %}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
+  {% if not scale -%}
   name: vdbench-pvc-claim
+  {%- else -%}
+  name: vdbench-pvc-claim-{{ scale }}
+  {%- endif %}
   namespace: {{ namespace }}
 spec:
   storageClassName: ocs-storagecluster-ceph-rbd
@@ -21,11 +27,20 @@ spec:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
+  {% if not scale -%}
   name: vdbench-{{ kind }}-{{ trunc_uuid }}
+  {%- else -%}
+  name: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+  {%- endif %}
   namespace: {{ namespace }}
   labels:
+    {% if not scale -%}
     app: vdbench-{{ trunc_uuid }}
     type: vdbench-{{ kind }}-{{ trunc_uuid }}
+    {%- else -%}
+    app: vdbench-{{ trunc_uuid }}-{{ scale }}
+    type: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+    {%- endif %}
     benchmark-uuid: {{ uuid }}
     benchmark-runner-workload: vdbench
 spec:
@@ -35,9 +50,13 @@ spec:
       labels:
         kubevirt-vm: vdbench
     spec:
-      {%- if pin_node != '' %}
+      {%- if pin_node1 or scale_node %}
       nodeSelector:
+        {% if not scale -%}
         kubernetes.io/hostname: {{ pin_node1 }}
+        {%- else -%}
+        kubernetes.io/hostname: {{ scale_node }}
+        {%- endif %}
       {%- endif %}
       domain:
         cpu:
@@ -70,10 +89,14 @@ spec:
 {%- if odf_pvc == True %}
         - name: data-volume
           persistentVolumeClaim:
+            {% if not scale -%}
             claimName: vdbench-pvc-claim
+            {%- else -%}
+            claimName: vdbench-pvc-claim-{{ scale }}
+            {%- endif %}
 {%- endif %}
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -99,7 +122,14 @@ spec:
                 - export DIRECTORIES={{ DIRECTORIES }}
                 - export FILES_PER_DIRECTORY={{ FILES_PER_DIRECTORY }}
                 - export SIZE_PER_FILE={{ SIZE_PER_FILE }}
+                - export REDIS_HOST={{ redis }}
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT={{ timeout }}
                 - echo @@~@@START-WORKLOAD@@~@@
+                {% if not scale -%}
                 - /vdbench/vdbench_runner.sh
+                {%- else -%}
+                - python3.9 /state_signals_responder.py '$REDIS_HOST' '$WORKLOAD_METHOD' '$TIMEOUT'
+                {%- endif %}
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -9,7 +9,7 @@ template_data:
     perf_ci:
       BLOCK_SIZES: oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64
       IO_OPERATION: oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write
-      IO_THREADS: 1,1,1,1,1,4,4,2,2,4,4,2,2
+      IO_THREADS: 16,16,16,16,16,4,4,2,2,4,4,2,2
       # How file IO will be done
       FILES_IO: oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random
       # an integer or "max"
@@ -17,7 +17,7 @@ template_data:
       # used for mixed workload 0-100
       MIX_PRECENTAGE:
       # duration time in sec
-      DURATION: 600
+      DURATION: 360
       # pause after every test in sec
       PAUSE: 20
       # warmup before any test in sec
@@ -41,7 +41,7 @@ template_data:
     default:
       BLOCK_SIZES: 64,oltp1
       IO_OPERATION: write,oltp1
-      IO_THREADS: 1,3
+      IO_THREADS: 16,3
       FILES_IO: random,oltp1
       IO_RATE: max,max
       # used for mixed workload 0-100
@@ -51,20 +51,20 @@ template_data:
       # pause after every test in sec
       PAUSE: 0
       # warmup before any test in sec
-      WARMUP: 0
+      WARMUP: 20
       # This parameter allows you to select directories and files for processing either sequential/random
       FILES_SELECTION: random
       # ratio is 1:X e.g 2 = 50% compressible
       COMPRESSION_RATIO: 2
       # will it run a fillup before testing starts yes/no
-      RUN_FILLUP: "no"
+      RUN_FILLUP: "yes"
       # how many directories to create
-      DIRECTORIES: 300
-      FILES_PER_DIRECTORY: 3
+      DIRECTORIES: 100
+      FILES_PER_DIRECTORY: 10
       # size in MB
-      SIZE_PER_FILE: 10
+      SIZE_PER_FILE: 5
       limits_cpu: 2
-      limits_memory: 2Gi
+      limits_memory: 4Gi
       requests_cpu: 10m
       requests_memory: 10Mi
       storage: 10Gi

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -36,7 +36,7 @@ class EnvironmentVariables:
         # This path is github actions runner path (benchmark-operator should be cloned here)
         self._environment_variables_dict['runner_path'] = os.environ.get('RUNNER_PATH', '/tmp')
         # This path is for vm/pod/prometheus run artifacts
-        self._environment_variables_dict['run_artifacts'] = os.environ.get('RUN_ARTIFACTS', '/tmp/benchmark-runner-run-artifacts')
+        self._environment_variables_dict['run_artifacts'] = os.environ.get('RUN_ARTIFACTS', os.path.join(self._environment_variables_dict['runner_path'], 'benchmark-runner-run-artifacts'))
 
         # dynamic parameters - configure for local run
         self._environment_variables_dict['workload'] = os.environ.get('WORKLOAD', '')
@@ -58,6 +58,12 @@ class EnvironmentVariables:
         # Workaround for Kata CPU offline problem in 4.9/4.10
         # Set to True to
         self._environment_variables_dict['kata_cpuoffline_workaround'] = os.environ.get('KATA_CPUOFFLINE_WORKAROUND', '')
+
+        # Scale
+        self._environment_variables_dict['scale'] = os.environ.get('SCALE', '')
+        # list of nodes per pod/vm, all will run on the same node when 1 node, e.g: [ 'master-1', 'master-2' ]
+        self._environment_variables_dict['scale_nodes'] = os.environ.get('SCALE_NODES', "")
+        self._environment_variables_dict['redis'] = os.environ.get('REDIS', '')
 
         # default parameter - change only if needed
         # Parameters below related to 'run_workload()'
@@ -92,14 +98,20 @@ class EnvironmentVariables:
         self._environment_variables_dict['workloads_odf_pvc'] = ['vdbench', 'hammerdb']
         # This parameter get from Test_CI.yml file
         self._environment_variables_dict['build_version'] = os.environ.get('BUILD_VERSION', '1.0.0')
-        # collect system metrics True/False
-        self._environment_variables_dict['system_metrics'] = os.environ.get('SYSTEM_METRICS', 'True')
+        # collect system metrics True/False - required by benchmark-operator
+        if self._environment_variables_dict['elasticsearch']:
+            self._environment_variables_dict['system_metrics'] = os.environ.get('SYSTEM_METRICS', 'True')
+        else:
+            self._environment_variables_dict['system_metrics'] = os.environ.get('SYSTEM_METRICS', 'False')
         # CI status update once at the end of CI pass/failed
         self._environment_variables_dict['ci_status'] = os.environ.get('CI_STATUS', '')
         # Valid run types
         self._environment_variables_dict['run_types'] = ['test_ci', 'func_ci', 'perf_ci']
         # Run type test_ci/func_ci/perf_ci, default test_ci same environment as func_ci
         self._environment_variables_dict['run_type'] = os.environ.get('RUN_TYPE', 'test_ci')
+        self._environment_variables_dict['runner_type'] = os.environ.get('RUNNER_TYPE')
+        self._environment_variables_dict['config_from_args'] = os.environ.get('CONFIG_FROM_ARGS')
+        self._environment_variables_dict['template_in_workload_dir'] = os.environ.get('TEMPLATE_IN_WORKLOAD_DIR')
 
         # Run uuid
         self._environment_variables_dict['uuid'] = os.environ.get('UUID', str(uuid4()))
@@ -117,12 +129,6 @@ class EnvironmentVariables:
         self._environment_variables_dict['save_artifacts_local'] = os.environ.get('SAVE_ARTIFACTS_LOCAL', None)
         # None/ 'True'(Default) to enable prometheus snapshot
         self._environment_variables_dict['enable_prometheus_snapshot'] = os.environ.get('ENABLE_PROMETHEUS_SNAPSHOT', 'True')
-
-        self._environment_variables_dict['runner_type'] = os.environ.get('RUNNER_TYPE')
-
-        self._environment_variables_dict['config_from_args'] = os.environ.get('CONFIG_FROM_ARGS')
-
-        self._environment_variables_dict['template_in_workload_dir'] = os.environ.get('TEMPLATE_IN_WORKLOAD_DIR')
 
         # end dynamic parameters - configure for local run
         ##################################################################################################

--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -165,7 +165,7 @@ def main():
         success = run_benchmark_runner_workload()
 
     else:
-        logger.error("could not determine the type of execution.")
+        logger.error(f"empty workload, choose one from the list: {environment_variables.workloads_list}")
         raise SystemExit(SYSTEM_EXIT_UNKNOWN_EXECUTION_TYPE)
 
     if not success:

--- a/benchmark_runner/main/temporary_environment_variables.py
+++ b/benchmark_runner/main/temporary_environment_variables.py
@@ -2,7 +2,8 @@
 import copy
 from benchmark_runner.main.environment_variables import environment_variables
 
-class TemporaryEnvironmentVariables():
+
+class TemporaryEnvironmentVariables:
     """
     Allow temporary replacement of environment variables for testing purposes.
     Intended to be used as

--- a/benchmark_runner/workloads/vdbench_pod.py
+++ b/benchmark_runner/workloads/vdbench_pod.py
@@ -1,6 +1,6 @@
 
 import os
-from typeguard import typechecked
+from multiprocessing import Process
 
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
@@ -20,6 +20,27 @@ class VdbenchPod(WorkloadsOperations):
         self.__status = ''
         self.__pod_name = ''
         self.__data_dict = {}
+
+    def __run_pod(self, pod_num: str):
+        """
+        This method runs pod in parallel
+        """
+        self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{pod_num}.yaml'), pod_name=f'{self.__pod_name}-{pod_num}')
+        self._oc.wait_for_initialized(label=f'app=vdbench-{self._trunc_uuid}-{pod_num}', label_uuid=False)
+        self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}-{pod_num}', label_uuid=False)
+        self.__status = self._oc.wait_for_pod_completed(label=f'app=vdbench-{self._trunc_uuid}-{pod_num}', label_uuid=False, job=False)
+        self.__status = 'complete' if self.__status else 'failed'
+        # save run artifacts logs
+        result_list = self._create_pod_run_artifacts(pod_name=f'{self.__pod_name}-{pod_num}')
+        if self._es_host:
+            # upload several run results
+            for result in result_list:
+                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=result)
+            # verify that data upload to elastic search according to unique uuid
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+        self._oc.delete_pod_sync(
+            yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{pod_num}.yaml'),
+            pod_name=f'{self.__pod_name}-{pod_num}')
 
     @logger_time_stamp
     def run(self):
@@ -41,22 +62,52 @@ class VdbenchPod(WorkloadsOperations):
             else:
                 self.__es_index = 'vdbench-results'
             self._environment_variables_dict['kind'] = self.__kind
-            self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), pod_name=self.__pod_name)
-            self._oc.wait_for_initialized(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False)
-            self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False)
-            self.__status = self._oc.wait_for_pod_completed(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False, job=False)
-            self.__status = 'complete' if self.__status else 'failed'
-            # save run artifacts logs
-            result_list = self._create_pod_run_artifacts(pod_name=self.__pod_name)
-            if self._es_host:
-                # upload several run results
-                for result in result_list:
-                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=result)
-                # verify that data upload to elastic search according to unique uuid
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
-            self._oc.delete_pod_sync(
-                yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
-                pod_name=self.__pod_name)
+            if not self._scale:
+                self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), pod_name=self.__pod_name)
+                self._oc.wait_for_initialized(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False)
+                self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False)
+                self.__status = self._oc.wait_for_pod_completed(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False, job=False)
+                self.__status = 'complete' if self.__status else 'failed'
+                # save run artifacts logs
+                result_list = self._create_pod_run_artifacts(pod_name=self.__pod_name)
+                if self._es_host:
+                    # upload several run results
+                    for result in result_list:
+                        self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=result)
+                    # verify that data upload to elastic search according to unique uuid
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+                self._oc.delete_pod_sync(
+                    yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
+                    pod_name=self.__pod_name)
+            # scale
+            else:
+                # create redis and state signals
+                sync_pods = {'redis': 'redis', 'state_signals_exporter_pod': 'state-signals-exporter'}
+                for pod, name in sync_pods.items():
+                    if pod == 'redis':
+                        pod_name = f'redis-master'
+                    else:
+                        pod_name = name
+                    self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
+                    self._oc.wait_for_initialized(label=f'app={name}', label_uuid=False)
+                    self._oc.wait_for_ready(label=f'app={name}', label_uuid=False)
+                proc = []
+                scale = int(self._scale)
+                # create all pods
+                for scale_num in range(scale):
+                    p = Process(target=self.__run_pod, args=(str(scale_num+1), ))
+                    p.start()
+                    proc.append(p)
+                for p in proc:
+                    p.join()
+                self._create_scale_logs()
+                # delete redis and state signals
+                for pod, name in sync_pods.items():
+                    if pod == 'redis':
+                        pod_name = f'redis-master'
+                    else:
+                        pod_name = name
+                    self._oc.delete_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_pod_sync(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
@@ -67,10 +118,10 @@ class VdbenchPod(WorkloadsOperations):
             if self._oc._is_pod_exist(pod_name=self.__pod_name):
                 self._create_pod_log(pod=self.__pod_name)
             self.__data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=self.__data_dict)
-            # verify that data upload to elastic search according to unique uuid
-            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=self.__data_dict)
+                # verify that data upload to elastic search according to unique uuid
+                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             self._oc.delete_pod_sync(
-                yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
-                pod_name=self.__pod_name)
+                yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), pod_name=self.__pod_name)
             raise err

--- a/benchmark_runner/workloads/vdbench_vm.py
+++ b/benchmark_runner/workloads/vdbench_vm.py
@@ -1,5 +1,6 @@
 
 import os
+from multiprocessing import Process
 
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
@@ -24,10 +25,32 @@ class VdbenchVM(WorkloadsOperations):
         self.__vm_name = ''
         self.__data_dict = {}
 
+    def __run_vm(self, vm_num: str):
+        """
+        This method run vm in parallel
+        """
+        self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{vm_num}.yaml'), vm_name=self.__vm_name)
+        self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}-{vm_num}', run_type='vm', label_uuid=False)
+        # Create vm log should be direct after vm is ready
+        self.__vm_name = self._create_vm_log(labels=[f'{self.__workload_name}-{self._trunc_uuid}-{vm_num}'])
+        self.__status = self._oc.wait_for_vm_log_completed(vm_name=self.__vm_name, end_stamp=self.END_STAMP)
+        self.__status = 'complete' if self.__status else 'failed'
+        # save run artifacts logs
+        result_list = self._create_vm_run_artifacts(vm_name=self.__vm_name, start_stamp=self.START_STAMP, end_stamp=self.END_STAMP)
+        if self._es_host:
+            # upload several run results
+            for result in result_list:
+                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=result)
+            # verify that data upload to elastic search according to unique uuid
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+        self._oc.delete_vm_sync(
+            yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}-{vm_num}.yaml'),
+            vm_name=f'{self.__vm_name}-{vm_num}')
+
     @logger_time_stamp
     def run(self):
         """
-        This method run the workload
+        This method runs the workload
         :return:
         """
         try:
@@ -40,23 +63,53 @@ class VdbenchVM(WorkloadsOperations):
             self.__vm_name = f'{self.__workload_name}-{self._trunc_uuid}'
             self.__kind = 'vm'
             self._environment_variables_dict['kind'] = 'vm'
-            self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
-            self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}', run_type='vm', label_uuid=False)
-            # Create vm log should be direct after vm is ready
-            self.__vm_name = self._create_vm_log(labels=[self.__workload_name])
-            self.__status = self._oc.wait_for_vm_log_completed(vm_name=self.__vm_name, end_stamp=self.END_STAMP)
-            self.__status = 'complete' if self.__status else 'failed'
-            # save run artifacts logs
-            result_list = self._create_vm_run_artifacts(vm_name=self.__vm_name, start_stamp=self.START_STAMP, end_stamp=self.END_STAMP)
-            if self._es_host:
-                # upload several run results
-                for result in result_list:
-                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=result)
-                # verify that data upload to elastic search according to unique uuid
-                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
-            self._oc.delete_vm_sync(
-                yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
-                vm_name=self.__vm_name)
+            if not self._scale:
+                self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
+                self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}', run_type='vm', label_uuid=False)
+                # Create vm log should be direct after vm is ready
+                self.__vm_name = self._create_vm_log(labels=[self.__workload_name])
+                self.__status = self._oc.wait_for_vm_log_completed(vm_name=self.__vm_name, end_stamp=self.END_STAMP)
+                self.__status = 'complete' if self.__status else 'failed'
+                # save run artifacts logs
+                result_list = self._create_vm_run_artifacts(vm_name=self.__vm_name, start_stamp=self.START_STAMP, end_stamp=self.END_STAMP)
+                if self._es_host:
+                    # upload several run results
+                    for result in result_list:
+                        self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=result)
+                    # verify that data upload to elastic search according to unique uuid
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+                self._oc.delete_vm_sync(
+                    yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
+                    vm_name=self.__vm_name)
+            # scale
+            else:
+                # create redis and state signals
+                sync_pods = {'redis': 'redis', 'state_signals_exporter_pod': 'state-signals-exporter'}
+                for pod, name in sync_pods.items():
+                    if pod == 'redis':
+                        pod_name = f'redis-master'
+                    else:
+                        pod_name = name
+                    self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
+                    self._oc.wait_for_initialized(label=f'app={name}', label_uuid=False)
+                    self._oc.wait_for_ready(label=f'app={name}', label_uuid=False)
+                proc = []
+                scale = int(self._scale)
+                # create all pods
+                for scale_num in range(scale):
+                    p = Process(target=self.__run_vm, args=(str(scale_num+1), ))
+                    p.start()
+                    proc.append(p)
+                for p in proc:
+                    p.join()
+                self._create_scale_logs()
+                # delete redis and state signals
+                for pod, name in sync_pods.items():
+                    if pod == 'redis':
+                        pod_name = f'redis-master'
+                    else:
+                        pod_name = name
+                    self._oc.delete_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_vm_sync(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
@@ -64,8 +117,9 @@ class VdbenchVM(WorkloadsOperations):
             raise err
         except Exception as err:
             # save run artifacts logs
-            self.__data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=self.__data_dict)
-            # verify that data upload to elastic search according to unique uuid
-            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            if self._es_host:
+                self.__data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
+                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=self.__data_dict)
+                # verify that data upload to elastic search according to unique uuid
+                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
             raise err

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -1,4 +1,5 @@
 
+import ast
 import os
 import datetime
 import tarfile
@@ -48,6 +49,12 @@ class WorkloadsOperations:
         self._es_user = self._environment_variables_dict.get('elasticsearch_user', '')
         self._es_password = self._environment_variables_dict.get('elasticsearch_password', '')
         self._es_url_protocol = self._environment_variables_dict['elasticsearch_url_protocol']
+        self._scale = self._environment_variables_dict.get('scale', '')
+        if self._scale:
+            self._scale_node = self._environment_variables_dict.get('scale_nodes', '')
+            self._scale_node_list = ast.literal_eval(self._scale_node)
+        else:
+            self._scale_node_list = []
         self._timeout = int(self._environment_variables_dict.get('timeout', ''))
         # Elasticsearch connection
         if self._es_host and self._es_port:
@@ -85,7 +92,7 @@ class WorkloadsOperations:
         This method delete all resources in namespace
         :return:
         """
-        self._oc.delete_all_resources(resources=['vm', 'pods', 'pvc'])
+        self._oc.delete_namespace()
 
     @logger_time_stamp
     def start_prometheus(self):
@@ -122,7 +129,7 @@ class WorkloadsOperations:
         :return:
         """
         workload_name = self._workload.split('_')
-        if self._odf_pvc == 'True' and workload_name[0] in self._workloads_odf_pvc:
+        if workload_name[0] in self._workloads_odf_pvc:
             if not self._oc.is_odf_installed():
                 raise ODFNonInstalled()
 
@@ -178,6 +185,14 @@ class WorkloadsOperations:
         except ValueError:
             return False
 
+    def _create_scale_logs(self):
+        """
+        The method create scale logs
+        :return:
+        """
+        self._create_pod_log(pod='state-signals-exporter')
+        self._create_pod_log(pod='redis-master')
+
     def _create_pod_run_artifacts(self, pod_name: str):
         """
         This method create pod run artifacts
@@ -212,6 +227,10 @@ class WorkloadsOperations:
         result_list = []
         results_list = self._oc.extract_vm_results(vm_name=vm_name, start_stamp=start_stamp, end_stamp=end_stamp)
         workload_name = self._environment_variables_dict.get('workload', '').replace('_', '-')
+        # save scale pod logs
+        if self._scale:
+            self._create_pod_log(pod='state-signals-exporter')
+            self._create_pod_log(pod='redis-master')
         # insert results to csv
         csv_result_file = os.path.join(self._run_artifacts_path, 'vdbench_vm_result.csv')
         with open(csv_result_file, 'w') as out:
@@ -246,21 +265,19 @@ class WorkloadsOperations:
     def upload_run_artifacts_to_s3(self):
         """
         This method uploads log to s3
-        :param workload:
         :return:
         """
         workload = self._workload.replace('_', '-')
         tar_run_artifacts_path = self.__make_run_artifacts_tarfile(workload)
         run_artifacts_hierarchy = self._get_run_artifacts_hierarchy(workload_name=workload)
         # Upload when endpoint_url is not None
-        if self._endpoint_url:
-            s3operations = S3Operations()
-            # change workload to key convention
-            upload_file = f"{workload}-{self._time_stamp_format}.tar.gz"
-            s3operations.upload_file(file_name_path=tar_run_artifacts_path,
-                                     bucket=self._environment_variables_dict.get('bucket', ''),
-                                     key=run_artifacts_hierarchy,
-                                     upload_file=upload_file)
+        s3operations = S3Operations()
+        # change workload to key convention
+        upload_file = f"{workload}-{self._time_stamp_format}.tar.gz"
+        s3operations.upload_file(file_name_path=tar_run_artifacts_path,
+                                 bucket=self._environment_variables_dict.get('bucket', ''),
+                                 key=run_artifacts_hierarchy,
+                                 upload_file=upload_file)
         # remove local run artifacts workload folder
         # verify that its not empty path
         if len(self._run_artifacts_path) > 3 and self._run_artifacts_path != '/' and self._run_artifacts_path and tar_run_artifacts_path and os.path.isfile(tar_run_artifacts_path) and not self._save_artifacts_local:
@@ -293,6 +310,13 @@ class WorkloadsOperations:
             metadata.update({'kind': kind})
         if status:
             metadata.update({'run_status': status})
+        if self._scale:
+            metadata.update({'scale': int(self._scale)})
+            for i, node in enumerate(self._scale_node_list):
+                if len(self._scale_node_list) == 1:
+                    metadata.update({f'{kind}-scale-node-{i+1}': self._scale_node_list[0]})
+                else:
+                    metadata.update({f'{kind}-scale-node-{i+1}': node})
         if result:
             metadata.update(result)
 
@@ -344,22 +368,33 @@ class WorkloadsOperations:
         metadata.update({'status': status, 'status#': status_dict[status], 'ci_minutes_time': ci_minutes_time, 'benchmark_operator_id': benchmark_operator_id, 'benchmark_wrapper_id': benchmark_wrapper_id, 'ocp_install_minutes_time': ocp_install_minutes_time, 'ocp_resource_install_minutes_time': ocp_resource_install_minutes_time})
         self.__es_operations.upload_to_elasticsearch(index=es_index, data=metadata)
 
+    @logger_time_stamp
+    def clear_nodes_cache(self):
+        """
+        This method clear nodes cache
+        """
+        self._oc.clear_node_caches()
+
     def initialize_workload(self):
         """
         This method includes all the initialization of workload
         :return:
         """
         self.delete_all()
-        self._oc.clear_nodes_cache()
-        self.odf_pvc_verification()
-        self._template.generate_yamls()
-        self.start_prometheus()
+        self.clear_nodes_cache()
+        if self._odf_pvc == 'True':
+            self.odf_pvc_verification()
+        self._template.generate_yamls(scale=self._scale, scale_nodes=self._scale_node_list)
+        if self._enable_prometheus_snapshot:
+            self.start_prometheus()
 
     def finalize_workload(self):
         """
         This method includes all the finalization of workload
         :return:
         """
-        self.end_prometheus()
-        self.upload_run_artifacts_to_s3()
+        if self._enable_prometheus_snapshot:
+            self.end_prometheus()
+        if self._endpoint_url:
+            self.upload_run_artifacts_to_s3()
         self.delete_all()

--- a/dockerfiles/centos-stream8-vdbench5.04.07 pod/Dockerfile
+++ b/dockerfiles/centos-stream8-vdbench5.04.07 pod/Dockerfile
@@ -1,0 +1,48 @@
+FROM quay.io/centos/centos:stream8
+# copying vdbench
+COPY vdbench50407.zip  /vdbench/vdbench50407.zip
+COPY vdbench_runner.sh /vdbench/vdbench_runner.sh
+
+# installing java
+RUN yum -y install java
+
+# installing vim
+RUN yum -y install vim
+
+# installing monitoring tools
+RUN yum -y install procps
+RUN yum -y install sysstat
+
+# add ntfs & xfs support
+ENV NTFS=ntfs3g
+COPY ${NTFS}  /${NTFS}
+WORKDIR ${NTFS}
+RUN yum -y install xfsprogs
+RUN yum -y groupinstall "Development Tools" \
+    && tar -xvf ntfs-3g_ntfsprogs-2017.3.23.tgz --strip-components 1 \
+    && ./configure --prefix=/usr/local --disable-static \
+    && make \
+    && make install
+
+#delete installation files
+WORKDIR /root
+RUN rm -rf /ntfs3g
+
+# extracting vdbench files
+RUN /bin/bash -c "unzip /vdbench/vdbench50407.zip -d /vdbench/"
+
+# skip: starting the vdbench runner
+# ENTRYPOINT /bin/bash -c "/vdbench/vdbench_runner.sh"
+
+RUN chmod +x /vdbench/vdbench
+
+# scale support - state signal
+# install python 3.9 - take several minutes
+RUN dnf install -y python3.9
+
+# install state-signals (--no-cache-dir for take always the latest)
+RUN python3.9 -m pip --no-cache-dir install --upgrade pip && pip --no-cache-dir install state-signals==0.5.2
+
+COPY state_signals_responder.py /state_signals_responder.py
+
+#podman build -t quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest . --no-cache

--- a/dockerfiles/centos-stream8-vdbench5.04.07 pod/readme.txt
+++ b/dockerfiles/centos-stream8-vdbench5.04.07 pod/readme.txt
@@ -1,5 +1,4 @@
 $ git clone https://github.com/bbenshab/vdpod
 $ cd vdpod
-$ vi Dockerfile
-change image to centos stream8
-Delete line with mkdir /workload
+cp Dockerfile Dockerfile
+cp state_signals_responder.py state_signals_responder.py

--- a/dockerfiles/centos-stream8-vdbench5.04.07 pod/state_signals_responder.py
+++ b/dockerfiles/centos-stream8-vdbench5.04.07 pod/state_signals_responder.py
@@ -1,0 +1,61 @@
+
+import sys
+import state_signals
+from multiprocessing import Process
+import argparse
+import subprocess
+
+
+class StateSignalsResponder:
+    """
+    This class runs state signals responder
+    """
+    def __init__(self, redis_host: str, run_workload_method: str, timeout: int):
+        self.__redis_host = redis_host
+        self.__run_workload_method = run_workload_method
+        self.__timeout = timeout
+
+    def _listener(self):
+        responder = state_signals.SignalResponder(
+            redis_host=self.__redis_host, responder_name="benchmark-runner", conn_timeout=self.__timeout
+        )
+        for signal in responder.listen():
+            if signal.tag == "bad":
+                ras = 0
+            elif signal.event == 'benchmark-start':
+                output = subprocess.check_output(
+                    self.__run_workload_method,
+                    stderr=subprocess.STDOUT,
+                    shell=True, timeout=self.__timeout,
+                    universal_newlines=False)
+                print(output.decode("utf-8"))
+                if output:
+                    ras = 1
+                else:
+                    ras = 0
+            elif signal.event == 'shutdown':
+                sys.exit()
+            else:
+                ras = 1
+            # responder.respond(signal.publisher_id, signal.event, ras)
+            responder.srespond(signal, ras=ras)
+
+
+def main():
+    # Instantiate the parser
+    parser = argparse.ArgumentParser(description='Signal State Responder')
+    # Required positional argument
+    parser.add_argument('redis_host', type=str,
+                        help='Redis host')
+    parser.add_argument('workload_method', type=str,
+                        help='workload method')
+    parser.add_argument('timeout', type=int,
+                        help='timeout')
+    args = parser.parse_args()
+    run = StateSignalsResponder(redis_host=args.redis_host, run_workload_method=args.workload_method, timeout=args.timeout)
+    init = Process(target=run._listener)
+    init.start()
+
+main()
+
+# python3.9 /state_signals_responder.py redis-deployment.redis-db.svc.cluster.local /vdbench/vdbench_runner.sh 3600

--- a/dockerfiles/centos-stream8-vdbench5.04.07-container-disk/install_vdbench.sh
+++ b/dockerfiles/centos-stream8-vdbench5.04.07-container-disk/install_vdbench.sh
@@ -4,13 +4,24 @@ sudo dnf -y update
 dnf install -y epel-release
 dnf install -y python3-pip
 dnf install -y git redis wget
+
 git clone https://github.com/bbenshab/vdpod
 cd vdpod/
 mkdir /vdbench
-cp -r vdbench_linux/*  /vdbench
+# copying vdbench
+cp vdbench50407.zip /vdbench/vdbench50407.zip
 cp vdbench_runner.sh /vdbench/vdbench_runner.sh
+
+# installing java
 yum -y install java
+
+# installing vim
 yum -y install vim
+
+# installing monitoring tools
+yum -y install procps
+yum -y install sysstat
+
 NTFS=ntfs3g
 cp -r ${NTFS}  /${NTFS}
 cd /ntfs3g/
@@ -19,4 +30,15 @@ yum -y groupinstall "Development Tools"
 tar -xvf ntfs-3g_ntfsprogs-2017.3.23.tgz --strip-components 1
 ./configure --prefix=/usr/local --disable-static
 make
+make install
 rm -rf /ntfs3g
+
+# extracting vdbench files
+unzip /vdbench/vdbench50407.zip -d /vdbench/
+chmod +x /vdbench/vdbench
+
+# add-on for state-signals
+dnf install -y python3.9
+cd /
+python3.9 -m pip --no-cache-dir install --upgrade pip && pip3.9 --no-cache-dir install state-signals==0.5.2
+cp state_signals_responder.py /state_signals_responder.py

--- a/dockerfiles/centos-stream8-vdbench5.04.07-container-disk/state_signals_responder.py
+++ b/dockerfiles/centos-stream8-vdbench5.04.07-container-disk/state_signals_responder.py
@@ -1,0 +1,61 @@
+
+import sys
+import state_signals
+from multiprocessing import Process
+import argparse
+import subprocess
+
+
+class StateSignalsResponder:
+    """
+    This class runs state signals responder
+    """
+    def __init__(self, redis_host: str, run_workload_method: str, timeout: int):
+        self.__redis_host = redis_host
+        self.__run_workload_method = run_workload_method
+        self.__timeout = timeout
+
+    def _listener(self):
+        responder = state_signals.SignalResponder(
+            redis_host=self.__redis_host, responder_name="benchmark-runner", conn_timeout=self.__timeout
+        )
+        for signal in responder.listen():
+            if signal.tag == "bad":
+                ras = 0
+            elif signal.event == 'benchmark-start':
+                output = subprocess.check_output(
+                    self.__run_workload_method,
+                    stderr=subprocess.STDOUT,
+                    shell=True, timeout=self.__timeout,
+                    universal_newlines=False)
+                print(output.decode("utf-8"))
+                if output:
+                    ras = 1
+                else:
+                    ras = 0
+            elif signal.event == 'shutdown':
+                sys.exit()
+            else:
+                ras = 1
+            # responder.respond(signal.publisher_id, signal.event, ras)
+            responder.srespond(signal, ras=ras)
+
+
+def main():
+    # Instantiate the parser
+    parser = argparse.ArgumentParser(description='Signal State Responder')
+    # Required positional argument
+    parser.add_argument('redis_host', type=str,
+                        help='Redis host')
+    parser.add_argument('workload_method', type=str,
+                        help='workload method')
+    parser.add_argument('timeout', type=int,
+                        help='timeout')
+    args = parser.parse_args()
+    run = StateSignalsResponder(redis_host=args.redis_host, run_workload_method=args.workload_method, timeout=args.timeout)
+    init = Process(target=run._listener)
+    init.start()
+
+main()
+
+# python3.9 /state_signals_responder.py redis-deployment.redis-db.svc.cluster.local /vdbench/vdbench_runner.sh 3600

--- a/dockerfiles/state-signals-exporter-0.5.2-pod/Dockerfile
+++ b/dockerfiles/state-signals-exporter-0.5.2-pod/Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/centos/centos:stream8
+
+# Update and use not only best candidate packages (avoiding failures)
+RUN dnf update -y --nobest
+
+# install python 3.9 - take several minutes
+RUN dnf install -y python3.9
+
+# install state-signals (--no-cache-dir for take always the latest)
+RUN python3 -m pip --no-cache-dir install --upgrade pip && pip --no-cache-dir install state-signals==0.5.2
+
+COPY state_signals_exporter.py /state_signals_exporter.py

--- a/dockerfiles/state-signals-exporter-0.5.2-pod/state_signals_exporter.py
+++ b/dockerfiles/state-signals-exporter-0.5.2-pod/state_signals_exporter.py
@@ -1,0 +1,57 @@
+
+import state_signals
+import argparse
+
+
+class StateSignalsExporter:
+    """
+    This class runs state signals exporter
+    """
+    def __init__(self, redis_host: str, scale_num: int, timeout: int):
+        self.__redis_host = redis_host
+        self.__scale_num = scale_num
+        self.__timeout = timeout
+
+    def state_signals_exporter(self):
+        """
+        This method runs state_signals
+        :return:
+        """
+        sig_ex = state_signals.SignalExporter(redis_host=self.__redis_host, process_name="benchmark-runner", conn_timeout=self.__timeout, log_level="DEBUG")
+        print("\nBENCHMARK INIT\n")
+        sig_ex.initialize_and_wait(
+            await_sub_count=self.__scale_num, legal_events=["benchmark-start"], periodic=True, timeout=self.__timeout
+        )
+        print(f"Proof of response (subs): {str(sig_ex.subs)}")
+
+        print("\nBENCHMARK START\n")
+        result, _ = sig_ex.publish_signal(
+            "benchmark-start", metadata={"something": "cool info"}, timeout=self.__timeout
+        )
+        print(f"SUBS CLEARED! Result code: {result}")
+
+        print("\nBENCHMARK SHUTDOWN\n")
+        print(f"Listening: {str(sig_ex.init_listener.is_alive())}")
+        sig_ex.shutdown()
+        print(f"Listening: {str(sig_ex.init_listener.is_alive())}")
+        print("NO LONGER LISTENING, DONE")
+
+
+def main():
+    # Instantiate the parser
+    parser = argparse.ArgumentParser(description='Signal State Exporter')
+    # Required positional argument
+    parser.add_argument('redis_host', type=str,
+                        help='Redis host')
+    parser.add_argument('scale_num', type=int,
+                        help='Number of scale workloads')
+    parser.add_argument('timeout', type=int,
+                        help='timeout')
+    args = parser.parse_args()
+    run = StateSignalsExporter(redis_host=args.redis_host, scale_num=args.scale_num, timeout=args.timeout)
+    run.state_signals_exporter()
+
+
+main()
+
+# python3 /state_signals_exporter.py 'redis-deployment.redis-db.svc.cluster.local' 1 3600

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -22,7 +22,7 @@ Reference:
 
 ![](../../media/docker2.png)
 
-![](../../media/demo.gif)
+![](../../media/benchmark-runner-demo.gif)
 
 
 <!-- Table of contents -->

--- a/docs/source/podman.md
+++ b/docs/source/podman.md
@@ -34,4 +34,7 @@ Choose one from the following list:
 ```sh
 podman run --rm -e WORKLOAD=$WORKLOAD -e KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD -e PIN_NODE_BENCHMARK_OPERATOR=$PIN_NODE_BENCHMARK_OPERATOR -e PIN_NODE1=$PIN_NODE1 -e PIN_NODE2=$PIN_NODE2 -e ELASTICSEARCH=$ELASTICSEARCH -e ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT -e log_level=INFO -v $KUBECONFIG:/root/.kube/config --privileged quay.io/ebattat/benchmark-runner:latest
 ```
-
+SAVE ARTIFACTS LOCAL:
+1. add "-e SAVE_ARTIFACTS_LOCAL='True'"
+2. add "-v /tmp:/tmp"
+3. git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator

--- a/tests/integration/benchmark_runner/common/oc/test_oc_benchmark_runner.py
+++ b/tests/integration/benchmark_runner/common/oc/test_oc_benchmark_runner.py
@@ -49,7 +49,7 @@ def before_after_each_test_fixture():
     test_environment_variable['namespace'] = 'benchmark-runner'
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.login()
-    oc.delete_all_resources(resources=['vm', 'pods', 'pvc'], namespace=test_environment_variable['namespace'])
+    oc.delete_namespace(namespace=test_environment_variable['namespace'])
     # @TODO add vm once implement
     kinds = ('vm', 'pod', 'kata')
     for kind in kinds:
@@ -58,7 +58,7 @@ def before_after_each_test_fixture():
     # After all tests
     for kind in kinds:
         __delete_test_objects(workload='vdbench', kind=kind)
-    oc.delete_all_resources(resources=['pods', 'pvc'], namespace=test_environment_variable['namespace'])
+    oc.delete_namespace(namespace=test_environment_variable['namespace'])
     # revert to defaults namespace
     test_environment_variable['namespace'] = 'benchmark-operator'
     print('Test End')

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -14,6 +14,7 @@ class GoldenFiles:
 
     def __init__(self):
         self.__file_path = os.path.join(f'{os.path.dirname(os.path.realpath(__file__))}', 'golden_files')
+        environment_variables.environment_variables_dict['system_metrics'] = 'True'
         environment_variables.environment_variables_dict['elasticsearch'] = 'elasticsearch.example.com'
         environment_variables.environment_variables_dict['elasticsearch_port'] = '9999'
         environment_variables.environment_variables_dict['elasticsearch_url'] = 'http://elasticsearch.example.com:gol9999'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,11 +27,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       env:
         - name: BLOCK_SIZES
@@ -38,7 +39,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -51,22 +52,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -39,11 +40,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: vdbench-pod-pvc-claim
@@ -54,7 +55,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -67,22 +68,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -25,11 +26,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       env:
         - name: BLOCK_SIZES
@@ -37,7 +38,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -50,22 +51,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -38,11 +39,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: vdbench-pod-pvc-claim
@@ -53,7 +54,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -66,22 +67,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -47,11 +48,11 @@ spec:
             memory: 10Mi
           limits:
             cpu: 2
-            memory: 2Gi
+            memory: 4Gi
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -64,19 +65,22 @@ spec:
               runcmd:
                 - export BLOCK_SIZES=64,oltp1
                 - export IO_OPERATION=write,oltp1
-                - export IO_THREADS=1,3
+                - export IO_THREADS=16,3
                 - export FILES_IO=random,oltp1
                 - export IO_RATE=max,max
                 - export MIX_PRECENTAGE # used for mixed workload 0-100
                 - export DURATION=20
                 - export PAUSE=0
-                - export WARMUP=0
+                - export WARMUP=20
                 - export FILES_SELECTION=random
                 - export COMPRESSION_RATIO=2
-                - export RUN_FILLUP=no
-                - export DIRECTORIES=300
-                - export FILES_PER_DIRECTORY=3
-                - export SIZE_PER_FILE=10
+                - export RUN_FILLUP=yes
+                - export DIRECTORIES=100
+                - export FILES_PER_DIRECTORY=10
+                - export SIZE_PER_FILE=5
+                - export REDIS_HOST=
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT=3600
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -60,14 +61,14 @@ spec:
             memory: 10Mi
           limits:
             cpu: 2
-            memory: 2Gi
+            memory: 4Gi
       terminationGracePeriodSeconds: 0
       volumes:
         - name: data-volume
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -80,19 +81,22 @@ spec:
               runcmd:
                 - export BLOCK_SIZES=64,oltp1
                 - export IO_OPERATION=write,oltp1
-                - export IO_THREADS=1,3
+                - export IO_THREADS=16,3
                 - export FILES_IO=random,oltp1
                 - export IO_RATE=max,max
                 - export MIX_PRECENTAGE # used for mixed workload 0-100
                 - export DURATION=20
                 - export PAUSE=0
-                - export WARMUP=0
+                - export WARMUP=20
                 - export FILES_SELECTION=random
                 - export COMPRESSION_RATIO=2
-                - export RUN_FILLUP=no
-                - export DIRECTORIES=300
-                - export FILES_PER_DIRECTORY=3
-                - export SIZE_PER_FILE=10
+                - export RUN_FILLUP=yes
+                - export DIRECTORIES=100
+                - export FILES_PER_DIRECTORY=10
+                - export SIZE_PER_FILE=5
+                - export REDIS_HOST=
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT=3600
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -30,7 +31,7 @@ spec:
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       env:
         - name: BLOCK_SIZES
@@ -38,7 +39,7 @@ spec:
         - name: IO_OPERATION
           value: "oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write"
         - name: IO_THREADS
-          value: "1,1,1,1,1,4,4,2,2,4,4,2,2"
+          value: "16,16,16,16,16,4,4,2,2,4,4,2,2"
         - name: FILES_IO #How file IO will be done
           value: "oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random"
         - name: IO_RATE # an integer or "max"
@@ -47,7 +48,7 @@ spec:
           value:
         #global settings
         - name: DURATION
-          value: "600"
+          value: "360"
         - name: PAUSE #pause after every test in sec
           value: "20"
         - name: WARMUP # warmup before any test in sec
@@ -65,8 +66,15 @@ spec:
           value: "10"
         - name: SIZE_PER_FILE # size in MB
           value: "10"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -43,7 +44,7 @@ spec:
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: vdbench-pod-pvc-claim
@@ -54,7 +55,7 @@ spec:
         - name: IO_OPERATION
           value: "oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write"
         - name: IO_THREADS
-          value: "1,1,1,1,1,4,4,2,2,4,4,2,2"
+          value: "16,16,16,16,16,4,4,2,2,4,4,2,2"
         - name: FILES_IO #How file IO will be done
           value: "oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random"
         - name: IO_RATE # an integer or "max"
@@ -63,7 +64,7 @@ spec:
           value:
         #global settings
         - name: DURATION
-          value: "600"
+          value: "360"
         - name: PAUSE #pause after every test in sec
           value: "20"
         - name: WARMUP # warmup before any test in sec
@@ -81,8 +82,15 @@ spec:
           value: "10"
         - name: SIZE_PER_FILE # size in MB
           value: "10"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -29,7 +30,7 @@ spec:
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       env:
         - name: BLOCK_SIZES
@@ -37,7 +38,7 @@ spec:
         - name: IO_OPERATION
           value: "oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write"
         - name: IO_THREADS
-          value: "1,1,1,1,1,4,4,2,2,4,4,2,2"
+          value: "16,16,16,16,16,4,4,2,2,4,4,2,2"
         - name: FILES_IO #How file IO will be done
           value: "oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random"
         - name: IO_RATE # an integer or "max"
@@ -46,7 +47,7 @@ spec:
           value:
         #global settings
         - name: DURATION
-          value: "600"
+          value: "360"
         - name: PAUSE #pause after every test in sec
           value: "20"
         - name: WARMUP # warmup before any test in sec
@@ -64,8 +65,15 @@ spec:
           value: "10"
         - name: SIZE_PER_FILE # size in MB
           value: "10"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -42,7 +43,7 @@ spec:
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: vdbench-pod-pvc-claim
@@ -53,7 +54,7 @@ spec:
         - name: IO_OPERATION
           value: "oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write"
         - name: IO_THREADS
-          value: "1,1,1,1,1,4,4,2,2,4,4,2,2"
+          value: "16,16,16,16,16,4,4,2,2,4,4,2,2"
         - name: FILES_IO #How file IO will be done
           value: "oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random"
         - name: IO_RATE # an integer or "max"
@@ -62,7 +63,7 @@ spec:
           value:
         #global settings
         - name: DURATION
-          value: "600"
+          value: "360"
         - name: PAUSE #pause after every test in sec
           value: "20"
         - name: WARMUP # warmup before any test in sec
@@ -80,8 +81,15 @@ spec:
           value: "10"
         - name: SIZE_PER_FILE # size in MB
           value: "10"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -51,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -64,11 +65,11 @@ spec:
               runcmd:
                 - export BLOCK_SIZES=oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64
                 - export IO_OPERATION=oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write
-                - export IO_THREADS=1,1,1,1,1,4,4,2,2,4,4,2,2
+                - export IO_THREADS=16,16,16,16,16,4,4,2,2,4,4,2,2
                 - export FILES_IO=oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random
                 - export IO_RATE=max,max,max,max,max,max,max,max,max,max,max,max,max
                 - export MIX_PRECENTAGE # used for mixed workload 0-100
-                - export DURATION=600
+                - export DURATION=360
                 - export PAUSE=20
                 - export WARMUP=20
                 - export FILES_SELECTION=random
@@ -77,6 +78,9 @@ spec:
                 - export DIRECTORIES=600
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=10
+                - export REDIS_HOST=
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT=3600
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -67,7 +68,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -80,11 +81,11 @@ spec:
               runcmd:
                 - export BLOCK_SIZES=oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64
                 - export IO_OPERATION=oltp1,oltp2,oltphw,odss2,odss128,read,read,read,read,write,write,write,write
-                - export IO_THREADS=1,1,1,1,1,4,4,2,2,4,4,2,2
+                - export IO_THREADS=16,16,16,16,16,4,4,2,2,4,4,2,2
                 - export FILES_IO=oltp1,oltp2,oltphw,odss2,odss128,random,random,random,random,random,random,random,random
                 - export IO_RATE=max,max,max,max,max,max,max,max,max,max,max,max,max
                 - export MIX_PRECENTAGE # used for mixed workload 0-100
-                - export DURATION=600
+                - export DURATION=360
                 - export PAUSE=20
                 - export WARMUP=20
                 - export FILES_SELECTION=random
@@ -93,6 +94,9 @@ spec:
                 - export DIRECTORIES=600
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=10
+                - export REDIS_HOST=
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT=3600
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -26,11 +27,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       env:
         - name: BLOCK_SIZES
@@ -38,7 +39,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -51,22 +52,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -39,11 +40,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: vdbench-pod-pvc-claim
@@ -54,7 +55,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -67,22 +68,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -25,11 +26,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       env:
         - name: BLOCK_SIZES
@@ -37,7 +38,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -50,22 +51,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -38,11 +39,11 @@ spec:
       memory: 10Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
   containers:
     - name: vdbench-pod
       namespace: benchmark-runner
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:latest
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.5
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - name: vdbench-pod-pvc-claim
@@ -53,7 +54,7 @@ spec:
         - name: IO_OPERATION
           value: "write,oltp1"
         - name: IO_THREADS
-          value: "1,3"
+          value: "16,3"
         - name: FILES_IO #How file IO will be done
           value: "random,oltp1"
         - name: IO_RATE # an integer or "max"
@@ -66,22 +67,29 @@ spec:
         - name: PAUSE #pause after every test in sec
           value: "0"
         - name: WARMUP # warmup before any test in sec
-          value: "0"
+          value: "20"
         - name: FILES_SELECTION #This parameter allows you to select directories and files for processing either sequential/random
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
         - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
-          value: "no"
+          value: "yes"
         #data set settings
         - name: DIRECTORIES #how many directories to create
-          value: "300"
+          value: "100"
         - name: FILES_PER_DIRECTORY
-          value: "3"
-        - name: SIZE_PER_FILE # size in MB
           value: "10"
+        - name: SIZE_PER_FILE # size in MB
+          value: "5"
+        #state-signals
+        - name: REDIS_HOST
+          value: ""
+        - name: WORKLOAD_METHOD
+          value: "/vdbench/vdbench_runner.sh"
+        - name: TIMEOUT
+          value: "3600"
       command: ["/bin/bash"]
-      args: ["-c", "/vdbench/vdbench_runner.sh"]
+      args: ["-c", "$WORKLOAD_METHOD"]
   restartPolicy: "Never"
   spec:
     pvc:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -47,11 +48,11 @@ spec:
             memory: 10Mi
           limits:
             cpu: 2
-            memory: 2Gi
+            memory: 4Gi
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -64,19 +65,22 @@ spec:
               runcmd:
                 - export BLOCK_SIZES=64,oltp1
                 - export IO_OPERATION=write,oltp1
-                - export IO_THREADS=1,3
+                - export IO_THREADS=16,3
                 - export FILES_IO=random,oltp1
                 - export IO_RATE=max,max
                 - export MIX_PRECENTAGE # used for mixed workload 0-100
                 - export DURATION=20
                 - export PAUSE=0
-                - export WARMUP=0
+                - export WARMUP=20
                 - export FILES_SELECTION=random
                 - export COMPRESSION_RATIO=2
-                - export RUN_FILLUP=no
-                - export DIRECTORIES=300
-                - export FILES_PER_DIRECTORY=3
-                - export SIZE_PER_FILE=10
+                - export RUN_FILLUP=yes
+                - export DIRECTORIES=100
+                - export FILES_PER_DIRECTORY=10
+                - export SIZE_PER_FILE=5
+                - export REDIS_HOST=
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT=3600
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -60,14 +61,14 @@ spec:
             memory: 10Mi
           limits:
             cpu: 2
-            memory: 2Gi
+            memory: 4Gi
       terminationGracePeriodSeconds: 0
       volumes:
         - name: data-volume
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.5
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -80,19 +81,22 @@ spec:
               runcmd:
                 - export BLOCK_SIZES=64,oltp1
                 - export IO_OPERATION=write,oltp1
-                - export IO_THREADS=1,3
+                - export IO_THREADS=16,3
                 - export FILES_IO=random,oltp1
                 - export IO_RATE=max,max
                 - export MIX_PRECENTAGE # used for mixed workload 0-100
                 - export DURATION=20
                 - export PAUSE=0
-                - export WARMUP=0
+                - export WARMUP=20
                 - export FILES_SELECTION=random
                 - export COMPRESSION_RATIO=2
-                - export RUN_FILLUP=no
-                - export DIRECTORIES=300
-                - export FILES_PER_DIRECTORY=3
-                - export SIZE_PER_FILE=10
+                - export RUN_FILLUP=yes
+                - export DIRECTORIES=100
+                - export FILES_PER_DIRECTORY=10
+                - export SIZE_PER_FILE=5
+                - export REDIS_HOST=
+                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export TIMEOUT=3600
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@


### PR DESCRIPTION
This PR including:

1. Add scale template for [state-signals](https://github.com/distributed-system-analysis/state-signals) **exporter**.
2. Add Redis Deployment and Service template
3. Update vdbench pod and vm templates for supporting scale
4. Update TemplateOperations class for supporting scale
5. Update VdbenchPod and VdbenchVM classes for supporting scale
6. Update new vdbench pod and vm images wrapping by [state-signals](https://github.com/distributed-system-analysis/state-signals) **responder**.:
vdbench pod image: quay.io/ebattat/centos-stream8-vdbench-5.04.07-pod:v1.0.0
vdbench vm image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.0
8. Skipping call to Prometheus or Upload S3 methods when its disabled.
9. Add 3 environment variables for supporting scale:
SCALE: scale number of pod or vm 
SCALE_NODES: list of nodes per pod/vm, all will run on the same node when 1 node, e.g: [ 'master-1', 'master-2' ]
REDIS: Redis service 
10. Nightly_Func_Env_CI.yml: Update func nightly run for running vdbench pod and vm in scale of 2
11. Update Uperf to supporting timestamp instead of uperf_ts due to changes in benchmark-wrapper (https://github.com/cloud-bulldozer/benchmark-wrapper/pull/424/files)
12. Update golden files and readme file