### PR TITLE
Correct the command to generate a Prometheus token

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -274,7 +274,7 @@ class OC(SSH):
         if major_version <= 4 and minor_version <= 10:
             prom_token = self.run(f"{self.__cli} -n openshift-monitoring sa get-token prometheus-k8s")
         else:
-            prom_token = self.run(f"{self.__cli} sa new-token -n openshift-monitoring prometheus-k8s")
+            prom_token = self.run(f"{self.__cli} create token -n openshift-monitoring prometheus-k8s")
         return prom_token
 
     @logger_time_stamp


### PR DESCRIPTION
oc sa new-token is deprecated; this change is needed so that the command doesn't generate spurious stderr that pollutes the output.