### PR TITLE
fix fio issue in clusterbuster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.1.5-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.1.6-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
This PR should fix clusterbuster fio issue:
Raised during [Perf CI](https://github.com/redhat-performance/benchmark-runner/actions/runs/3042386081/jobs/4900511290)
```
      0:06 fio-kata-0000-1P
Run took 3:05:38 (Failed)
Traceback (most recent call last):
  File "/tmp/OpenShift4-tools/analyze-clusterbuster-report", line 29, in <module>
    data = ClusterBusterLoader(args.files).Load()
  File "/tmp/OpenShift4-tools/lib/clusterbuster/loader/ClusterBusterLoader.py", line 96, in Load
    i[1](report, answer).Load()
  File "/tmp/OpenShift4-tools/lib/clusterbuster/loader/uperf_loader.py", line 37, in Load
    root['ops_sec'] = job['ops_rate']
KeyError: 'ops_rate'
```

Clusterbuster version: v1.1.6-kata-ci should fix this issue.

