### PR TITLE
Hammerdb LSO support

### DIFF
--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -90,7 +90,7 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix: 
-          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb',  'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
+          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb',  'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
@@ -153,6 +153,7 @@ jobs:
         FUNC_RUN_ARTIFACTS_URL: ${{ secrets.FUNC_RUN_ARTIFACTS_URL }}
         FUNC_SCALE_NODES: ${{ secrets.FUNC_SCALE_NODES }}
         FUNC_REDIS: ${{ secrets.FUNC_REDIS }}
+        FUNC_LSO_PATH: ${{ secrets.FUNC_LSO_PATH }}
         FUNC_TIMEOUT: 3600
         SCALE: 1
       run: |
@@ -171,7 +172,7 @@ jobs:
         then
             ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e FUNC_RUN_ARTIFACTS_URL='$FUNC_RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='func_ci' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e FUNC_TIMEOUT='$FUNC_TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
         else
-            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e FUNC_RUN_ARTIFACTS_URL='$FUNC_RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='func_ci' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e FUNC_TIMEOUT='$FUNC_TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e FUNC_RUN_ARTIFACTS_URL='$FUNC_RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='func_ci' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e FUNC_LSO_PATH='$FUNC_LSO_PATH' -e FUNC_TIMEOUT='$FUNC_TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
         fi
         ssh -t provision "podman rmi -f 'quay.io/ebattat/benchmark-runner:latest'"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> End E2E workload: ${{ matrix.workload }} >>>>>>>>>>>>>>>>>>>>>>>>>>>>'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following options may be passed via command line flags or set in the environ
 
 Choose one from the following list:
 
-`['stressng_pod', 'stressng_vm', 'stressng_kata','uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_pod_mssql', 'hammerdb_pod_postgres', 'hammerdb_vm_mariadb', 'hammerdb_vm_mssql', 'hammerdb_vm_postgres', 'hammerdb_kata_mariadb', 'hammerdb_kata_mssql', 'hammerdb_kata_postgres', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']`
+`['stressng_pod', 'stressng_vm', 'stressng_kata', 'uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_kata_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_kata_mssql_lso', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'clusterbuster']`
 
 ** clusterbuster workloads: cpusoaker, files, fio, uperf. for more details [see](https://github.com/RobertKrawitz/OpenShift4-tools)
 

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -150,6 +150,17 @@ class OC(SSH):
         """
         return self.run(fr""" {self.__cli} get nodes -l node-role.kubernetes.io/worker= -o jsonpath="{{range .items[*]}}{{.metadata.name}}{{'\n'}}{{end}}" """)
 
+    def delete_available_released_pv(self):
+        """
+        This method delete available or released pv because that avoid launching new pv
+        """
+        pv_status_list = self.run(fr"{self.__cli} get pv -ojsonpath={{..status.phase}}").split()
+        for pv_status in pv_status_list:
+            if pv_status == 'Available' or pv_status == 'Released':
+                available_pv = self.run(fr"{self.__cli} get pv -ojsonpath={{.items[{pv_status_list.index(pv_status)}].metadata.name}}")
+                logger.info(f'Delete {pv_status} pv {available_pv}')
+                self.run(fr"{self.__cli} delete pv {available_pv}")
+
     def clear_node_caches(self):
         """
         This method clears the node's buffer cache

--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -91,7 +91,7 @@ class TemplateOperations:
         # being able to create this without an actual workload.
         self.__workload_name = self.__workload.split('_')[0]
         self.__workload_kind = self.__workload.split('_')[1]
-        self.__workload_extra_name = '_'.join(self.__workload.split('_')[2:])
+        self.__workload_extra_name = '_'.join(self.__workload.split('_')[2:3])
         self.__workload_template_kind = self.__get_workload_template_kind()
         if self.__workload_extra_name:
             self.__standard_output_file = f"{'_'.join([self.__workload_name, self.__workload_template_kind, self.__workload_extra_name])}.yaml"

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_vm_template.yaml
@@ -1,3 +1,25 @@
+{% if storage_type == 'lso' -%}
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ pin_node2 }}
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      fsType: ext4
+      devicePaths:
+        - {{ lso_path }}
+---
+{%- endif %}
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +42,7 @@ spec:
     name: hammerdb
     args:
       pin: {{ pin }} # enable for nodeSelector
-      pin_node: "{{ pin_node1 }}"
+      pin_node: "{{ pin_node2 }}"
       db_type: "{{ db_type }}"
       timed_test: true
       test_type: "tpc-c"
@@ -92,9 +114,14 @@ spec:
           #- hostpassthrough
         # ODF PVC
         pvc: {{ odf_pvc }} # enable for ODF PVC
