### PR TITLE
run Perf CI 3 days a week

### DIFF
--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -5,8 +5,8 @@ name: Deploy Func Env Nightly CI
 on:
   # Run on Nightly
   schedule:
-    - cron: '0 4 * * 1-6' # run Monday-Sunday at 4 AM UTC/ 0 AM EDT
-  # Run on weekly after assisted installer and operator completed
+    - cron: '0 4 * * 1-6' # run Monday-Saturday at 4 AM UTC/ 0 AM EDT
+  # Run on Sunday after assisted installer and operator completed
   workflow_run:
     workflows: ["Deploy Operator FUNC Env Weekly CI"]
     types:

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -6,8 +6,8 @@ name: Deploy Perf Env Nightly CI
 on:
   # Run on Nightly
   schedule:
-    - cron: '0 4 * * 0,2-6' # run Sunday, Tuesday-Sunday at 4 AM UTC/ 0 AM EDT
-  # Run on weekly after assisted installer and operator completed
+    - cron: '0 4 * * 3,5' # run Wednesday, Friday at 4 AM UTC/ 0 AM EDT
+  # Run on Monday after assisted installer and operator completed
   workflow_run:
     workflows: ["Deploy Operator Perf Env Weekly CI"]
     types:

--- a/docs/source/prometheus.md
+++ b/docs/source/prometheus.md
@@ -47,15 +47,28 @@ snapshot within is named
 `promdb_2022_01_04T08_21_52+0000_2022_01_04T08_45_47+0000`, you could run as follows:
 
 ```
+$ tar -xvf /hammerdb-vm-mariadb-2022-01-04-08-21-23/promdb_2022_01_04T08_21_52+0000_2022_01_04T08_45_47+0000.tar
 $ local_prometheus_snapshot=/hammerdb-vm-mariadb-2022-01-04-08-21-23/promdb_2022_01_04T08_21_52+0000_2022_01_04T08_45_47+0000
 $ chmod -R g-s,a+rw "$local_prometheus_snapshot"
-$ sudo podman run --rm -p 9090:9090 -uroot -v "$local_prometheus_snapshot:/prometheus" --privileged prom/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=100000d --storage.tsdb.retention.size=1000PB
-```
+$ sudo podman pod create --name prometheus_grafana_pod -p 9090:9090 -p 3000:3000
+$ sudo podman run --name grafana --pod prometheus_grafana_pod -d --name=grafana grafana/grafana
+$ sudo podman run --name prometheus --pod prometheus_grafana_pod -uroot -v "$local_prometheus_snapshot:/prometheus" --privileged prom/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=100000d --storage.tsdb.retention.size=1000PB
 
-and point your browser at port 9090 on your local system, you can run queries against it, e. g.
+For removing pod:
+$ sudo podman pod rm -f prometheus_grafana_pod```
+
+1. Open http://localhost:9090/, you can run queries against it
+2. Open http://localhost:3000/, add prometheus data source and you can run queries against it
+3. Grafana: login with admin/admin and create prometheus data source: http://localhost:9090, create panel, select time and run query as code
+** Important: please select the exact file time: 2022_01_04T08_21_52+0000_2022_01_04T08_45_47+0000
 
 ```
+Example query: 
+
 sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
+
+[OpenShift example queries](https://github.com/redhat-performance/benchmark-runner/blob/main/benchmark_runner/common/prometheus/metrics-default.yaml)
+
 ```
 
 It is important to use the `--storage.tsdb.retention.time` option to


### PR DESCRIPTION
**Problem:**

The current CI is running more than 24 hours and that cause to overlapping and mixing data in Grafana dashboard

**Solution:**

Run Perf CI 3 times a week: **Monday, Wednesday, Friday**
**Monday:** Run on Monday after assisted installer and operator completed
**Wednesday, Friday** - run Wednesday, Friday at 4 AM UTC/ 0 AM EDT

Every Cycle have up to 48 run hours

