### PR TITLE
fix PostgreSQL LSO

### DIFF
--- a/benchmark_runner/benchmark_operator/benchmark_operator_exceptions.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_exceptions.py
@@ -14,6 +14,14 @@ class ODFNonInstalled(BenchmarkOperatorError):
         super(ODFNonInstalled, self).__init__(self.message)
 
 
+class EmptyLSOPath(BenchmarkOperatorError):
+    """
+    This class is error that LSO path is empty
+    """
+    def __init__(self):
+        self.message = "LSO path is empty"
+        super(EmptyLSOPath, self).__init__(self.message)
+
 class PrometheusSnapshotFailed(BenchmarkOperatorError):
     """
     Prometheus snapshot failed

--- a/benchmark_runner/benchmark_operator/benchmark_operator_workloads_operations.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_workloads_operations.py
@@ -11,7 +11,7 @@ from benchmark_runner.common.oc.oc import OC
 from benchmark_runner.common.template_operations.template_operations import TemplateOperations
 from benchmark_runner.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
 from benchmark_runner.common.ssh.ssh import SSH
-from benchmark_runner.benchmark_operator.benchmark_operator_exceptions import ODFNonInstalled
+from benchmark_runner.benchmark_operator.benchmark_operator_exceptions import ODFNonInstalled, EmptyLSOPath
 from benchmark_runner.main.environment_variables import environment_variables
 from benchmark_runner.common.clouds.shared.s3.s3_operations import S3Operations
 from benchmark_runner.common.prometheus.prometheus_snapshot import PrometheusSnapshot
@@ -37,6 +37,7 @@ class BenchmarkOperatorWorkloadsOperations:
         self._elasticsearch = self._environment_variables_dict.get('elasticsearch', '')
         self._run_artifacts = self._environment_variables_dict.get('run_artifacts', '')
         self._run_artifacts_path = self._environment_variables_dict.get('run_artifacts_path', '')
+        self._lso_path = self._environment_variables_dict.get('lso_path', '')
         self._date_key = self._environment_variables_dict.get('date_key', '')
         self._key = self._environment_variables_dict.get('key', '')
         self._endpoint_url = self._environment_variables_dict.get('endpoint_url', '')
@@ -456,6 +457,15 @@ class BenchmarkOperatorWorkloadsOperations:
                 raise ODFNonInstalled()
 
     @logger_time_stamp
+    def verify_lso(self):
+        """
+        This method Verifies that lso path exist
+        :return:
+        """
+        if not self._lso_path:
+            raise EmptyLSOPath()
+
+    @logger_time_stamp
     def delete_all(self):
         """
         This method delete all pod or unbound pv in namespace
@@ -484,6 +494,8 @@ class BenchmarkOperatorWorkloadsOperations:
         self.clear_nodes_cache()
         if self._odf_pvc:
             self.odf_pvc_verification()
+        if 'lso' in self._workload:
+            self.verify_lso()
         # make deploy benchmark controller manager
         self.make_deploy_benchmark_controller_manager(runner_path=environment_variables.environment_variables_dict['runner_path'])
         self._template.generate_yamls()

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -8,9 +8,11 @@ template_data:
   shared:
     pin_node1: {{ pin_node1 }}
     pin_node2: {{ pin_node2 }}
-    transactions: 100000
     odf_pvc: {{ odf_pvc }}
     resources: true
+    transactions: 100000
+    rampup: 1
+    runtime: 1
   run_type:
     perf_ci:
       db_num_workers: 32
@@ -44,7 +46,6 @@ template_data:
       db_type: mariadb
       db_user: root
       db_server_pod: mariadb-deployment.mariadb-db
-      runtime: 1
     mssql:
       db_image: centos-stream8-mssql2019-container-disk:latest
       db_pass: s3curePasswordString
@@ -52,7 +53,6 @@ template_data:
       db_type: mssql
       db_user: SA
       db_server_pod: mssql-deployment.mssql-db
-      runtime: 1
     postgres:
       db_image: centos-stream8-postgres10-container-disk:latest
       db_pass: postgres
@@ -60,7 +60,7 @@ template_data:
       db_type: pg
       db_user: postgres
       db_server_pod: postgres-deployment.postgres-db
-      runtime: 2
+      transactions: 200000
   kind:
     vm:
       run_type:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_pod_template.yaml
@@ -46,7 +46,7 @@ spec:
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
-      rampup: 1
+      rampup: {{ rampup }}
       runtime: {{ runtime }}
       allwarehouse: false
       timeprofile: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -40,12 +40,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -38,12 +38,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -35,12 +35,12 @@ spec:
       db_user: "postgres"
       db_pass: "postgres"
       db_name: "tpcc"
-      transactions: 100000
+      transactions: 200000
       raiseerror: "false"
       keyandthink: "false"
       driver: "timed"
       rampup: 1
-      runtime: 2
+      runtime: 1
       allwarehouse: false
       timeprofile: false
       async_scale: false


### PR DESCRIPTION
This PR should fix PostgreSQL LSO hammerdb issue.
The current results of ODF are better than LSO because lack of load transactions.

There are 2 changes in this PR:
1. Update load transactions to 200K instead of 100K
2. Add LSO verification in case of empty path.
