### PR TITLE
enable vdbench scale

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -86,7 +86,7 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix: 
-          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'clusterbuster']
+          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs==21.4.0
 azure==4.0.0
-boto3==1.20.24
-botocore==1.23.24
+boto3==1.26.1
+botocore==1.29.1
 cryptography==36.0.2
 elasticsearch==7.16.1
 elasticsearch_dsl==7.4.0

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
     install_requires=[
         'attrs==21.4.0', # readthedocs
         'azure==4.0.0',
-        'boto3==1.20.24',  # s3
-        'botocore==1.23.24',  # s3
+        'boto3==1.26.1',  # s3
+        'botocore==1.29.1',  # s3
         'cryptography==36.0.2',  # Remove once https://github.com/paramiko/paramiko/issues/2038 gets fixed.
         'elasticsearch==7.16.1',
         'elasticsearch_dsl==7.4.0',  # for deep search


### PR DESCRIPTION
This PR enables vdbench scale for pod/kata/vm
The scale is 2, meaning running 2 pod/kata/vm per worker node (3 workers), total 6 pod/kata/vm

Update botocore and boto3 for latest stable