### PR TITLE
Adding custom workload support for vdbench

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -769,8 +769,8 @@ class OC(SSH):
                     copy = False
                     continue
                 elif copy:
-                    # Strip line prefix from VM output
-                    if 'cloud-init' in line:
+                    # Filter 'cloud-init' and CSV lines only
+                    if 'cloud-init' in line and ',' in line:
                         if vm_name in line:
                             # filter the title, placed after the second :
                             results_list.append(line.strip().split(':')[title_index:])

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -102,7 +102,7 @@ spec:
   {%- endif %}
   containers:
     - name: vdbench-pod
-      image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
+      image: {{ vdbench_image }}
       imagePullPolicy: "IfNotPresent"
       resources:
         requests:

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   storageClassName: ocs-storagecluster-ceph-rbd
   accessModes: [ "ReadWriteOnce" ]
-  volumeMode: Filesystem
+  volumeMode: Block
   resources:
     requests:
       storage: {{ storage }}
@@ -96,7 +96,7 @@ spec:
             {%- endif %}
 {%- endif %}
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: {{ centos_stream8_container_disk }}
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -123,14 +123,14 @@ spec:
                 - export FILES_PER_DIRECTORY={{ FILES_PER_DIRECTORY }}
                 - export SIZE_PER_FILE={{ SIZE_PER_FILE }}
                 - export REDIS_HOST={{ redis }}
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD={{ WORKLOAD_METHOD }}
                 - export TIMEOUT={{ timeout }}
                 - export LOGS_DIR={{ LOGS_DIR }}
                 - echo @@~@@START-WORKLOAD@@~@@
                 {% if not scale -%}
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged {{ vdbench_image }} "$WORKLOAD_METHOD"
                 {%- else -%}
-                - python3.9 /state_signals_responder.py $REDIS_HOST $WORKLOAD_METHOD $TIMEOUT
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e  MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e  PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged {{ vdbench_image }} python3.9 /state_signals_responder.py "$REDIS_HOST" "$WORKLOAD_METHOD" "$TIMEOUT"
                 {%- endif %}
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -5,6 +5,8 @@ template_data:
     pin_node: {{ pin_node1 }}
     odf_pvc: {{ odf_pvc }}
     uuid: {{ uuid }}
+    vdbench_image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
+    centos_stream8_container_disk: quay.io/ebattat/centos-stream8-container-disk:latest
   run_type:
     perf_ci:
       BLOCK_SIZES: oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64
@@ -28,7 +30,10 @@ template_data:
       COMPRESSION_RATIO: 2
       # will it run a fillup before testing starts yes/no
       RUN_FILLUP: "yes"
+      # Logs directory
       LOGS_DIR: "/workload/"
+      # vdbench workload main script
+      WORKLOAD_METHOD: "/vdbench/vdbench_runner.sh"
       # how many directories to create
       DIRECTORIES: 600
       FILES_PER_DIRECTORY: 10
@@ -59,7 +64,10 @@ template_data:
       COMPRESSION_RATIO: 2
       # will it run a fillup before testing starts yes/no
       RUN_FILLUP: "yes"
+      # Logs directory
       LOGS_DIR: "/workload/"
+      # vdbench workload main script
+      WORKLOAD_METHOD: "/vdbench/vdbench_runner.sh"
       # how many directories to create
       DIRECTORIES: 100
       FILES_PER_DIRECTORY: 10

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -244,7 +244,7 @@ class WorkloadsOperations:
             self._create_pod_log(pod='state-signals-exporter')
             self._create_pod_log(pod='redis-master')
         # insert results to csv
-        csv_result_file = os.path.join(self._run_artifacts_path, 'vdbench_vm_result.csv')
+        csv_result_file = os.path.join(self._run_artifacts_path, f'{vm_name}_result.csv')
         with open(csv_result_file, 'w') as out:
             for row in results_list:
                 if row:
@@ -331,7 +331,7 @@ class WorkloadsOperations:
             for scale_node in range(len(self._scale_node_list)):
                 for scale_num in range(self._scale):
                     count += 1
-                    metadata.update({f'{kind}-scale-node-{count}': self._scale_node_list[scale_node]})
+                    metadata.update({f'scale-{kind}--node-{count}': self._scale_node_list[scale_node]})
         if result:
             metadata.update(result)
 

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -79,10 +79,10 @@ spec:
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=5
                 - export REDIS_HOST=
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD=/vdbench/vdbench_runner.sh
                 - export TIMEOUT=3600
                 - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13 "$WORKLOAD_METHOD"
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   storageClassName: ocs-storagecluster-ceph-rbd
   accessModes: [ "ReadWriteOnce" ]
-  volumeMode: Filesystem
+  volumeMode: Block
   resources:
     requests:
       storage: 10Gi
@@ -68,7 +68,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -95,10 +95,10 @@ spec:
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=5
                 - export REDIS_HOST=
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD=/vdbench/vdbench_runner.sh
                 - export TIMEOUT=3600
                 - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13 "$WORKLOAD_METHOD"
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -79,10 +79,10 @@ spec:
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=10
                 - export REDIS_HOST=
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD=/vdbench/vdbench_runner.sh
                 - export TIMEOUT=3600
                 - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13 "$WORKLOAD_METHOD"
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   storageClassName: ocs-storagecluster-ceph-rbd
   accessModes: [ "ReadWriteOnce" ]
-  volumeMode: Filesystem
+  volumeMode: Block
   resources:
     requests:
       storage: 64Gi
@@ -68,7 +68,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -95,10 +95,10 @@ spec:
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=10
                 - export REDIS_HOST=
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD=/vdbench/vdbench_runner.sh
                 - export TIMEOUT=3600
                 - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13 "$WORKLOAD_METHOD"
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -52,7 +52,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -79,10 +79,10 @@ spec:
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=5
                 - export REDIS_HOST=
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD=/vdbench/vdbench_runner.sh
                 - export TIMEOUT=3600
                 - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13 "$WORKLOAD_METHOD"
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   storageClassName: ocs-storagecluster-ceph-rbd
   accessModes: [ "ReadWriteOnce" ]
-  volumeMode: Filesystem
+  volumeMode: Block
   resources:
     requests:
       storage: 10Gi
@@ -68,7 +68,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:v1.0.13
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -95,10 +95,10 @@ spec:
                 - export FILES_PER_DIRECTORY=10
                 - export SIZE_PER_FILE=5
                 - export REDIS_HOST=
-                - export WORKLOAD_METHOD="/vdbench/vdbench_runner.sh"
+                - export WORKLOAD_METHOD=/vdbench/vdbench_runner.sh
                 - export TIMEOUT=3600
                 - export LOGS_DIR=/workload/
                 - echo @@~@@START-WORKLOAD@@~@@
-                - /vdbench/vdbench_runner.sh
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13 "$WORKLOAD_METHOD"
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk


### PR DESCRIPTION
Meaning that for every new workload need only **1 image** for pod and vm 
For VM: 
1. Using Vanilla Centos stream 8 container disk that run vdbench image inside. 
2. Running vdbench image using podman command.
3. Mound volume using '-v' in podman command.
![Screenshot from 2022-06-10 10-52-08](https://user-images.githubusercontent.com/73884315/173017985-d8fe9136-68be-4f83-bff5-a164a2a66070.png)

