### PR TITLE
add ClusterBuster support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.352
+current_version = 1.0.353
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -49,7 +49,7 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix: 
-          workload: [ 'stressng_pod', 'stressng_kata', 'stressng_vm', 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale']
+          workload: [ 'stressng_pod', 'stressng_kata', 'stressng_vm', 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,10 @@ RUN mkdir -p /tmp/run_artifacts
 # download benchmark-operator to /tmp default path
 RUN git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
+# download clusterbuster to /tmp default path && install cluster-buster dependency
+RUN git clone -b v1.0.3-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+    && dnf install -y hostname bc
+
 # Add main
 COPY benchmark_runner/main/main.py /benchmark_runner/main/main.py
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## What is it?
 
-**benchmark-runner** is a containerized Python lightweight and flexible framework for running benchmark workloads 
+**benchmark-runner** is a containerized Python lightweight and flexible framework for running benchmark workloads
 on Kubernetes/OpenShift runtype kinds Pod, kata and VM.
 
 This framework support the following embedded workloads:
@@ -41,16 +41,16 @@ _**Table of Contents**_
 
 <!-- TOC -->
 - [Benchmark-Runner](#benchmark-runner)
-    - [Documentation](#documentation)
-    - [Run workload using Podman or Docker](#run-workload-using-podman-or-docker)
-    - [Run workload in Pod using Kubernetes or OpenShift](#run-workload-in-pod-using-kubernetes-or-openshift)
-    - [Grafana dashboards](#grafana-dashboards)
-    - [Inspect Prometheus Metrics](#inspect-prometheus-metrics)
-    - [How to develop in benchmark-runner](#how-to-develop-in-benchmark-runner)
+  - [Documentation](#documentation)
+  - [Run workload using Podman or Docker](#run-workload-using-podman-or-docker)
+  - [Run workload in Pod using Kubernetes or OpenShift](#run-workload-in-pod-using-kubernetes-or-openshift)
+  - [Grafana dashboards](#grafana-dashboards)
+  - [Inspect Prometheus Metrics](#inspect-prometheus-metrics)
+  - [How to develop in benchmark-runner](#how-to-develop-in-benchmark-runner)
 
 <!-- /TOC -->
 
-## Run workload using Podman or Docker 
+## Run workload using Podman or Docker
 
 #### Environment variables description:
 
@@ -58,7 +58,9 @@ _**Table of Contents**_
 
 Choose one from the following list:
 
-`['stressng_pod', 'stressng_vm', 'stressng_kata','uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_pod_mssql', 'hammerdb_pod_postgres', 'hammerdb_vm_mariadb', 'hammerdb_vm_mssql', 'hammerdb_vm_postgres', 'hammerdb_kata_mariadb', 'hammerdb_kata_mssql', 'hammerdb_kata_postgres', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm']`
+`['stressng_pod', 'stressng_vm', 'stressng_kata','uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_pod_mssql', 'hammerdb_pod_postgres', 'hammerdb_vm_mariadb', 'hammerdb_vm_mssql', 'hammerdb_vm_postgres', 'hammerdb_kata_mariadb', 'hammerdb_kata_mssql', 'hammerdb_kata_postgres', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']`
+
+** clusterbuster workloads: cpusoaker, files, fio, uperf. for more details [see](https://github.com/RobertKrawitz/OpenShift4-tools)
 
 **auto:** NAMESPACE=benchmark-operator [ The default namespace is benchmark-operator ]
 
@@ -84,15 +86,21 @@ Choose one from the following list:
 
 **optional:** CLUSTER=$CLUSTER [ set CLUSTER='kubernetes' to run workload on a kubernetes cluster, default 'openshift' ]
 
+**optional:** SCALE=SCALE [For Vdbench only: Scale in each node]
+
+**optional:** SCALE_NODES=SCALE_NODES [For Vdbench only: Scale's node]
+
+**optional:** REDIS=REDIS [For Vdbench only: redis for scale synchronization]
+
 ```sh
 podman run --rm -e WORKLOAD=$WORKLOAD -e KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD -e PIN_NODE_BENCHMARK_OPERATOR=$PIN_NODE_BENCHMARK_OPERATOR -e PIN_NODE1=$PIN_NODE1 -e PIN_NODE2=$PIN_NODE2 -e ELASTICSEARCH=$ELASTICSEARCH -e ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT -e log_level=INFO -v $KUBECONFIG:/root/.kube/config --privileged quay.io/ebattat/benchmark-runner:latest
 ```
-SAVE ARTIFACTS LOCAL: 
+SAVE RUN ARTIFACTS LOCAL:
 1. add "-e SAVE_ARTIFACTS_LOCAL='True'"
-2. add "-v /tmp:/tmp" 
+2. add "-v /tmp:/tmp"
 3. git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
-### Run vdbench workload in Pod using OpenShift 
+### Run vdbench workload in Pod using OpenShift
 ![](media/benchmark-runner-demo.gif)
 
 ### Run vdbench workload in Pod using Kubernetes
@@ -106,9 +114,9 @@ SAVE ARTIFACTS LOCAL:
 
 There are 3 grafana dashboards templates:
 1. [benchmark-runner-ci-status-report.json](grafana/benchmark-runner-ci-status-report.json)
-![](media/benchmark-runner-ci-status.png)
+   ![](media/benchmark-runner-ci-status.png)
 2. [benchmark-runner-report.json](grafana/benchmark-runner-report.json)
-![](media/benchmark-runner-report.png)
+   ![](media/benchmark-runner-report.png)
 
 ** After importing json in grafana, you need to configure elasticsearch data source. (for more details: see [HOW_TO.md](HOW_TO.md))
 
@@ -135,7 +143,7 @@ $ chmod -R g-s,a+rw "$local_prometheus_snapshot"
 $ sudo podman run --rm -p 9090:9090 -uroot -v "$local_prometheus_snapshot:/prometheus" --privileged prom/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=100000d --storage.tsdb.retention.size=1000PB
 ```
 
-and point your browser at port 9090 on your local system, you can run queries against it, e. g.
+and point your browser at port 9090 on your local system, you can run queries against it, e.g.
 
 ```
 sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0

--- a/benchmark_runner/clusterbuster/clusterbuster_exceptions.py
+++ b/benchmark_runner/clusterbuster/clusterbuster_exceptions.py
@@ -1,0 +1,23 @@
+
+class ClusterBusterError(Exception):
+    """ Base class for all benchmark operator error classes.
+        All exceptions raised by the benchmark runner library should inherit from this class. """
+    pass
+
+
+class MissingResultReport(ClusterBusterError):
+    """
+    This class is error for missing cluster buster report result
+    """
+    def __init__(self):
+        self.message = "Missing cluster buster result report"
+        super(MissingResultReport, self).__init__(self.message)
+
+
+class MissingElasticSearch(ClusterBusterError):
+    """
+    This class is error for missing ElasticSearch details
+    """
+    def __init__(self):
+        self.message = "Missing ElasticSearch details"
+        super(MissingElasticSearch, self).__init__(self.message)

--- a/benchmark_runner/clusterbuster/clusterbuster_workloads.py
+++ b/benchmark_runner/clusterbuster/clusterbuster_workloads.py
@@ -1,0 +1,80 @@
+
+import os
+import json
+
+from benchmark_runner.common.ssh.ssh import SSH
+from benchmark_runner.main.environment_variables import environment_variables
+from benchmark_runner.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
+from benchmark_runner.clusterbuster.clusterbuster_exceptions import MissingResultReport, MissingElasticSearch
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp
+
+
+class ClusterBusterWorkloads:
+    """
+    This class is responsible for all ClusterBuster workloads
+    """
+
+    def __init__(self):
+        self.result_report = '/tmp/clusterbuster-report.json'
+        self.__ssh = SSH()
+        # environment variables
+        self.__environment_variables_dict = environment_variables.environment_variables_dict
+        self.__namespace = self.__environment_variables_dict.get('namespace', '')
+        self.__run_type = self.__environment_variables_dict.get('run_type', '')
+        self.__pin_node1 = self.__environment_variables_dict.get('pin_node1', '')
+        self.__pin_node2 = self.__environment_variables_dict.get('pin_node2', '')
+        # ElasticSearch connection
+        self.__es_host = self.__environment_variables_dict.get('elasticsearch', '')
+        self.__es_port = self.__environment_variables_dict.get('elasticsearch_port', '')
+        self.__es_user = self.__environment_variables_dict.get('elasticsearch_user', '')
+        self.__es_password = self.__environment_variables_dict.get('elasticsearch_password', '')
+        self.__timeout = int(self.__environment_variables_dict.get('timeout', ''))
+        self.__uuid = self.__environment_variables_dict.get('uuid', '')
+        self.__es_url_protocol = self.__environment_variables_dict['elasticsearch_url_protocol']
+        self._ssh = SSH()
+        # ElasticSearch connection
+        if self.__es_host and self.__es_port:
+            self.__es_operations = ElasticSearchOperations(es_host=self.__es_host,
+                                                           es_port=self.__es_port,
+                                                           es_user=self.__es_user,
+                                                           es_password=self.__es_password,
+                                                           es_url_protocol=self.__es_url_protocol,
+                                                           timeout=self.__timeout)
+        else:
+            raise MissingElasticSearch()
+
+    @logger_time_stamp
+    def upload_clusterbuster_result_to_elasticsearch(self):
+        """
+        This method upload to ElasticSearch the results
+        :return:
+        """
+        result_report_json_file = open(self.result_report)
+        result_report_json_str = result_report_json_file.read()
+        result_report_json_data = json.loads(result_report_json_str)
+        for workload, clusterbuster_tests in result_report_json_data.items():
+            if self.__run_type == 'test_ci':
+                index = f'clusterbuster-{workload}-test-ci-results'
+            else:
+                index = f'clusterbuster-{workload}-results'
+            print(index)
+            if workload != 'metadata':
+                for clusterbuster_test in clusterbuster_tests:
+                    self.__es_operations.upload_to_elasticsearch(index=index, data=clusterbuster_test)
+            # metadata
+            elif workload == 'metadata':
+                self.__es_operations.upload_to_elasticsearch(index=index, data=result_report_json_data['metadata'])
+                self.__es_operations.verify_elasticsearch_data_uploaded(index=index, uuid=result_report_json_data['metadata']['uuid'])
+
+    @logger_time_stamp
+    def run(self):
+        """
+        This method run clusterbuster workloads
+        :return:
+        """
+        self.__ssh.run(cmd=f'cd /tmp/OpenShift4-tools/CI; ./run-kata-perf-suite --run_type={self.__run_type} --client-pin-node={self.__pin_node1} --server-pin-node={self.__pin_node2} --sync-pin-node={self.__pin_node2} --basename={self.__namespace} --artifactdir=/tmp/clusterbuster-ci --analyze=/tmp/clusterbuster-report.json')
+        if os.path.exists(os.path.join(self.result_report)):
+            self.upload_clusterbuster_result_to_elasticsearch()
+            return True
+        else:
+            raise MissingResultReport()

--- a/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
+++ b/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
@@ -1,7 +1,7 @@
 
 import time
 import ssl
-import urllib3
+
 from typeguard import typechecked
 from elasticsearch import Elasticsearch
 from elasticsearch.connection import create_ssl_context

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -61,7 +61,7 @@ class EnvironmentVariables:
         # Set to True to
         self._environment_variables_dict['kata_cpuoffline_workaround'] = os.environ.get('KATA_CPUOFFLINE_WORKAROUND', '')
 
-        # Scale
+        # Scale in each node
         self._environment_variables_dict['scale'] = os.environ.get('SCALE', '')
         # list of nodes per pod/vm, scale number per node, e.g: [ 'master-1', 'master-2' ] - run 1 pod/vm in each node
         self._environment_variables_dict['scale_nodes'] = os.environ.get('SCALE_NODES', "")
@@ -74,16 +74,18 @@ class EnvironmentVariables:
                                                          'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb',
                                                          'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres',
                                                          'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql',
-                                                         'vdbench_pod', 'vdbench_kata', 'vdbench_vm']
-        # benchmark-operator workload types
+                                                         'vdbench_pod', 'vdbench_kata', 'vdbench_vm',
+                                                         'clusterbuster']
+        # Workloads namespaces
         self._environment_variables_dict['workload_namespaces'] = {
             'stressng': 'benchmark-operator',
             'hammerdb': 'benchmark-operator',
             'uperf': 'benchmark-operator',
             'vdbench': 'benchmark-runner',
+            'clusterbuster': 'clusterbuster',
         }
 
-        # Choose default namespace
+        # Update namespace
         base_workload = self._environment_variables_dict['workload'].split('_')[0]
         if os.environ.get('NAMESPACE'):
             self._environment_variables_dict['namespace'] = os.environ.get('NAMESPACE')

--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -1,4 +1,4 @@
-import sys
+
 import ast  # change string list to list
 
 from benchmark_runner.main.environment_variables import *
@@ -8,7 +8,7 @@ from benchmark_runner.workloads.workloads import Workloads
 from benchmark_runner.main.environment_variables import environment_variables
 from benchmark_runner.common.clouds.Azure.azure_operations import AzureOperations
 from benchmark_runner.common.clouds.IBM.ibm_operations import IBMOperations
-
+from benchmark_runner.clusterbuster.clusterbuster_workloads import ClusterBusterWorkloads
 
 # logger
 log_level = os.environ.get('log_level', 'INFO').upper()
@@ -29,6 +29,7 @@ def main():
     """
     benchmark_operator_workload = None
     benchmark_runner_workload = None
+    clusterbuster_workload = None
     environment_variables_dict = environment_variables.environment_variables_dict
     # environment variables data
     workload = environment_variables_dict.get('workload', '')
@@ -41,6 +42,7 @@ def main():
 
     is_benchmark_operator_workload = 'benchmark-operator' in (environment_variables.get_workload_namespace(workload), environment_variables_dict.get("runner_type"))
     is_benchmark_runner_workload = 'benchmark-runner' in (environment_variables.get_workload_namespace(workload), environment_variables_dict.get("runner_type"))
+    is_clusterbuster_workload = 'clusterbuster' in (environment_variables.get_workload_namespace(workload), environment_variables_dict.get("runner_type"))
     # workload name validation
     if workload and not ci_status:
         if workload not in environment_variables.workloads_list:
@@ -50,7 +52,9 @@ def main():
         if run_type not in environment_variables.run_types_list:
             logger.info(f'Enter valid run type {environment_variables.run_types_list}')
             raise Exception(f'Invalid run type: {run_type} \n, choose one from the list: {environment_variables.run_types_list}')
-        if is_benchmark_operator_workload:
+        if is_clusterbuster_workload:
+            clusterbuster_workload = ClusterBusterWorkloads()
+        elif is_benchmark_operator_workload:
             benchmark_operator_workload = BenchmarkOperatorWorkloads()
         elif is_benchmark_runner_workload:
             benchmark_runner_workload = Workloads()
@@ -142,8 +146,17 @@ def main():
         This method run benchmark-runner workload
         :return:
         """
-        # benchmark-operator node selector
+        # benchmark-runner node selector
         return benchmark_runner_workload.run()
+
+    @logger_time_stamp
+    def run_clusterbuster_workload():
+        """
+        This method run clusterbuster workload
+        :return:
+        """
+        # benchmark-runner node selector
+        return clusterbuster_workload.run()
 
     success = True
     # azure_cluster_start_stop
@@ -160,10 +173,10 @@ def main():
         update_ci_status()
     elif is_benchmark_operator_workload:
         success = run_benchmark_operator_workload()
-
     elif is_benchmark_runner_workload:
         success = run_benchmark_runner_workload()
-
+    elif is_clusterbuster_workload:
+        success = run_clusterbuster_workload()
     else:
         logger.error(f"empty workload, choose one from the list: {environment_variables.workloads_list}")
         raise SystemExit(SYSTEM_EXIT_UNKNOWN_EXECUTION_TYPE)

--- a/docs/source/podman.md
+++ b/docs/source/podman.md
@@ -7,7 +7,9 @@
 
 Choose one from the following list:
 
-`['stressng_pod', 'stressng_vm', 'stressng_kata','uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_pod_mssql', 'hammerdb_pod_postgres', 'hammerdb_vm_mariadb', 'hammerdb_vm_mssql', 'hammerdb_vm_postgres', 'hammerdb_kata_mariadb', 'hammerdb_kata_mssql', 'hammerdb_kata_postgres', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm']`
+`['stressng_pod', 'stressng_vm', 'stressng_kata','uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_pod_mssql', 'hammerdb_pod_postgres', 'hammerdb_vm_mariadb', 'hammerdb_vm_mssql', 'hammerdb_vm_postgres', 'hammerdb_kata_mariadb', 'hammerdb_kata_mssql', 'hammerdb_kata_postgres', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']`
+
+** clusterbuster workloads: cpusoaker, files, fio, uperf. for more details [see](https://github.com/RobertKrawitz/OpenShift4-tools)
 
 **auto:** NAMESPACE=benchmark-operator [ The default namespace is benchmark-operator ]
 
@@ -33,10 +35,16 @@ Choose one from the following list:
 
 **optional:** CLUSTER=$CLUSTER [ set CLUSTER='kubernetes' to run workload on a kubernetes cluster, default 'openshift' ]
 
+**optional:** SCALE=SCALE [For Vdbench only: Scale in each node]
+
+**optional:** SCALE_NODES=SCALE_NODES [For Vdbench only: Scale's node]
+
+**optional:** REDIS=REDIS [For Vdbench only: redis for scale synchronization]
+
 ```sh
 podman run --rm -e WORKLOAD=$WORKLOAD -e KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD -e PIN_NODE_BENCHMARK_OPERATOR=$PIN_NODE_BENCHMARK_OPERATOR -e PIN_NODE1=$PIN_NODE1 -e PIN_NODE2=$PIN_NODE2 -e ELASTICSEARCH=$ELASTICSEARCH -e ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT -e log_level=INFO -v $KUBECONFIG:/root/.kube/config --privileged quay.io/ebattat/benchmark-runner:latest
 ```
-SAVE ARTIFACTS LOCAL:
+SAVE RUN ARTIFACTS LOCAL:
 1. add "-e SAVE_ARTIFACTS_LOCAL='True'"
 2. add "-v /tmp:/tmp"
 3. git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.352'
+__version__ = '1.0.353'
 
 
 here = path.abspath(path.dirname(__file__))

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -24,6 +24,12 @@ class GoldenFiles:
         environment_variables.environment_variables_dict['prom_token_override'] = 'fake_prom_token'
         environment_variables.environment_variables_dict['uuid'] = 'deadbeef-0123-3210-cdef-01234567890abcdef'
         environment_variables.environment_variables_dict['trunc_uuid'] = environment_variables.environment_variables_dict['uuid'].split('-')[0]
+        environment_variables.environment_variables_dict['workloads'] = ['stressng_pod', 'stressng_vm', 'stressng_kata',
+                                                         'uperf_pod', 'uperf_vm', 'uperf_kata',
+                                                         'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb',
+                                                         'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres',
+                                                         'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql',
+                                                         'vdbench_pod', 'vdbench_kata', 'vdbench_vm']
 
     def __clear_directory_yaml(self, dir):
         if os.path.isdir(dir):


### PR DESCRIPTION
Add cluster buster support:
1. Add cluster buster as special workload in benchmark-runner workloads
2. Run main shell of cluster buster according to run_type: perf_ci, func_ci
3. Upload cluster buster results to ElasticSearch
4. Verify data uploaded to ElasticSearch