+        {%- if storage_type == 'lso' %}
+        pvc_storageclass: local-sc
+        pvc_pvcaccessmode: ReadWriteOnce
+        {%- else %}
         pvc_storageclass: ocs-storagecluster-ceph-rbd
         # Can be one of ReadWriteOnce,ReadOnlyMany,ReadWriteMany Default: ReadWriteOnce
         pvc_pvcaccessmode: ReadWriteMany
+        {%- endif %}
         # Can be one of Filesystem,Block Default: Filesystem
         pvc_pvcvolumemode: Block
         pvc_storagesize: {{ storage }}

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mariadb_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mariadb_template.yaml
@@ -20,6 +20,47 @@ users:
 - system:serviceaccount:mariadb-db:default
 ---
 {%- endif %}
+{%- if storage_type == 'lso' %}
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ pin_node2 }}
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - {{ lso_path }}
+---
+{%- endif %}
+{%- if storage_type == 'lso' or  odf_pvc == True %}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    {%- if storage_type == 'lso' %}
+    storageClassName: local-sc
+    {%- else %}
+    storageClassName: ocs-storagecluster-ceph-rbd
+    {%- endif %}
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: {{ storage }}
+---
+{%- endif %}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -96,33 +137,20 @@ spec:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf
             subPath: custom.conf #should be the name used in the ConfigMap
-          {%- if odf_pvc == True %}
+          {%- if storage_type == 'lso' or odf_pvc == True %}
           - name: mariadb-persistent-storage
             mountPath: /var/lib/mysql
             readOnly: false
-      {%- endif %}
+          {%- endif %}
       volumes:
         - name: mariadb-custom-config
           configMap:
             name: mariadb-custom-config
-        {%- if odf_pvc == True %}
+        {%- if storage_type == 'lso' or odf_pvc == True %}
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: {{ storage }}
-{%- endif %}
+        {%- endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/mssql_template.yaml
@@ -20,6 +20,47 @@ users:
 - system:serviceaccount:mssql-db:default
 ---
 {%- endif %}
+{%- if storage_type == 'lso' %}
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ pin_node2 }}
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - {{ lso_path }}
+---
+{%- endif %}
+{%- if storage_type == 'lso' or  odf_pvc == True %}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    {%- if storage_type == 'lso' %}
+    storageClassName: local-sc
+    {%- else %}
+    storageClassName: ocs-storagecluster-ceph-rbd
+    {%- endif %}
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: {{ storage }}
+---
+{%- endif %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,31 +112,18 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
-        {%- if odf_pvc == True %}
+        securityContext:
+          allowPrivilegeEscalation: true
+      {%- if storage_type == 'lso' or odf_pvc == True %}
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: {{ storage }}
-{%- endif %}
+      {%- endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml
@@ -20,6 +20,47 @@ users:
 - system:serviceaccount:postgres-db:default
 ---
 {%- endif %}
+{%- if storage_type == 'lso' %}
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ pin_node2 }}
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - {{ lso_path }}
+---
+{%- endif %}
+{%- if storage_type == 'lso' or  odf_pvc == True %}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    {%- if storage_type == 'lso' %}
+    storageClassName: local-sc
+    {%- else %}
+    storageClassName: ocs-storagecluster-ceph-rbd
+    {%- endif %}
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: {{ storage }}
+---
+{%- endif %}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,33 +131,20 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
-          {%- if odf_pvc == True %}
+          {%- if storage_type == 'lso' or odf_pvc == True %}
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false
-      {%- endif %}
+          {%- endif %}
       volumes:
         - name: postgres-custom-config
           configMap:
             name: postgres-custom-config
