### PR TITLE
Split vdbench tests

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.346
+current_version = 1.0.347
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -102,7 +102,7 @@ spec:
   {%- endif %}
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -149,10 +149,10 @@ spec:
           value: "{{ FILES_SELECTION }}"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "{{ COMPRESSION_RATIO }}"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "{{ RUN_FILLUP }}"
         - name: LOGS_DIR # logs directory
-          value: "/workload/"
+          value: "{{ LOGS_DIR }}"
         #data set settings
         - name: DIRECTORIES #how many directories to create
           value: "{{ DIRECTORIES }}"

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -96,7 +96,7 @@ spec:
             {%- endif %}
 {%- endif %}
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -125,7 +125,7 @@ spec:
                 - export REDIS_HOST={{ redis }}
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT={{ timeout }}
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR={{ LOGS_DIR }}
                 - echo @@~@@START-WORKLOAD@@~@@
                 {% if not scale -%}
                 - /vdbench/vdbench_runner.sh

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -28,13 +28,14 @@ template_data:
       COMPRESSION_RATIO: 2
       # will it run a fillup before testing starts yes/no
       RUN_FILLUP: "yes"
+      LOGS_DIR: "/workload/"
       # how many directories to create
       DIRECTORIES: 600
       FILES_PER_DIRECTORY: 10
       # size in MB
       SIZE_PER_FILE: 10
       limits_cpu: 2
-      limits_memory: 4Gi
+      limits_memory: 32Gi
       requests_cpu: 2
       requests_memory: 4Gi
       storage: 64Gi
@@ -58,6 +59,7 @@ template_data:
       COMPRESSION_RATIO: 2
       # will it run a fillup before testing starts yes/no
       RUN_FILLUP: "yes"
+      LOGS_DIR: "/workload/"
       # how many directories to create
       DIRECTORIES: 100
       FILES_PER_DIRECTORY: 10

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.346'
+__version__ = '1.0.347'
 
 
 here = path.abspath(path.dirname(__file__))

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -26,7 +26,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -59,7 +59,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -38,7 +38,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -74,7 +74,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -24,7 +24,7 @@ spec:
     kubernetes.io/hostname: pin-node-1
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -57,7 +57,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -36,7 +36,7 @@ spec:
     kubernetes.io/hostname: pin-node-1
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -72,7 +72,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -81,7 +81,7 @@ spec:
                 - export REDIS_HOST=
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT=3600
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -68,7 +68,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -97,7 +97,7 @@ spec:
                 - export REDIS_HOST=
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT=3600
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -26,7 +26,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -34,7 +34,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
+          memory: 32Gi
       env:
         - name: BLOCK_SIZES
           value: "oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64"
@@ -59,7 +59,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -38,7 +38,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -46,7 +46,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
+          memory: 32Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"
@@ -74,7 +74,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -24,7 +24,7 @@ spec:
     kubernetes.io/hostname: pin-node-1
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -32,7 +32,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
+          memory: 32Gi
       env:
         - name: BLOCK_SIZES
           value: "oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64"
@@ -57,7 +57,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -36,7 +36,7 @@ spec:
     kubernetes.io/hostname: pin-node-1
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -44,7 +44,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
+          memory: 32Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"
@@ -72,7 +72,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -48,11 +48,11 @@ spec:
             memory: 4Gi
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 32Gi
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -81,7 +81,7 @@ spec:
                 - export REDIS_HOST=
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT=3600
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -61,14 +61,14 @@ spec:
             memory: 4Gi
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 32Gi
       terminationGracePeriodSeconds: 0
       volumes:
         - name: data-volume
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -97,7 +97,7 @@ spec:
                 - export REDIS_HOST=
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT=3600
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -26,7 +26,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -59,7 +59,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -38,7 +38,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -74,7 +74,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -24,7 +24,7 @@ spec:
     kubernetes.io/hostname: pin-node-1
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -57,7 +57,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -36,7 +36,7 @@ spec:
     kubernetes.io/hostname: pin-node-1
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.12
+      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:
@@ -72,7 +72,7 @@ spec:
           value: "random"
         - name: COMPRESSION_RATIO #ratio is 1:X e.g 2 = 50% compressible
           value: "2"
-        - name: RUN_FILLUP #will it run a fillup before testing starts yes/no
+        - name: RUN_FILLUP # will it run a fillup before testing starts yes/no
           value: "yes"
         - name: LOGS_DIR # logs directory
           value: "/workload/"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -81,7 +81,7 @@ spec:
                 - export REDIS_HOST=
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT=3600
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -68,7 +68,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.12
+            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -97,7 +97,7 @@ spec:
                 - export REDIS_HOST=
                 - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
                 - export TIMEOUT=3600
-                - export LOGS_DIR="/workload"
+                - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
                 - /vdbench/vdbench_runner.sh
                 - echo @@~@@END-WORKLOAD@@~@@


### PR DESCRIPTION
This PR split 12 vdbench tests to run desperately. 
That should improve the log output and memory consumption.