### PR TITLE
update set-output

### DIFF
--- a/.github/workflows/Func_Env_Build_Test_CI.yml
+++ b/.github/workflows/Func_Env_Build_Test_CI.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: start_step
-      run: echo "::set-output name=start_time::$(printf '%(%s)T' -1)"
+      run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/Func_Env_E2E_Test_CI.yml
+++ b/.github/workflows/Func_Env_E2E_Test_CI.yml
@@ -119,7 +119,7 @@ jobs:
           #end=$(printf '%(%s)T' -1)
           #echo "INSTALL_OCP_RESOURCE_MINUTES_TIME=$(( (( end - start )) / 60))" >> "$GITHUB_ENV"
       - id: ocp_install_resource_step
-        run: echo "::set-output name=install_resource_time::$INSTALL_OCP_RESOURCE_MINUTES_TIME"
+        run: echo "install_resource_time=$INSTALL_OCP_RESOURCE_MINUTES_TIME" >> $GITHUB_OUTPUT
       - name: ☉ Rerun OCP Operator Reources install after failure
         env:
           CNV_VERSION: "4.10"

--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: nightly_start_step
-      run: echo "::set-output name=start_time::$(printf '%(%s)T' -1)"
+      run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
       env:
         PROVISION_PRIVATE_KEY: ${{ secrets.FUNC_PROVISION_PRIVATE_KEY }}
@@ -180,8 +180,8 @@ jobs:
     - id: job_step
       if: always()
       run: |
-          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "::set-output name=status::${{ job.status }}"; fi
-   
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "status=${{ job.status }}" >> $GITHUB_OUTPUT; fi
+
   finalize_nightly:
     name: finalize nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: nightly_start_step
-      run: echo "::set-output name=start_time::$(printf '%(%s)T' -1)"
+      run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
       env:
         PROVISION_PRIVATE_KEY: ${{ secrets.PERF_PROVISION_PRIVATE_KEY }}
@@ -163,8 +163,7 @@ jobs:
     - id: job_step
       if: always()
       run: |
-          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "::set-output name=status::${{ job.status }}"; fi
-        
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "status=${{ job.status }}" >> $GITHUB_OUTPUT; fi
   finalize_nightly:
     name: finalize nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/Release_ClusterBuster_Perf_Env_CI.yml
+++ b/.github/workflows/Release_ClusterBuster_Perf_Env_CI.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: nightly_start_step
-      run: echo "::set-output name=start_time::$(printf '%(%s)T' -1)"
+      run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
       env:
         PROVISION_PRIVATE_KEY: ${{ secrets.PERF_PROVISION_PRIVATE_KEY }}
@@ -151,8 +151,8 @@ jobs:
     - id: job_step
       if: always()
       run: |
-          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "::set-output name=status::${{ job.status }}"; fi
-        
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "status=${{ job.status }}" >> $GITHUB_OUTPUT; fi
+
   finalize_nightly:
     name: finalize nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/Weekly_Func_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Operator_CI.yml
@@ -117,7 +117,7 @@ jobs:
           end=$(printf '%(%s)T' -1)
           echo "INSTALL_OCP_RESOURCE_MINUTES_TIME=$(( (( end - start )) / 60))" >> "$GITHUB_ENV"
       - id: ocp_install_resource_step
-        run: echo "::set-output name=install_resource_time::$INSTALL_OCP_RESOURCE_MINUTES_TIME"
+        run: echo "install_resource_time=$INSTALL_OCP_RESOURCE_MINUTES_TIME" >> $GITHUB_OUTPUT
       - name: ☉ Rerun OCP Operator Reources install after failure
         env:
           CNV_VERSION: "4.11"

--- a/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
@@ -117,7 +117,7 @@ jobs:
           end=$(printf '%(%s)T' -1)
           echo "INSTALL_OCP_RESOURCE_MINUTES_TIME=$(( (( end - start )) / 60))" >> "$GITHUB_ENV"
       - id: ocp_install_resource_step
-        run: echo "::set-output name=install_resource_time::$INSTALL_OCP_RESOURCE_MINUTES_TIME"
+        run: echo "install_resource_time=$INSTALL_OCP_RESOURCE_MINUTES_TIME" >> $GITHUB_OUTPUT
       - name: ☉ Rerun OCP Operator Resources install after failure
         env:
           CNV_VERSION: "4.11"


### PR DESCRIPTION
Change due to:
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/