### PR TITLE
fix kata virtiofsd permission issue

### DIFF
--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mariadb_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mariadb_template.yaml
@@ -3,6 +3,23 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+{%- if kind == 'kata' %}
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
+{%- endif %}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -48,6 +65,9 @@ spec:
         kubernetes.io/hostname: "{{ pin_node2 }}"
       {%- if kind == 'kata' %}
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       {%- endif %}
       terminationGracePeriodSeconds: 10
       containers:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml
@@ -3,6 +3,23 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+{%- if kind == 'kata' %}
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
+{%- endif %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,6 +44,9 @@ spec:
         kubernetes.io/hostname: "{{ pin_node2 }}"
       {%- if kind == 'kata' %}
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       {%- endif %}
       terminationGracePeriodSeconds: 10
       containers:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml
@@ -3,6 +3,23 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+{%- if kind == 'kata' %}
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
+{%- endif %}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,6 +57,9 @@ spec:
         kubernetes.io/hostname: "{{ pin_node2 }}"
       {%- if kind == 'kata' %}
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       {%- endif %}
       terminationGracePeriodSeconds: 10
       containers:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mariadbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mariadb-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,6 +58,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mariadb

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: mssqldbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:mssql-db:default
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +37,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
       - name: mssql

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,21 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+#This is a tweak of the restricted scc, to allow fsGroup to be specified in a deployment
+# workaround for kata virtiofsd permission error in ODF 4.10.5
+apiVersion: security.openshift.io/v1
+metadata:
+  name: postgresdbscc
+kind: SecurityContextConstraints
+fsGroup:
+  type: RunAsAny
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+users:
+- system:serviceaccount:postgres-db:default
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,6 +50,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: "pin-node-2"
       runtimeClassName: kata
+      # workaround for kata virtiofsd permission error in ODF 4.10.5
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres


### PR DESCRIPTION

This PR should supply temporary workaround for kata virtiofsd permission issue 
**The issue:**
kata database failed due to permission issue in mssql/mariadb/pssql: cannot create directory '/var/lib/mysql/data': Permission denied

**Root cause:**
Failed only for kata using ODF4.10.5, working for kata using ODF4.9.10 (regardless of whether OCP 4.10 or 4.11 is in use).  virtiofsd does not check secondary group ids; it only relies on the primary group id.

**The temporary workaround:**
Add to the deployment spec:
```

securityContext:
  fsGroup: 0

And the SCC:

apiVersion: security.openshift.io/v1
metadata:
  name: mariadbscc
kind: SecurityContextConstraints
fsGroup:
  type: RunAsAny
runAsUser:
  type: MustRunAsRange
seLinuxContext:
  type: MustRunAs
users:
  - system:serviceaccount:mariadb-db:default

```