### PR TITLE
add prometheus_metrics support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,3 +30,6 @@ include benchmark_runner/common/ocp_resources/cnv/template/*.sh
 include benchmark_runner/common/ocp_resources/cnv/template/*.yaml
 include benchmark_runner/common/ocp_resources/custom/template/*.sh
 include benchmark_runner/common/ocp_resources/custom/template/*.yaml
+
+# prometheus queries yaml
+include benchmark_runner/common/prometheus/metrics-default.yaml

--- a/benchmark_runner/common/prometheus/metrics-default.yaml
+++ b/benchmark_runner/common/prometheus/metrics-default.yaml
@@ -1,0 +1,267 @@
+# API server
+- query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
+  metricName: API99thLatency
+
+- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+  metricName: APIRequestRate
+
+- query: sum(apiserver_current_inflight_requests{}) by (request_kind) > 0
+  metricName: APIInflightRequests
+
+# Container & pod metrics
+- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+  metricName: containerMemory-Masters
+
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+  metricName: containerCPU-Masters
+
+- query: (sum(irate(container_cpu_usage_seconds_total{pod!="",container="prometheus",namespace="openshift-monitoring"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
+  metricName: containerCPU-prometheus
+
+- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
+  metricName: containerCPU-AggregatedWorkers
+
+- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|logging)"}[2m]) * 100 and on (node) kube_node_role{role="infra"}) by (namespace, container)) > 0
+  metricName: containerCPU-AggregatedInfra
+
+- query: (sum(container_memory_rss{pod!="",namespace="openshift-monitoring",name!="",container="prometheus"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
+  metricName: containerMemory-prometheus
+
+- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
+  metricName: containerMemory-AggregatedWorkers
+
+- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|logging)"} and on (node) kube_node_role{role="infra"}) by (container, namespace)
+  metricName: containerMemory-AggregatedInfra
+
+- query: (sum(container_memory_rss{pod!="",namespace=~"{{ namespace_re }}",name!=""}) by (node)) > 0
+  metricName: containerMemoryRSS-clusterbuster
+
+- query: (sum(container_memory_working_set_bytes{pod!="",namespace=~"{{ namespace_re }}",name!=""}) by (node)) > 0
+  metricName: containerMemoryWorkingSet-clusterbuster
+
+- query: (sum(irate(container_cpu_usage_seconds_total{container!="",namespace=~"{{ namespace_re }}"}[2m])) by (node)) > 0
+  metricName: containerCPU-clusterbuster
+
+# Node metrics
+- query: (sum(irate(node_cpu_seconds_total{mode!="idle"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Masters
+
+- query: (sum(irate(node_cpu_seconds_total{mode!="idle"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Workers
+
+- query: (sum(irate(node_cpu_seconds_total{mode!="idle"}[2m])) by (instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPUUtil-Workers
+
+- query: (sum(irate(node_cpu_seconds_total{mode="user"}[2m])) by (instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPUUser-Workers
+
+- query: (sum(irate(node_cpu_seconds_total{mode="system"}[2m])) by (instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPUSys-Workers
+
+- query: (avg((sum(irate(node_cpu_seconds_total{mode!="idle"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+  metricName: nodeCPU-AggregatedWorkers
+
+- query: (avg((sum(irate(node_cpu_seconds_total{mode!="idle"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+  metricName: nodeCPU-AggregatedInfra
+
+- query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Masters
+
+- query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Workers
+
+- query: avg(node_memory_MemTotal_bytes - node_memory_MemFree_bytes - node_memory_Cached_bytes - node_memory_Buffers_bytes - node_memory_SReclaimable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryInUse-Masters
+
+- query: avg(node_memory_MemTotal_bytes - node_memory_MemFree_bytes - node_memory_Cached_bytes - node_memory_Buffers_bytes - node_memory_SReclaimable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryInUse-Workers
+
+- query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryAvailable-AggregatedWorkers
+
+- query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryAvailable-AggregatedInfra
+
+- query: avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryActive-Masters
+
+- query: avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryActive-Workers
+
+- query: avg(node_memory_Active_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryActive-AggregatedWorkers
+
+- query: avg(avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryActive-AggregatedInfra
+
+- query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryCached+nodeMemoryBuffers-Masters
+
+- query: avg(node_memory_Cached_bytes + node_memory_Buffers_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryCached+nodeMemoryBuffers-AggregatedWorkers
+
+- query: avg(node_memory_Cached_bytes + node_memory_Buffers_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryCached+nodeMemoryBuffers-AggregatedInfra
+
+- query: irate(node_network_receive_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: rxNetworkBytes-Masters
+
+- query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: rxNetworkBytes-AggregatedWorkers
+
+- query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: rxNetworkBytes-WorkerByNodeAndDevice
+
+- query: avg(irate(node_network_receive_packets_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: rxNetworkPackets-WorkerByNodeAndDevice
+
+- query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: rxNetworkBytes-WorkerByNode
+
+- query: avg(irate(node_network_receive_packets_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: rxNetworkPackets-WorkerByNode
+
+- query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: rxNetworkBytes-AggregatedInfra
+
+- query: irate(node_network_transmit_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: txNetworkBytes-Masters
+
+- query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: txNetworkBytes-AggregatedWorkers
+
+- query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: txNetworkBytes-WorkerByNodeAndDevice
+
+- query: avg(irate(node_network_transmit_packets_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: txNetworkPackets-WorkerByNodeAndDevice
+
+- query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: txNetworkBytes-WorkerByNode
+
+- query: avg(irate(node_network_transmit_packets_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: txNetworkPackets-WorkerByNode
+
+- query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|enp|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: txNetworkBytes-AggregatedInfra
+
+- query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeDiskWrittenBytes-Masters
+
+- query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: nodeDiskWrittenBytes-AggregatedWorkers
+
+- query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: nodeDiskWrittenBytes-WorkerByNodeAndDevice
+
+- query: avg(rate(node_disk_writes_completed_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: nodeDiskWrites-WorkerByNodeAndDevice
+
+- query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: nodeDiskWrittenBytes-WorkerByNode
+
+- query: avg(rate(node_disk_writes_completed_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: nodeDiskWrites-WorkerByNode
+
+- query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: nodeDiskWrittenBytes-AggregatedInfra
+
+- query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeDiskReadBytes-Masters
+
+- query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: nodeDiskReadBytes-AggregatedWorkers
+
+- query: avg(rate(node_disk_reads_completed_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: nodeDiskReads-WorkerByNodeAndDevice
+
+- query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance,device)
+  metricName: nodeDiskReadBytes-WorkerByNodeAndDevice
+
+- query: avg(rate(node_disk_reads_completed_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: nodeDiskReads-WorkerByNode
+
+- query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance)
+  metricName: nodeDiskReadBytes-WorkerByNode
+
+- query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+  metricName: nodeDiskReadBytes-AggregatedInfra
+
+# Etcd metrics
+- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
+  metricName: etcdLeaderChangesRate
+
+- query: etcd_server_is_leader > 0
+  metricName: etcdServerIsLeader
+
+- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
+  metricName: 99thEtcdDiskBackendCommitDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))
+  metricName: 99thEtcdDiskWalFsyncDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
+  metricName: 99thEtcdRoundTripTimeSeconds
+
+- query: etcd_mvcc_db_total_size_in_bytes
+  metricName: etcdDBPhysicalSizeBytes
+
+- query: etcd_mvcc_db_total_size_in_use_in_bytes
+  metricName: etcdDBLogicalSizeBytes
+
+- query: sum by (cluster_version)(etcd_cluster_version)
+  metricName: etcdVersion
+  instant: true
+
+- query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
+  metricName: etcdObjectCount
+
+- query: histogram_quantile(0.99,sum(rate(etcd_request_duration_seconds_bucket[2m])) by (le,operation,apiserver)) > 0
+  metricName: P99APIEtcdRequestLatency
+
+# Cluster metrics
+- query: sum(kube_namespace_status_phase) by (phase) > 0
+  metricName: namespaceCount
+
+- query: sum(kube_pod_status_phase{}) by (phase)
+  metricName: podStatusCount
+
+- query: count(kube_secret_info{})
+  metricName: secretCount
+
+- query: count(kube_deployment_labels{})
+  metricName: deploymentCount
+
+- query: count(kube_configmap_info{})
+  metricName: configmapCount
+
+- query: count(kube_service_info{})
+  metricName: serviceCount
+
+- query: kube_node_role
+  metricName: nodeRoles
+  instant: true
+
+- query: sum(kube_node_status_condition{status="true"}) by (condition)
+  metricName: nodeStatus
+
+- query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
+  metricName: containerDiskUsage
+
+- query: cluster_version{type="completed"}
+  metricName: clusterVersion
+  instant: true
+
+# Golang metrics
+
+- query: go_memstats_heap_alloc_bytes{job=~"apiserver|api|etcd"}
+  metricName: goHeapAllocBytes
+
+- query: go_memstats_heap_inuse_bytes{job=~"apiserver|api|etcd"}
+  metricName: goHeapInuseBytes
+
+- query: go_gc_duration_seconds{job=~"apiserver|api|etcd",quantile="1"}
+  metricName: goGCDurationSeconds
+
+- query: topk(10,ALERTS{severity!="none"})
+  metricName: alerts

--- a/benchmark_runner/common/prometheus/prometheus_metrics.py
+++ b/benchmark_runner/common/prometheus/prometheus_metrics.py
@@ -1,0 +1,34 @@
+
+from functools import wraps
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.prometheus.prometheus_metrics_operations import PrometheusMetricsOperation
+
+
+def prometheus_metrics(yaml_full_path: str = None):
+    """
+    This decorator method run prometheus metrics
+    :param yaml_full_path: custom metric full path of yaml file [optional]
+    :return:
+    """
+    def prometheus_metrics_internal(method):
+        """
+        This decorator method is for running prometheus queries and get prometheus metrics
+        """
+        @wraps(method)  # solve method help doc
+        def method_wrapper(*args, **kwargs):
+            prometheus_metrics_operation = PrometheusMetricsOperation()
+            prometheus_metrics_operation.init_prometheus()
+            try:
+                result = method(*args, **kwargs)
+                prometheus_metrics_operation.finalize_prometheus()
+                # run several queries from custom yaml queries file or default yaml queries  file
+                prometheus_metrics_operation.run_prometheus_queries(query_yaml_file=yaml_full_path)
+                prometheus_metrics_operation.upload_result_to_elastic()
+            except Exception as err:
+                logger.error(f'error :{err}')
+                raise err  # MethodError(method.__name__, err)
+
+            return result
+        return method_wrapper
+    return prometheus_metrics_internal

--- a/benchmark_runner/common/prometheus/prometheus_metrics_operations.py
+++ b/benchmark_runner/common/prometheus/prometheus_metrics_operations.py
@@ -1,0 +1,161 @@
+import os
+import yaml
+import time
+import datetime
+import openshift
+from prometheus_api_client import PrometheusConnect
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3 import disable_warnings
+disable_warnings(InsecureRequestWarning)
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
+
+
+class PrometheusMetricsOperation(WorkloadsOperations):
+    """
+    This class Run prometheus queries
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.__current_dir = os.path.dirname(os.path.abspath(__file__))
+        self.__queries_file = os.path.join(self.__current_dir, 'metrics-default.yaml')
+        self.__authorization = {'Authorization': self.__get_prometheus_token()}
+        self.__prometheus = PrometheusConnect(url=self.__get_prometheus_default_url(), disable_ssl=True, headers=self.__authorization)
+        self.__metrics_start_time = None
+        self.__metrics_end_time = None
+        self.__metric_results = {}
+
+    @staticmethod
+    def __get_prometheus_default_url():
+        """
+        This method return prometheus default url
+        :return:
+        """
+        try:
+            with openshift.project('openshift-monitoring'):
+                return f"https://{openshift.selector(['route/prometheus-k8s']).objects()[0].as_dict()['spec']['host']}"
+        except Exception as err:
+            raise f'Unable to retrieve prometheus-k8s route: {err}'
+
+    def __get_prometheus_token(self):
+        """
+        This method return prometheus token
+        :return:
+        """
+        try:
+            return f'Bearer {self.__get_prometheus_token_by_version()}'
+        except Exception as err:
+            raise f'Unable to retrieve prometheus-k8s token: {err}'
+
+    @staticmethod
+    def __get_prometheus_token_by_version():
+        """
+        This method return prometheus token
+        :return:
+        """
+        with openshift.project('openshift-monitoring'):
+            openshift_version = openshift.get_server_version().split('-')[0].split('.')
+            if int(openshift_version[0]) > 4 or (int(openshift_version[0]) == 4 and int(openshift_version[1]) > 10):
+                return openshift.invoke('sa', ['new-token', '-n', 'openshift-monitoring', 'prometheus-k8s']).out().strip()
+            else:
+                return openshift.get_serviceaccount_auth_token('prometheus-k8s')
+
+    @staticmethod
+    def get_prometheus_timestamp():
+        """
+        This method return prometheus time stamp
+        :return:
+        """
+        retries = 5
+        while retries > 0:
+            retries = retries - 1
+            try:
+                with openshift.project('openshift-monitoring'):
+                    result = openshift.selector('pod/prometheus-k8s-0').object().execute(['date', '+%s.%N'],
+                                                                                         container_name='prometheus')
+                    return datetime.datetime.utcfromtimestamp(float(result.out()))
+            except Exception as err:
+                if retries <= 0:
+                    raise f'Unable to retrieve date: {err}'
+                else:
+                    time.sleep(5)
+
+    def yaml_to_dict(self):
+        """
+        This method convert yaml file to dictionary
+        :return:
+        """
+        with open(self.__queries_file) as metrics_yaml:
+            queries = metrics_yaml.read()
+            return yaml.safe_load(queries)
+
+    def init_prometheus(self):
+        """
+        This method init prometheus time
+        :return:
+        """
+        self.__metrics_start_time = self.get_prometheus_timestamp()
+        logger.info(f'prometheus metric start: {self.__metrics_start_time}')
+        return self.__metrics_start_time
+
+    def finalize_prometheus(self):
+        """
+        This method init prometheus time
+        :return:
+        """
+        self.__metrics_end_time = self.get_prometheus_timestamp()
+        logger.info(f'prometheus metric end: {self.__metrics_end_time}')
+        return self.__metrics_end_time
+
+    def run_prometheus_query(self, query: str, instant: bool = False):
+        """
+        This method run one prometheus query and return dictionary result
+        :param instant:
+        :param query:
+        :return:
+        """
+        if instant:
+            metric_result = (self.__prometheus.custom_query(query=query))
+        else:
+            metric_result = self.__prometheus.custom_query_range(query=query, start_time=self.__metrics_start_time, end_time=self.__metrics_end_time, step='30')
+        self.__metric_results['metrics_result'] = metric_result
+        return self.__metric_results
+
+    def run_prometheus_queries(self, query_yaml_file: str = None):
+        """
+        This method run several prometheus queries and return list of dictionaries result
+        :param query_yaml_file:
+        :return:
+        """
+        if query_yaml_file and os.path.isfile(query_yaml_file):
+            self.__queries_file = query_yaml_file
+        metrics = self.yaml_to_dict()
+        for metric in metrics:
+            if 'query' not in metric:
+                continue
+            try:
+                if 'instant' not in metric or metric['instant'] is not True:
+                    metric_result = self.__prometheus.custom_query_range(metric['query'], start_time=self.__metrics_start_time, end_time=self.__metrics_end_time, step='30')
+                else:
+                    metric_result = (self.__prometheus.custom_query(metric['query']))
+                self.__metric_results[metric['metricName']] = metric_result
+            except Exception as err:
+                raise f"Query {metric['metricName']} ({metric['query']}) failed: {err}"
+        return self.__metric_results
+
+    #  @todo TBD: verify before uploading if it visualize correctly
+    def upload_result_to_elastic(self):
+        """
+        This method upload result to ElasticSearch
+        :return: 
+        """
+        pass
+        # if self._es_host and self._es_port:
+        #     for query, results in self.__metric_results.items():
+        #         pass
+        #         self._es_operations.upload_to_elasticsearch(index=query, data=results)
+        # else:
+        #     raise Exception('Missing ElasticSearch data')
+        

--- a/docs/source/prometheus.md
+++ b/docs/source/prometheus.md
@@ -1,6 +1,36 @@
 
 ## Inspect Prometheus Metrics
 
+For Inspect Prometheus Metrics use @prometheus_metrics decorator.
+
+For using default metrics benchmark_runner.common.prometheus.metrics-default.yaml:
+[This will collect the metric for run() method]
+```
+from benchmark_runner.common.prometheus.prometheus_metrics import prometheus_metrics
+
+@prometheus_metrics
+def run():
+    print('sleep 30 sec')
+    time.sleep(30)
+run()
+```
+
+For using custom metrics file, pass it as argument to decorator:
+[This will collect custom metrics for run() method]
+```
+current_dir = os.path.dirname(os.path.abspath(__file__))
+yaml_full_path = os.path.join(current_dir, 'metrics.yaml')
+
+
+@prometheus_metrics(yaml_full_path=yaml_full_path)
+def run():
+    print('sleep 30 sec')
+    time.sleep(30)
+run()
+```
+
+## Inspect Prometheus Snapshots
+
 The CI jobs store snapshots of the Prometheus database for each run as part of the artifacts.  Within the artifact directory is a Prometheus snapshot directory named:
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,9 @@ elasticsearch==7.16.1
 elasticsearch_dsl==7.4.0
 jinja2==3.0.3
 myst-parser==0.17.0
-openshift-client==1.0.14
+openshift-client==1.0.17
 pandas
 paramiko==2.10.1
-prometheus-api-client==0.5.0
 PyGitHub==1.55
 PyYAML==6.0
 sphinx==4.5.0
@@ -18,3 +17,4 @@ sphinx_rtd_theme==1.0.0
 tenacity==8.0.1
 typeguard==2.12.1
 typing==3.7.4.3
+prometheus-api-client==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'elasticsearch_dsl==7.4.0',  # for deep search
         'jinja2==3.0.3',
         'myst-parser==0.17.0',  # readthedocs
-        'openshift-client==1.0.14', # clusterbuster, until it uses kubernetes client rather than openshift.
+        'openshift-client==1.0.17',  # clusterbuster, until it uses kubernetes client rather than openshift. && prometheus metrics
         'pandas',  # required latest
         'paramiko==2.10.1',
         'prometheus-api-client==0.5.0',   # clusterbuster
@@ -61,6 +61,7 @@ setup(
         'tenacity==8.0.1',  # retry decorator
         'typeguard==2.12.1',
         'typing==3.7.4.3',
+        'prometheus-api-client==0.5.1',  # prometheus metrics
         # must add new package inside requirements.txt
     ],
 

--- a/tests/integration/benchmark_runner/common/prometheus/metrics.yaml
+++ b/tests/integration/benchmark_runner/common/prometheus/metrics.yaml
@@ -1,0 +1,3 @@
+# CPU
+- query: sum(irate(node_cpu_seconds_total[1m])) by (mode,instance) > 0
+  metricName: CPU

--- a/tests/integration/benchmark_runner/common/prometheus/test_prometeus_metrics_operations.py
+++ b/tests/integration/benchmark_runner/common/prometheus/test_prometeus_metrics_operations.py
@@ -1,0 +1,61 @@
+import os
+import time
+from datetime import datetime
+
+from benchmark_runner.common.prometheus.prometheus_metrics_operations import PrometheusMetricsOperation
+
+
+def test_get_prometheus_timestamp():
+    """
+    This method test get prometheus timestamp
+    :return: 
+    """
+    prometheus_metrics_operation = PrometheusMetricsOperation()
+    assert prometheus_metrics_operation.get_prometheus_timestamp()
+    assert type(prometheus_metrics_operation.get_prometheus_timestamp()) == datetime
+
+
+def test_init_prometheus():
+    """
+    This method test_init_prometheus
+    :return:
+    """
+    prometheus_metrics_operation = PrometheusMetricsOperation()
+    assert prometheus_metrics_operation.init_prometheus()
+    assert type(prometheus_metrics_operation.init_prometheus()) == datetime
+
+
+def test_finalize_prometheus():
+    """
+    This method test_finalize_prometheus
+    :return:
+    """
+    prometheus_metrics_operation = PrometheusMetricsOperation()
+    assert prometheus_metrics_operation.finalize_prometheus()
+    assert type(prometheus_metrics_operation.finalize_prometheus()) == datetime
+
+
+def test_run_prometheus_query():
+    """
+    This method test_run_prometheus_queries
+    :return:
+    """
+    prometheus_metrics_operation = PrometheusMetricsOperation()
+    prometheus_metrics_operation.init_prometheus()
+    time.sleep(70)
+    prometheus_metrics_operation.finalize_prometheus()
+    assert prometheus_metrics_operation.run_prometheus_query(query='sum(irate(node_cpu_seconds_total[1m])) by (mode,instance) > 0')
+
+
+def test_run_prometheus_queries():
+    """
+    This method test_run_prometheus_queries
+    :return:
+    """
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    yaml_full_path = os.path.join(current_dir, 'metrics.yaml')
+    prometheus_metrics_operation = PrometheusMetricsOperation()
+    prometheus_metrics_operation.init_prometheus()
+    time.sleep(70)
+    prometheus_metrics_operation.finalize_prometheus()
+    assert prometheus_metrics_operation.run_prometheus_queries(query_yaml_file=yaml_full_path)


### PR DESCRIPTION
Adding prometheus metrics support:
1. Run directly the query and get prometheus metrics
2. Run query yaml file and get prometheus metrics
3. Add prometheus_metrics decorator ability:

For using custom metrics file (optional), pass it as argument to decorator:
[This will collect custom metrics for run() method]

```
current_dir = os.path.dirname(os.path.abspath(__file__))
yaml_full_path = os.path.join(current_dir, 'metrics.yaml')


@prometheus_metrics(yaml_full_path=yaml_full_path)
def run():
    print('sleep 30 sec')
    time.sleep(30)
run()
```