-        {%- if odf_pvc == True %}
+        {%- if storage_type == 'lso' or odf_pvc == True %}
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: {{ storage }}
-{%- endif %}
+        {%- endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -12,6 +12,8 @@ class EnvironmentVariables:
     This class manage environment variable parameters
     """
 
+    HAMMERDB_LSO_LEN = 4
+
     def __init__(self):
 
         self._environment_variables_dict = {}
@@ -76,8 +78,11 @@ class EnvironmentVariables:
         self._environment_variables_dict['workloads'] = ['stressng_pod', 'stressng_vm', 'stressng_kata',
                                                          'uperf_pod', 'uperf_vm', 'uperf_kata',
                                                          'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb',
+                                                         'hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_kata_mariadb_lso',
                                                          'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres',
+                                                         'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_kata_postgres_lso',
                                                          'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql',
+                                                         'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_kata_mssql_lso',
                                                          'vdbench_pod', 'vdbench_kata', 'vdbench_vm',
                                                          'clusterbuster']
         # Workloads namespaces
@@ -102,6 +107,15 @@ class EnvironmentVariables:
 
         # run workload with odf pvc True/False. True=ODF, False=Ephemeral
         self._environment_variables_dict['odf_pvc'] = EnvironmentVariables.get_boolean_from_environment('ODF_PVC', True)
+        if base_workload == 'hammerdb':
+            if len(self._environment_variables_dict['workload'].split('_')) == self.HAMMERDB_LSO_LEN:
+                self._environment_variables_dict['storage_type'] = self._environment_variables_dict['workload'].split('_')[self.HAMMERDB_LSO_LEN-1]
+            elif self._environment_variables_dict['odf_pvc']:
+                self._environment_variables_dict['storage_type'] = 'odf'
+            else:
+                self._environment_variables_dict['storage_type'] = 'ephemeral'
+        # LSO Disk path
+        self._environment_variables_dict['lso_path'] = EnvironmentVariables.get_env('LSO_PATH', '')
         # Workloads that required ODF
         self._environment_variables_dict['workloads_odf_pvc'] = ['vdbench', 'hammerdb']
         # This parameter get from Test_CI.yml file

--- a/docs/source/podman.md
+++ b/docs/source/podman.md
@@ -7,7 +7,7 @@ The following options may be passed via command line flags or set in the environ
 
 Choose one from the following list:
 
-`['stressng_pod', 'stressng_vm', 'stressng_kata','uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_pod_mssql', 'hammerdb_pod_postgres', 'hammerdb_vm_mariadb', 'hammerdb_vm_mssql', 'hammerdb_vm_postgres', 'hammerdb_kata_mariadb', 'hammerdb_kata_mssql', 'hammerdb_kata_postgres', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']`
+`['stressng_pod', 'stressng_vm', 'stressng_kata', 'uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_kata_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_kata_mssql_lso', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'clusterbuster']`
 
 ** clusterbuster workloads: cpusoaker, files, fio, uperf.  For more details [see](https://github.com/RobertKrawitz/OpenShift4-tools)
 

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mariadb-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -96,19 +109,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -61,6 +61,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mssql-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,29 +74,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:postgres-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,19 +103,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -77,19 +90,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -42,6 +42,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,29 +55,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -71,19 +84,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mariadb-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -96,19 +109,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 100Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -61,6 +61,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mssql-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,29 +74,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 100Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:postgres-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,19 +103,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 100Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -77,19 +90,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 100Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -42,6 +42,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,29 +55,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 100Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -71,19 +84,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 100Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mariadb-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -96,19 +109,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -61,6 +61,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mssql-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,29 +74,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:postgres-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,19 +103,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -77,19 +90,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -42,6 +42,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,29 +55,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -71,19 +84,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mariadb-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -96,19 +109,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -61,6 +61,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:mssql-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,29 +74,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -18,6 +18,19 @@ seLinuxContext:
 users:
 - system:serviceaccount:postgres-db:default
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -90,19 +103,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mariadb-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: mariadb-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -77,19 +90,6 @@ spec:
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
             claimName: mariadb-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mariadb-persistent-storage
-    namespace: mariadb-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -42,6 +42,8 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: mssql-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: mssql-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,29 +55,16 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        securityContext:
+          allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql
             readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: true
       volumes:
         - name: mssql-persistent-storage
           persistentVolumeClaim:
             claimName: mssql-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: mssql-persistent-storage
-    namespace: mssql-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -3,6 +3,19 @@ kind: Namespace
 metadata:
   name: postgres-db
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: postgres-db
+spec:
+    storageClassName: ocs-storagecluster-ceph-rbd
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -71,19 +84,6 @@ spec:
         - name: postgres-persistent-storage
           persistentVolumeClaim:
             claimName: postgres-persistent-storage
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-    name: postgres-persistent-storage
-    namespace: postgres-db
-spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
-    accessModes: [ "ReadWriteOnce" ]
-    volumeMode: Filesystem
-    resources:
-      requests:
-        storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mariadb"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -20,7 +21,7 @@ spec:
     name: hammerdb
     args:
       pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
+      pin_node: "pin-node-2"
       db_type: "pg"
       timed_test: true
       test_type: "tpc-c"


### PR DESCRIPTION
This PR is including:

1. Adding LSO support for the following databases for pod/kata/vm:
    a. PostgreSQL
    b. MariaDB
    c. MSSQL
2. Adding storage_type field indication: odf, lso, ephemeral
3. Enable PostgreSQL pod/kata/vm in functional CI.