### PR TITLE
fix mssql security context for ocp4.11

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -598,10 +598,10 @@ class OC(SSH):
             if 'met' in result.decode("utf-8"):
                 return True
         except Exception as err:
-            if 'pod' in workload:
-                raise PodNotReadyTimeout(workload=workload)
-            else:
+            if 'vm' in workload:
                 raise VMNotReadyTimeout(workload=workload)
+            else:
+                raise PodNotReadyTimeout(workload=workload)
 
     @typechecked
     @logger_time_stamp

--- a/benchmark_runner/common/ocp_resources/custom/template/01_coredns_patch_template.sh
+++ b/benchmark_runner/common/ocp_resources/custom/template/01_coredns_patch_template.sh
@@ -1,2 +1,3 @@
 # solved Error: Failed to download metadata for repo 'fedora-cisco-openh264': Cannot prepare internal mirrorlist
 oc get nodes -l node-role.kubernetes.io/worker= -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" |  xargs -I{} oc debug node/{} -- chroot /host sh -c "sed -i '/bufsize 512/d' /etc/coredns/Corefile"
+

--- a/benchmark_runner/common/ocp_resources/custom/template/02_mssql_patch_template.sh
+++ b/benchmark_runner/common/ocp_resources/custom/template/02_mssql_patch_template.sh
@@ -1,0 +1,2 @@
+# ocp4.11: solved mssql securityContext permission issue
+oc adm policy add-scc-to-group restricted system:authenticated --context admin mssql-db

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml
@@ -56,6 +56,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -47,6 +47,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -46,6 +46,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -47,6 +47,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -46,6 +46,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -47,6 +47,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -46,6 +46,8 @@ spec:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:


### PR DESCRIPTION
This PR fix MSSQL security context issue for OCP4.11
There are 2 changes:
1. Add to the [mssql.yaml](https://github.com/redhat-performance/benchmark-runner/blob/main/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml)
```
        securityContext:
          allowPrivilegeEscalation: true
```
2. Update admin for mssql-db namespace:
```
oc adm policy add-scc-to-group restricted system:serviceaccounts --context admin mssql-db
OR
oc adm policy add-scc-to-group restricted system:authenticated --context admin mssql-db
```

Also have opened [issue](https://github.com/microsoft/mssql-docker/issues/769) for mssql container team for getting the correct security context for image: mcr.microsoft.com/mssql/rhel/server:2019-latest