### PR TITLE
ClusterBuster OCP 4.11 fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.359
+current_version = 1.0.360
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.0.3-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.0.5-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc
 
 # Add main

--- a/benchmark_runner/clusterbuster/clusterbuster_workloads.py
+++ b/benchmark_runner/clusterbuster/clusterbuster_workloads.py
@@ -97,7 +97,7 @@ class ClusterBusterWorkloads(WorkloadsOperations):
         This method run ClusterBuster workload
         :return:
         """
-        self.__ssh.run(cmd=f'{self.__clusterbuster_path} --run_type={self._run_type} --client-pin-node={self._pin_node1} --server-pin-node={self._pin_node2} --sync-pin-node={self._pin_node2} --basename={self.__namespace} --artifactdir={self.__artifactdir} --analyze={self.__result_report} > {self.__clusterbuster_log}')
+        self.__ssh.run(cmd=f'{self.__clusterbuster_path} --run_type={self._run_type} --client-pin-node={self._pin_node1} --server-pin-node={self._pin_node2} --sync-pin-node={self._pin_node2} --basename={self.__namespace} --artifactdir={self.__artifactdir} --analyze={self.__result_report} > {self.__clusterbuster_log} 2>&1')
 
     @logger_time_stamp
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.359'
+__version__ = '1.0.360'
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
This PR include:
1. Update clusterbuster version to v1.0.5-kata-ci, including ocp4.11 enhancement
2. Update clusterbuster log path