### PR TITLE
split vdbench workload in perf ci

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_Even_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_Even_CI.yml
@@ -1,16 +1,17 @@
 # Nightly CI https://github.com/marketplace/actions/deploy-nightly
-# This is a nightly CI Pipeline against Functional environment
-name: Deploy Func Env Nightly CI
+# This is a nightly CI Pipeline against Performance environment
+# GitHub Actions is limited 6 hours for each job
+name: Deploy Perf Env Nightly CI
 
 on:
   # Run on Nightly
   schedule:
-    - cron: '0 4 * * 1-6' # run Monday-Sunday at 4 AM UTC/ 0 AM EDT
+    - cron: '0 4 * * 3,5' # run Wednesday, Friday at 4 AM UTC/ 0 AM EDT
   # Run on weekly after assisted installer and operator completed
-  workflow_run: # run Sunday after installer
-    workflows: ["Deploy Operator FUNC Env Weekly CI"]
+  workflow_run: # run Monday after installer
+    workflows: ["Deploy Operator Perf Env Weekly CI"]
     types:
-      - completed
+    - completed
   workflow_dispatch:
 
 # on:
@@ -19,12 +20,11 @@ on:
 
 # Ensures that only one deploy task per branch/environment will run at a time.
 concurrency:
-  group: functional-environment
-  cancel-in-progress: false
+  group: performance-environment
 
 jobs:
   initialize_nightly:
-    name: initialize func nightly
+    name: initialize perf nightly
     runs-on: ubuntu-latest
     outputs:
       start_time_output: ${{ steps.nightly_start_step.outputs.start_time }}
@@ -34,10 +34,10 @@ jobs:
       run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
       env:
-        PROVISION_PRIVATE_KEY: ${{ secrets.FUNC_PROVISION_PRIVATE_KEY }}
+        PROVISION_PRIVATE_KEY: ${{ secrets.PERF_PROVISION_PRIVATE_KEY }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
-        PROVISION_IP: ${{ secrets.FUNC_PROVISION_IP }}
-        PROVISION_USER: ${{ secrets.FUNC_PROVISION_USER }}
+        PROVISION_IP: ${{ secrets.PERF_PROVISION_IP }}
+        PROVISION_USER: ${{ secrets.PERF_PROVISION_USER }}
       run: |
         mkdir -p "$RUNNER_PATH/.ssh/"
         echo "$PROVISION_PRIVATE_KEY" > $RUNNER_PATH/private_key.txt
@@ -54,15 +54,15 @@ jobs:
         END
     - name: ⚙️ Set Kubeconfig and hosts
       env:
-        KUBECONFIG_CONTENTS: ${{ secrets.FUNC_KUBECONFIG }}
+        KUBECONFIG_CONTENTS: ${{ secrets.PERF_KUBECONFIG }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
-        OCP_HOSTS: ${{ secrets.FUNC_OCP_HOSTS }}
+        OCP_HOSTS: ${{ secrets.PERF_OCP_HOSTS }}
       run: |
         mkdir -p "$RUNNER_PATH/.kube/"
         echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
         echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
         sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
-    - name: ⚙ Remove images on provistion and copy config to provision
+    - name: ⚙ Remove images on provision and copy config to provision
       env:
         CONTAINER_KUBECONFIG_PATH: ${{ secrets.CONTAINER_KUBECONFIG_PATH }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
@@ -73,25 +73,21 @@ jobs:
         ssh -t provision "chmod +x /tmp/remove_image.sh;/tmp/./remove_image.sh;rm -f /tmp/remove_image.sh"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Copy config to provision  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
         scp -r "$RUNNER_PATH/.kube/config" provision:"$CONTAINER_KUBECONFIG_PATH"
-    - name: ⌛ Build & Upload 🐋 to quay.io - latest benchmark-operator
-      run: |
-        sudo docker build --build-arg VERSION=latest -t quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:latest .
-        sudo docker login quay.io -u ${{ secrets.QAUYIO_ROBOT_USER }} -p ${{ secrets.QAUYIO_ROBOT_TOKEN }}
-        sudo docker push quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:latest
-  
+
   workload:
     name: workload
     runs-on: ubuntu-latest
     outputs:
       job_status: ${{ steps.job_step.outputs.status }}
-    needs: initialize_nightly     
+    needs: initialize_nightly 
     strategy:
        # run one job every time
        max-parallel: 1
        # continue to next job if failed
        fail-fast: false
-       matrix: 
-          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb',  'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
+       matrix:
+          # Even day, skip vdbench scale tests: 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale'
+          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'clusterbuster']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -102,14 +98,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install benchmark-runner
-    - name: ⚙️ SET SSH key
+    - name: ⚙️ Set SSH key
       env:
-        PROVISION_PRIVATE_KEY: ${{ secrets.FUNC_PROVISION_PRIVATE_KEY }}
+        PROVISION_PRIVATE_KEY: ${{ secrets.PERF_PROVISION_PRIVATE_KEY }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
-        PROVISION_IP: ${{ secrets.FUNC_PROVISION_IP }}
-        PROVISION_USER: ${{ secrets.FUNC_PROVISION_USER }}
+        PROVISION_IP: ${{ secrets.PERF_PROVISION_IP }}
+        PROVISION_USER: ${{ secrets.PERF_PROVISION_USER }}
       run: |
-        umask 77
         mkdir -p "$RUNNER_PATH/.ssh/"
         echo "$PROVISION_PRIVATE_KEY" > $RUNNER_PATH/private_key.txt
         sudo chmod 600 $RUNNER_PATH/private_key.txt
@@ -125,9 +120,9 @@ jobs:
         END
     - name: ⚙️ Set Kubeconfig and hosts
       env:
-        KUBECONFIG_CONTENTS: ${{ secrets.FUNC_KUBECONFIG }}
+        KUBECONFIG_CONTENTS: ${{ secrets.PERF_KUBECONFIG }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
-        OCP_HOSTS: ${{ secrets.FUNC_OCP_HOSTS }}
+        OCP_HOSTS: ${{ secrets.PERF_OCP_HOSTS }}
       run: |
         mkdir -p "$RUNNER_PATH/.kube/"
         echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
@@ -135,14 +130,14 @@ jobs:
         sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: ✔️ Run workload ${{ matrix.workload }}
       env:
-        KUBEADMIN_PASSWORD: ${{ secrets.FUNC_KUBEADMIN_PASSWORD }}
-        PIN_NODE_BENCHMARK_OPERATOR: ${{ secrets.FUNC_PIN_NODE_BENCHMARK_OPERATOR }}
-        PIN_NODE1: ${{ secrets.FUNC_PIN_NODE1 }}
-        PIN_NODE2: ${{ secrets.FUNC_PIN_NODE2 }}
-        ELASTICSEARCH: ${{ secrets.FUNC_ELASTICSEARCH }}
-        ELASTICSEARCH_PORT: ${{ secrets.FUNC_ELASTICSEARCH_PORT }}
-        ELASTICSEARCH_USER: ${{ secrets.FUNC_ELASTICSEARCH_USER }}
-        ELASTICSEARCH_PASSWORD: ${{ secrets.FUNC_ELASTICSEARCH_PASSWORD }}
+        KUBEADMIN_PASSWORD: ${{ secrets.PERF_KUBEADMIN_PASSWORD }}
+        PIN_NODE_BENCHMARK_OPERATOR: ${{ secrets.PERF_PIN_NODE_BENCHMARK_OPERATOR }}
+        PIN_NODE1: ${{ secrets.PERF_PIN_NODE1 }}
+        PIN_NODE2: ${{ secrets.PERF_PIN_NODE2 }}
+        ELASTICSEARCH: ${{ secrets.PERF_ELASTICSEARCH }}
+        ELASTICSEARCH_PORT: ${{ secrets.PERF_ELASTICSEARCH_PORT }}
+        ELASTICSEARCH_USER: ${{ secrets.PERF_ELASTICSEARCH_USER }}
+        ELASTICSEARCH_PASSWORD: ${{ secrets.PERF_ELASTICSEARCH_PASSWORD }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
         CONTAINER_KUBECONFIG_PATH: ${{ secrets.CONTAINER_KUBECONFIG_PATH }}
         IBM_REGION_NAME: ${{ secrets.IBM_REGION_NAME }}
@@ -151,18 +146,17 @@ jobs:
         IBM_SECRET_ACCESS_KEY: ${{ secrets.IBM_SECRET_ACCESS_KEY }}
         IBM_BUCKET: ${{ secrets.IBM_BUCKET }}
         IBM_KEY: ${{ secrets.IBM_KEY }}
-        RUN_ARTIFACTS_URL: ${{ secrets.FUNC_RUN_ARTIFACTS_URL }}
-        SCALE_NODES: ${{ secrets.FUNC_SCALE_NODES }}
+        RUN_ARTIFACTS_URL: ${{ secrets.PERF_RUN_ARTIFACTS_URL }}
+        SCALE_NODES: ${{ secrets.PERF_SCALE_NODES }}
         REDIS: ${{ secrets.REDIS }}
-        LSO_PATH: ${{ secrets.FUNC_LSO_PATH }}
-        TIMEOUT: 3600
-        SCALE: 1
-        RUN_TYPE: 'func_ci'
+        LSO_PATH: ${{ secrets.PERF_LSO_PATH }}
+        TIMEOUT: 8000
+        SCALE: 2
+        RUN_TYPE: 'perf_ci'
       run: |
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Start E2E workload: ${{ matrix.workload }} >>>>>>>>>>>>>>>>>>>>>>>>>>'
-        scp -r "$RUNNER_PATH/.kube/config" provision:"$CONTAINER_KUBECONFIG_PATH"
         # Run vdbench scale 
         if [[ '${{ matrix.workload }}' == 'vdbench_pod_scale' || '${{ matrix.workload }}' == 'vdbench_kata_scale' || '${{ matrix.workload }}' == 'vdbench_vm_scale' ]]
         then
@@ -170,24 +164,23 @@ jobs:
             # SCALE_NODES is a list, not add ''
             ssh -t provision "podman run --rm -t -e WORKLOAD='$workload' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e SCALE='$SCALE' -e SCALE_NODES=$SCALE_NODES -e REDIS='$REDIS' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
         # clusterbuster: disable prometheus logs
+        # clusterbuster: disable prometheus logs
         elif [[ '${{ matrix.workload }}' == 'clusterbuster' ]]
         then
-            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='True' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' -v '/tmp/benchmark-runner-run-artifacts':'/tmp/benchmark-runner-run-artifacts' --privileged 'quay.io/ebattat/benchmark-runner:v$build_version'"
         else
-            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e LSO_PATH='$LSO_PATH' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='True' -e LSO_PATH='$LSO_PATH' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:v$build_version'"
         fi
-        ssh -t provision "podman rmi -f 'quay.io/ebattat/benchmark-runner:latest'"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> End E2E workload: ${{ matrix.workload }} >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
     - id: job_step
       if: always()
       run: |
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then echo "status=${{ job.status }}" >> $GITHUB_OUTPUT; fi
-
   finalize_nightly:
     name: finalize nightly
     runs-on: ubuntu-latest
     if: always()
-    needs: [initialize_nightly, workload]      
+    needs: [initialize_nightly, workload]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -200,14 +193,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install benchmark-runner
-    - name: ⚙️ SET SSH key
+    - name: ⚙️ Set SSH key
       env:
-        PROVISION_PRIVATE_KEY: ${{ secrets.FUNC_PROVISION_PRIVATE_KEY }}
+        PROVISION_PRIVATE_KEY: ${{ secrets.PERF_PROVISION_PRIVATE_KEY }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
-        PROVISION_IP: ${{ secrets.FUNC_PROVISION_IP }}
-        PROVISION_USER: ${{ secrets.FUNC_PROVISION_USER }}
+        PROVISION_IP: ${{ secrets.PERF_PROVISION_IP }}
+        PROVISION_USER: ${{ secrets.PERF_PROVISION_USER }}
       run: |
-        umask 77
         mkdir -p "$RUNNER_PATH/.ssh/"
         echo "$PROVISION_PRIVATE_KEY" > $RUNNER_PATH/private_key.txt
         sudo chmod 600 $RUNNER_PATH/private_key.txt
@@ -223,9 +215,9 @@ jobs:
         END
     - name: ⚙️ Set Kubeconfig and hosts
       env:
-        KUBECONFIG_CONTENTS: ${{ secrets.FUNC_KUBECONFIG }}
+        KUBECONFIG_CONTENTS: ${{ secrets.PERF_KUBECONFIG }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
-        OCP_HOSTS: ${{ secrets.FUNC_OCP_HOSTS }}
+        OCP_HOSTS: ${{ secrets.PERF_OCP_HOSTS }}
       run: |
         mkdir -p "$RUNNER_PATH/.kube/"
         echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
@@ -233,23 +225,16 @@ jobs:
         sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: ✔️ Update status
       env:
-        KUBEADMIN_PASSWORD: ${{ secrets.FUNC_KUBEADMIN_PASSWORD }}
-        PIN_NODE_BENCHMARK_OPERATOR: ${{ secrets.FUNC_PIN_NODE_BENCHMARK_OPERATOR }}
-        PIN_NODE1: ${{ secrets.FUNC_PIN_NODE1 }}
-        PIN_NODE2: ${{ secrets.FUNC_PIN_NODE2 }}
-        ELASTICSEARCH: ${{ secrets.FUNC_ELASTICSEARCH }}
-        ELASTICSEARCH_PORT: ${{ secrets.FUNC_ELASTICSEARCH_PORT }}
-        ELASTICSEARCH_USER: ${{ secrets.FUNC_ELASTICSEARCH_USER }}
-        ELASTICSEARCH_PASSWORD: ${{ secrets.FUNC_ELASTICSEARCH_PASSWORD }}
+        KUBEADMIN_PASSWORD: ${{ secrets.PERF_KUBEADMIN_PASSWORD }}
+        PIN_NODE_BENCHMARK_OPERATOR: ${{ secrets.PERF_PIN_NODE_BENCHMARK_OPERATOR }}
+        PIN_NODE1: ${{ secrets.PERF_PIN_NODE1 }}
+        PIN_NODE2: ${{ secrets.PERF_PIN_NODE2 }}
+        ELASTICSEARCH: ${{ secrets.PERF_ELASTICSEARCH }}
+        ELASTICSEARCH_PORT: ${{ secrets.PERF_ELASTICSEARCH_PORT }}
+        ELASTICSEARCH_USER: ${{ secrets.PERF_ELASTICSEARCH_USER }}
+        ELASTICSEARCH_PASSWORD: ${{ secrets.PERF_ELASTICSEARCH_PASSWORD }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
         CONTAINER_KUBECONFIG_PATH: ${{ secrets.CONTAINER_KUBECONFIG_PATH }}
-        IBM_REGION_NAME: ${{ secrets.IBM_REGION_NAME }}
-        IBM_ENDPOINT_URL: ${{ secrets.IBM_ENDPOINT_URL }}
-        IBM_ACCESS_KEY_ID: ${{ secrets.IBM_ACCESS_KEY_ID }}
-        IBM_SECRET_ACCESS_KEY: ${{ secrets.IBM_SECRET_ACCESS_KEY }}
-        IBM_BUCKET: ${{ secrets.IBM_BUCKET }}
-        IBM_KEY: ${{ secrets.IBM_KEY }}
-        RUN_ARTIFACTS_URL: ${{ secrets.RUN_ARTIFACTS_URL }}
       run: |
         # get repository last id
         declare -a repositories=('benchmark-operator' 'benchmark-wrapper')
@@ -274,7 +259,7 @@ jobs:
         # Check for workload failure or success => return pass/failed
         if [[ "${{needs.workload.outputs.job_status}}" == "failure" || "${{needs.workload.outputs.job_status}}" == "cancelled" ]]; then status="failed"; else status="pass"; fi
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Update CI status $status >>>>>>>>>>>>>>>>>>>>>>>>>>'
-        podman run --rm -e KUBEADMIN_PASSWORD="$KUBEADMIN_PASSWORD" -e PIN_NODE_BENCHMARK_OPERATOR="$PIN_NODE_BENCHMARK_OPERATOR" -e PIN_NODE1="$PIN_NODE1" -e PIN_NODE2="$PIN_NODE2" -e ELASTICSEARCH="$ELASTICSEARCH" -e ELASTICSEARCH_PORT="$ELASTICSEARCH_PORT" -e ELASTICSEARCH_USER="$ELASTICSEARCH_USER" -e ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" -e BUILD_VERSION="$build_version" -e CI_STATUS="$status" -e CI_MINUTES_TIME="$ci_minutes_time" -e BENCHMARK_OPERATOR_ID="$BENCHMARK_OPERATOR_ID" -e BENCHMARK_WRAPPER_ID="$BENCHMARK_WRAPPER_ID" -e RUN_TYPE="func_ci" -e TIMEOUT="2000" -e log_level="INFO" -v "$KUBECONFIG_PATH":"$CONTAINER_KUBECONFIG_PATH" --privileged "quay.io/ebattat/benchmark-runner:v$build_version"
+        podman run --rm -e KUBEADMIN_PASSWORD="$KUBEADMIN_PASSWORD" -e PIN_NODE_BENCHMARK_OPERATOR="$PIN_NODE_BENCHMARK_OPERATOR" -e PIN_NODE1="$PIN_NODE1" -e PIN_NODE2="$PIN_NODE2" -e ELASTICSEARCH="$ELASTICSEARCH" -e ELASTICSEARCH_PORT="$ELASTICSEARCH_PORT" -e ELASTICSEARCH_USER="$ELASTICSEARCH_USER" -e ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" -e BUILD_VERSION="$build_version" -e CI_STATUS="$status" -e CI_MINUTES_TIME="$ci_minutes_time" -e BENCHMARK_OPERATOR_ID="$BENCHMARK_OPERATOR_ID" -e BENCHMARK_WRAPPER_ID="$BENCHMARK_WRAPPER_ID" -e RUN_TYPE="perf_ci" -e TIMEOUT="3600" -e log_level="INFO" -v "$KUBECONFIG_PATH":"$CONTAINER_KUBECONFIG_PATH" --privileged "quay.io/ebattat/benchmark-runner:v$build_version"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Remove image on provision >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
         echo "if [[ \"\$(sudo podman images -q quay.io/ebattat/benchmark-runner 2> /dev/null)\" != \"\" ]]; then sudo podman rmi -f \$(sudo podman images -q quay.io/ebattat/benchmark-runner 2> /dev/null); fi" > "$RUNNER_PATH/remove_image.sh"
         scp -r "$RUNNER_PATH/remove_image.sh" provision:"/tmp/remove_image.sh"

--- a/.github/workflows/Nightly_Perf_Env_Odd_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_Odd_CI.yml
@@ -6,12 +6,7 @@ name: Deploy Perf Env Nightly CI
 on:
   # Run on Nightly
   schedule:
-    - cron: '0 4 * * 0,2-6' # run Sunday, Tuesday-Sunday at 4 AM UTC/ 0 AM EDT
-  # Run on weekly after assisted installer and operator completed
-  workflow_run:
-    workflows: ["Deploy Operator Perf Env Weekly CI"]
-    types:
-    - completed
+    - cron: '0 4 * * 0,2,4,6' # run Sunday, Tuesday, Thursday, Saturday at 4 AM UTC/ 0 AM EDT
   workflow_dispatch:
 
 # on:
@@ -85,8 +80,9 @@ jobs:
        max-parallel: 1
        # continue to next job if failed
        fail-fast: false
-       matrix: 
-          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
+       matrix:
+         # Odd day, skip vdbench tests: 'vdbench_pod', 'vdbench_kata', 'vdbench_vm'
+          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10

--- a/docs/source/prometheus.md
+++ b/docs/source/prometheus.md
@@ -49,13 +49,25 @@ snapshot within is named
 ```
 $ local_prometheus_snapshot=/hammerdb-vm-mariadb-2022-01-04-08-21-23/promdb_2022_01_04T08_21_52+0000_2022_01_04T08_45_47+0000
 $ chmod -R g-s,a+rw "$local_prometheus_snapshot"
-$ sudo podman run --rm -p 9090:9090 -uroot -v "$local_prometheus_snapshot:/prometheus" --privileged prom/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=100000d --storage.tsdb.retention.size=1000PB
-```
+$ sudo podman pod create --name prometheus_grafana_pod -p 9090:9090 -p 3000:3000
+$ sudo podman run --name grafana --pod prometheus_grafana_pod -d --name=grafana grafana/grafana
+$ sudo podman run --name prometheus --pod prometheus_grafana_pod -uroot -v "$local_prometheus_snapshot:/prometheus" --privileged prom/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=100000d --storage.tsdb.retention.size=1000PB
 
-and point your browser at port 9090 on your local system, you can run queries against it, e. g.
+For removing pod:
+$ sudo podman pod rm -f prometheus_grafana_pod```
+
+1. Open http://localhost:9090/, you can run queries against it
+2. Open http://localhost:3000/, add prometheus data source and you can run queries against it
+3. Grafana: login with admin/admin and create prometheus data source: http://localhost:9090, create panel, select time and run query as code
+** Important: please select the exact file time: 2022_01_04T08_21_52+0000_2022_01_04T08_45_47+0000
 
 ```
+Example query: 
+
 sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
+
+[OpenShift example queries](https://github.com/redhat-performance/benchmark-runner/blob/main/benchmark_runner/common/prometheus/metrics-default.yaml)
+
 ```
 
 It is important to use the `--storage.tsdb.retention.time` option to


### PR DESCRIPTION
The main problem is that Perf CI is running more than 24 hours and that cause mixing data in Grafana dashboard 
This Pr split vdbench workload between odd and even week days because each vdbench run took ~1.5 hours.

1. Odd week days: **Sunday, Tuesday, Thursday, Saturday** - running vdbench scale workloads: 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale'
2. Even week days: **Monday, Wednesday, Friday** - running vdbench workloads: 'vdbench_pod', 'vdbench_kata', 'vdbench_vm'


