### PR TITLE
Adding Bootstorm vm workload support

### DIFF
--- a/.github/workflows/Func_Env_Build_Test_CI.yml
+++ b/.github/workflows/Func_Env_Build_Test_CI.yml
@@ -71,7 +71,7 @@ jobs:
           # Install Dockerfile content for pytest
           # install oc/kubectl
           oc_version=4.11.0-0.okd-2022-10-15-073651
-          curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
+          curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
           tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
           rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
           cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl
@@ -139,7 +139,7 @@ jobs:
         # Install Dockerfile content for pytest
         # install oc/kubectl
         oc_version=4.11.0-0.okd-2022-10-15-073651
-        curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
+        curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
         tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
         rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
         cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl

--- a/.github/workflows/Func_Env_PR_Test_CI.yml
+++ b/.github/workflows/Func_Env_PR_Test_CI.yml
@@ -73,7 +73,7 @@ jobs:
           # Install Dockerfile content for pytest
           # install oc/kubectl
           oc_version=4.11.0-0.okd-2022-10-15-073651
-          curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
+          curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
           tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
           rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
           cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl
@@ -143,12 +143,19 @@ jobs:
         # Install Dockerfile content for pytest
         # install oc/kubectl
         oc_version=4.11.0-0.okd-2022-10-15-073651
-        curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
+        curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
         tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
         rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
         cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl
         cp $RUNNER_PATH/oc /usr/local/bin/oc
-
+        
+        # install virtctl for VNC
+        virtctl_version=0.52.0
+        curl -L "https://github.com/kubevirt/kubevirt/releases/download/v${virtctl_version}/virtctl-v${virtctl_version}-linux-amd64" -o  "$RUNNER_PATH/virtctl"
+        chmod +x $RUNNER_PATH/virtctl 
+        cp $RUNNER_PATH/virtctl /usr/local/bin/virtctl 
+        rm -rf $RUNNER_PATH/virtctl
+        
         # clone benchmark-operator v1.0.1
         git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
 
@@ -202,7 +209,7 @@ jobs:
        # Install Dockerfile content for pytest
        # install oc/kubectl
        oc_version=4.11.0-0.okd-2022-10-15-073651
-       curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
+       curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
        tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
        rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
        cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl

--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -91,7 +91,30 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix: 
-          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb',  'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
+          workload:
+              - 'uperf_pod'
+              - 'uperf_kata'
+              - 'uperf_vm'
+              - 'hammerdb_pod_mariadb'
+              - 'hammerdb_kata_mariadb'
+              - 'hammerdb_vm_mariadb'
+              - 'hammerdb_pod_postgres'
+              - 'hammerdb_kata_postgres'
+              - 'hammerdb_vm_postgres'
+              - 'hammerdb_pod_postgres_lso'
+              - 'hammerdb_kata_postgres_lso'
+              - 'hammerdb_vm_postgres_lso'
+              - 'hammerdb_pod_mssql'
+              - 'hammerdb_kata_mssql'
+              - 'hammerdb_vm_mssql'
+              - 'vdbench_pod'
+              - 'vdbench_kata'
+              - 'vdbench_vm'
+              - 'vdbench_pod_scale'
+              - 'vdbench_kata_scale'
+              - 'vdbench_vm_scale'
+              - 'clusterbuster'
+              - 'bootstorm_vm'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -157,6 +180,7 @@ jobs:
         LSO_PATH: ${{ secrets.FUNC_LSO_PATH }}
         TIMEOUT: 3600
         SCALE: 1
+        BOOTSTORM_SCALE: 10
         RUN_TYPE: 'func_ci'
       run: |
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
@@ -174,7 +198,7 @@ jobs:
         then
             ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
         else
-            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e LSO_PATH='$LSO_PATH' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
+            ssh -t provision "podman run --rm -t -e WORKLOAD='${{ matrix.workload }}' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e IBM_REGION_NAME='$IBM_REGION_NAME' -e IBM_ENDPOINT_URL='$IBM_ENDPOINT_URL' -e IBM_ACCESS_KEY_ID='$IBM_ACCESS_KEY_ID' -e IBM_SECRET_ACCESS_KEY='$IBM_SECRET_ACCESS_KEY' -e IBM_BUCKET='$IBM_BUCKET' -e IBM_KEY='$IBM_KEY' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='False' -e LSO_PATH='$LSO_PATH' -e SCALE='$BOOTSTORM_SCALE' -e SCALE_NODES=$SCALE_NODES -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"
         fi
         ssh -t provision "podman rmi -f 'quay.io/ebattat/benchmark-runner:latest'"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> End E2E workload: ${{ matrix.workload }} >>>>>>>>>>>>>>>>>>>>>>>>>>>>'

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -86,7 +86,29 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix: 
-          workload: [ 'uperf_pod', 'uperf_kata', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_pod_postgres', 'hammerdb_kata_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_kata_mssql', 'hammerdb_vm_mssql', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_kata_scale', 'vdbench_vm_scale', 'clusterbuster']
+          workload:
+              - 'uperf_pod'
+              - 'uperf_kata'
+              - 'uperf_vm'
+              - 'hammerdb_pod_mariadb'
+              - 'hammerdb_kata_mariadb'
+              - 'hammerdb_vm_mariadb'
+              - 'hammerdb_pod_postgres'
+              - 'hammerdb_kata_postgres'
+              - 'hammerdb_vm_postgres'
+              - 'hammerdb_pod_postgres_lso'
+              - 'hammerdb_kata_postgres_lso'
+              - 'hammerdb_vm_postgres_lso'
+              - 'hammerdb_pod_mssql'
+              - 'hammerdb_kata_mssql'
+              - 'hammerdb_vm_mssql'
+              - 'vdbench_pod'
+              - 'vdbench_kata'
+              - 'vdbench_vm'
+              - 'vdbench_pod_scale'
+              - 'vdbench_kata_scale'
+              - 'vdbench_vm_scale'
+              - 'clusterbuster'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,8 @@ include benchmark_runner/common/template_operations/templates/uperf/internal_dat
 include benchmark_runner/common/template_operations/templates/scale/*.yaml
 include benchmark_runner/common/template_operations/templates/vdbench/*.yaml
 include benchmark_runner/common/template_operations/templates/vdbench/internal_data/*.yaml
+include benchmark_runner/common/template_operations/templates/bootstorm/*.yaml
+include benchmark_runner/common/template_operations/templates/bootstorm/internal_data/*.yaml
 
 # ocp resource
 include benchmark_runner/common/ocp_resources/local_storage/template/*.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This framework support the following embedded workloads:
 * [stressng](https://wiki.ubuntu.com/Kernel/Reference/stress-ng): running stressng workload in Pod, Kata or VM [Configuration](benchmark_runner/common/template_operations/templates/stressng)
 * [uperf](http://uperf.org/): running uperf workload in Pod, Kata or VM with [Configuration](benchmark_runner/common/template_operations/templates/uperf)
 * [vdbench](https://wiki.lustre.org/VDBench/): running vdbench workload in Pod, Kata or VM with [Configuration](benchmark_runner/common/template_operations/templates/vdbench)
+* [bootstorm](https://en.wiktionary.org/wiki/boot_storm): calculate VMs boot load time [Configuration](benchmark_runner/common/template_operations/templates/bootstorm)
 
 Benchmark-runner grafana dashboard example:
 ![](media/grafana.png)
@@ -62,7 +63,7 @@ The following options may be passed via command line flags or set in the environ
 
 Choose one from the following list:
 
-`['stressng_pod', 'stressng_vm', 'stressng_kata', 'uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_kata_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_kata_mssql_lso', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'clusterbuster']`
+`['stressng_pod', 'stressng_vm', 'stressng_kata', 'uperf_pod', 'uperf_vm', 'uperf_kata', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb', 'hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_kata_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_kata_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_kata_mssql_lso', 'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'clusterbuster', 'bootstorm_vm']`
 
 ** clusterbuster workloads: cpusoaker, files, fio, uperf. for more details [see](https://github.com/RobertKrawitz/OpenShift4-tools)
 
@@ -88,11 +89,11 @@ Choose one from the following list:
 
 **optional:** CLUSTER=$CLUSTER [ set CLUSTER='kubernetes' to run workload on a kubernetes cluster, default 'openshift' ]
 
-**optional:** SCALE=$SCALE [For Vdbench only: Scale in each node]
+**optional:scale** SCALE=$SCALE [For Vdbench/Bootstorm: Scale in each node]
 
-**optional:** SCALE_NODES=$SCALE_NODES [For Vdbench only: Scale's node]
+**optional:scale** SCALE_NODES=$SCALE_NODES [For Vdbench/Bootstorm: Scale's node]
 
-**optional:** REDIS=$REDIS [For Vdbench only: redis for scale synchronization]
+**optional:scale** REDIS=$REDIS [For Vdbench only: redis for scale synchronization]
 
 **optional:** LSO_PATH=$LSO_PATH [LSO_PATH='/dev/sdb/' For hammerdb only: for using Local Storage Operator]
 

--- a/benchmark_runner/benchmark_operator/benchmark_operator_workloads_operations.py
+++ b/benchmark_runner/benchmark_operator/benchmark_operator_workloads_operations.py
@@ -8,6 +8,7 @@ from typeguard import typechecked
 
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.common.oc.oc import OC
+from benchmark_runner.common.virtctl.virtctl import Virtctl
 from benchmark_runner.common.template_operations.template_operations import TemplateOperations
 from benchmark_runner.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
 from benchmark_runner.common.ssh.ssh import SSH
@@ -68,6 +69,7 @@ class BenchmarkOperatorWorkloadsOperations:
         self._template = TemplateOperations(workload=self._workload)
         # set oc login
         self._oc = self.set_login(kubeadmin_password=self._kubeadmin_password)
+        self._virtctl = Virtctl()
         # PrometheusSnapshot
         if self._enable_prometheus_snapshot:
             self._snapshot = PrometheusSnapshot(oc=self._oc, artifacts_path=self._run_artifacts_path, verbose=True)
@@ -201,7 +203,6 @@ class BenchmarkOperatorWorkloadsOperations:
             else:
                 self._verify_elasticsearch_data_uploaded(index=es_index, uuid=self._oc.get_long_uuid(workload=workload), workload='system-metrics', fast_check=True)
 
-
     def __get_metadata(self, kind: str = None, database: str = None, status: str = None, run_artifacts_url: str = None, uuid: str = None) -> dict:
         """
         This method return metadata kind and database argument are optional
@@ -314,7 +315,7 @@ class BenchmarkOperatorWorkloadsOperations:
         vm_name = ''
         for label in labels:
             vm_name = self._oc.get_vm(label=label)
-            self._oc.save_vm_log(vm_name=vm_name)
+            self._virtctl.save_vm_log(vm_name=vm_name)
         return vm_name
 
     def _create_pod_log(self, label: str = '', database: str = '') -> str:

--- a/benchmark_runner/benchmark_operator/hammerdb_vm.py
+++ b/benchmark_runner/benchmark_operator/hammerdb_vm.py
@@ -43,7 +43,7 @@ class HammerdbVM(BenchmarkOperatorWorkloadsOperations):
             environment_variables.environment_variables_dict['kind'] = 'vm'
             self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{self.__database}.yaml'), vm_name=f'{self.__workload_name}-workload')
             # hammerdb workload and database
-            self._oc.wait_for_vm_create(vm_name=f'{self.__workload_name}-workload')
+            self._oc.wait_for_vm_creation(vm_name=f'{self.__workload_name}-workload')
             self._oc.wait_for_initialized(label='app=hammerdb_workload', workload=self.__workload_name)
             self._oc.wait_for_ready(label='app=hammerdb_workload', workload=self.__workload_name)
             # Create vm log should be direct after vm is ready

--- a/benchmark_runner/benchmark_operator/uperf_vm.py
+++ b/benchmark_runner/benchmark_operator/uperf_vm.py
@@ -38,11 +38,11 @@ class UperfVM(BenchmarkOperatorWorkloadsOperations):
             environment_variables.environment_variables_dict['kind'] = 'vm'
             self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name='uperf-server')
             # uperf server
-            self._oc.wait_for_vm_create(vm_name='uperf-server')
+            self._oc.wait_for_vm_creation(vm_name='uperf-server')
             self._oc.wait_for_initialized(label='app=uperf-bench-server-0', workload=self.__workload_name)
             self._oc.wait_for_ready(label='app=uperf-bench-server-0', workload=self.__workload_name)
             # client server
-            self._oc.wait_for_vm_create(vm_name='uperf-client')
+            self._oc.wait_for_vm_creation(vm_name='uperf-client')
             self._oc.wait_for_initialized(label='app=uperf-bench-client', workload=self.__workload_name)
             self._oc.wait_for_ready(label='app=uperf-bench-client', workload=self.__workload_name)
             # Create vm log should be direct after vm is ready

--- a/benchmark_runner/common/clouds/IBM/ibm_operations.py
+++ b/benchmark_runner/common/clouds/IBM/ibm_operations.py
@@ -30,6 +30,7 @@ class IBMOperations:
     This class is responsible for all IBM cloud operations, all commands run on remote provision IBM host
     """
     LATEST = 'latest'
+    SHORT_TIMEOUT = 600
 
     @typechecked
     def __init__(self, user: str):
@@ -107,7 +108,7 @@ class IBMOperations:
         """
         self.__remote_ssh.run_command(command=f'ibmcloud sl hardware {action} {machine_id} -f')
 
-    def __wait_for_active_machine(self, machine_id: str, sleep_time=10, timeout=600):
+    def __wait_for_active_machine(self, machine_id: str, sleep_time=10, timeout=SHORT_TIMEOUT):
         """
         This method wait till machine will be active
         :param machine_id:
@@ -122,14 +123,14 @@ class IBMOperations:
             current_wait_time += sleep_time
         raise IBMMachineNotLoad()
 
-    def __wait_for_install_complete(self, sleep_time: int = 600):
+    def __wait_for_install_complete(self, sleep_time: int = SHORT_TIMEOUT):
         """
         This method wait till ocp install complete
         :param sleep_time:
         :return:
         """
         current_wait_time = 0
-        while current_wait_time <= self.__provision_timeout:
+        while self.__provision_timeout <= 0 or current_wait_time <= self.__provision_timeout:
             install_log = self.__remote_ssh.run_command(self.__provision_installer_log)
             if 'failed=0' in install_log:
                 return True

--- a/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
+++ b/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
@@ -122,13 +122,15 @@ class ElasticSearchOperations:
 
     @typechecked()
     @logger_time_stamp
-    def verify_elasticsearch_data_uploaded(self, index: str, uuid: str = '', workload: str = '', fast_check: bool = False, timeout: int = None, es_fetch_min_time: int = None):
+    def verify_elasticsearch_data_uploaded(self, index: str, uuid: str = '', workload: str = '',
+                                           fast_check: bool = False, timeout: int = None, es_fetch_min_time: int = None):
         """
         The method wait till data upload to elastic search and wait if there is new data, search in last 15 minutes
         :param es_fetch_min_time:
         :param index:
         :param uuid: the current workload uuid
         :param workload: workload name only if there is a different timestamp parameter name in elasticsearch
+        :param timeout:
         :param fast_check: return response on first doc
 
         :return:
@@ -137,7 +139,7 @@ class ElasticSearchOperations:
         current_hits = 0
         self.__timeout = timeout if timeout else self.__timeout
         # waiting for any hits
-        while current_wait_time <= self.__timeout:
+        while self.__timeout <= 0 or current_wait_time <= self.__timeout:
             # waiting for new hits
             new_hits = self.__elasticsearch_get_index_hits(index=index, uuid=uuid, fast_check=fast_check, es_fetch_min_time=es_fetch_min_time)
             if current_hits < new_hits:

--- a/benchmark_runner/common/oc/oc_exceptions.py
+++ b/benchmark_runner/common/oc/oc_exceptions.py
@@ -96,6 +96,13 @@ class VMNotReadyTimeout(OCError):
         super(VMNotReadyTimeout, self).__init__(self.message)
 
 
+class VMStateTimeout(OCError):
+    """This exception indicates timeout for VM state """
+    def __init__(self, vm_name, state):
+        self.message = f'VM: {vm_name} does not reach to start: {state}'
+        super(VMStateTimeout, self).__init__(self.message)
+
+
 class VMNotCompletedTimeout(OCError):
     """This exception return vm completed error"""
     def __init__(self, workload):

--- a/benchmark_runner/common/ocp_resources/create_kata.py
+++ b/benchmark_runner/common/ocp_resources/create_kata.py
@@ -29,8 +29,9 @@ class CreateKata(CreateOCPResourceOperations):
         :param resource: name of resource to create
         :return:
         """
+        timeout = int(environment_variables.environment_variables_dict['timeout'])
         current_wait_time = 0
-        while current_wait_time < int(environment_variables.environment_variables_dict['timeout']):
+        while timeout <= 0 or current_wait_time < timeout:
             self.__oc._create_async(yaml_file)
             # We cannot wait for a condition here, because the
             # create_async may simply not work even if it returns success.

--- a/benchmark_runner/common/ocp_resources/create_ocp_resource_operations.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource_operations.py
@@ -45,8 +45,9 @@ class CreateOCPResourceOperations:
             :param resource: name of resource to create
             :return:
             """
+            timeout = int(environment_variables.environment_variables_dict['timeout'])
             current_wait_time = 0
-            while current_wait_time < int(environment_variables.environment_variables_dict['timeout']):
+            while timeout <= 0 or current_wait_time < timeout:
                 self.__oc._create_async(yaml_file)
                 # We cannot wait for a condition here, because the
                 # create_async may simply not work even if it returns success.
@@ -70,7 +71,7 @@ class CreateOCPResourceOperations:
         :return: True if met the result
         """
         current_wait_time = 0
-        while current_wait_time <= timeout:
+        while timeout <= 0 or current_wait_time <= timeout:
             # Count openshift-storage/ pv
             if count_openshift_storage:
                 if int(self.__oc.run(verify_cmd)) == self.__oc.get_num_active_nodes() * int(environment_variables.environment_variables_dict['num_odf_disk']):

--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -82,7 +82,7 @@ class TemplateOperations:
                 **extra_data, **extra_kind_data, **extra_runtype_data, **extra_kind_runtype_data}
 
     @logger_time_stamp
-    def generate_yamls_internal(self, scale: str = None, scale_node: str = None):
+    def generate_yamls_internal(self, scale: str = None, scale_node: str = None, redis: str = None):
         """
         Generate required .yaml files as a dictionary of file names and contents
         :return: Dictionary <filename:contents>
@@ -144,8 +144,10 @@ class TemplateOperations:
                 template = Template(f.read())
             answer[filename] = f"{template.render(render_data)}\n"
             if scale:
-                answer['redis.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='redis.yaml', environment_variable_dict=self.__environment_variables_dict)
-                answer['state_signals_exporter_pod.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='state_signals_exporter_pod.yaml', environment_variable_dict=self.__environment_variables_dict)
+                answer['namespace.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='namespace.yaml', environment_variable_dict=self.__environment_variables_dict)
+                if redis:
+                    answer['redis.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='redis.yaml', environment_variable_dict=self.__environment_variables_dict)
+                    answer['state_signals_exporter_pod.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='state_signals_exporter_pod.yaml', environment_variable_dict=self.__environment_variables_dict)
         return answer
 
     @logger_time_stamp
@@ -155,7 +157,7 @@ class TemplateOperations:
                 f.write(data)
 
     @logger_time_stamp
-    def generate_yamls(self, scale: str = '', scale_nodes: list = []):
+    def generate_yamls(self, scale: str = '', scale_nodes: list = [], redis: str = None):
         """
         This method generate workload yaml from template
         :return:
@@ -170,7 +172,7 @@ class TemplateOperations:
                 for scale_node in range(len(scale_nodes)):
                     for scale_num in range(scale):
                         count += 1
-                        p = Process(target=self.generate_files, args=(self.generate_yamls_internal(scale=str(count), scale_node=scale_nodes[scale_node]), ))
+                        p = Process(target=self.generate_files, args=(self.generate_yamls_internal(scale=str(count), scale_node=scale_nodes[scale_node], redis=redis), ))
                         p.start()
                         proc.append(p)
                     for p in proc:

--- a/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
@@ -1,0 +1,22 @@
+metadata:
+  name: bootstorm
+template_data:
+  shared:
+    pin_node: {{ pin_node1 }}
+    odf_pvc: {{ odf_pvc }}
+    uuid: {{ uuid }}
+    fedora_container_disk: quay.io/ebattat/fedora36-container-disk:latest
+  run_type:
+    perf_ci:
+      limits_memory: 1Gi
+      requests_memory: 10Mi
+    default:
+      limits_memory: 1Gi
+      requests_memory: 10Mi
+  kind:
+    vm:
+      run_type:
+        perf_ci:
+          sockets: 1
+        default:
+          sockets: 1

--- a/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
@@ -1,0 +1,70 @@
+{%- if not scale %}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+---
+{%- endif %}
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  {% if scale -%}
+  name: bootstorm-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+  {%- else -%}
+  name: bootstorm-{{ kind }}-{{ trunc_uuid }}
+  {%- endif %}
+  namespace: {{ namespace }}
+  labels:
+    {% if scale -%}
+    app: bootstorm-{{ trunc_uuid }}-{{ scale }}
+    type: bootstorm-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+    {%- else -%}
+    app: bootstorm-{{ trunc_uuid }}
+    type: bootstorm-{{ kind }}-{{ trunc_uuid }}
+    {%- endif %}
+    benchmark-uuid: {{uuid }}
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      {%- if pin_node1 or scale_node %}
+      nodeSelector:
+        {% if scale -%}
+        kubernetes.io/hostname: {{ scale_node }}
+        {%- else -%}
+        kubernetes.io/hostname: {{ pin_node1 }}
+        {%- endif %}
+      {%- endif %}
+      domain:
+        cpu:
+          sockets: {{ sockets }}
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: {{ requests_memory }}
+          limits:
+            memory: {{ limits_memory }}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: {{ fedora_container_disk }}
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/benchmark_runner/common/template_operations/templates/scale/namespace.yaml
+++ b/benchmark_runner/common/template_operations/templates/scale/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -39,10 +39,10 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {% if not scale -%}
-  name: vdbench-pod-pvc-claim
-  {%- else -%}
+  {% if scale -%}
   name: vdbench-pod-pvc-claim-{{ scale }}
+  {%- else -%}
+  name: vdbench-pod-pvc-claim
   {%- endif %}
   namespace: {{ namespace }}
 spec:
@@ -57,10 +57,10 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  {% if not scale -%}
-  name: vdbench-{{ kind }}-{{ trunc_uuid }}
-  {%- else -%}
+  {% if scale -%}
   name: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+  {%- else -%}
+  name: vdbench-{{ kind }}-{{ trunc_uuid }}
   {%- endif %}
   namespace: {{ namespace }}
   annotations:
@@ -68,12 +68,12 @@ metadata:
     io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
     {%- endif %}
   labels:
-    {% if not scale -%}
-    app: vdbench-{{ trunc_uuid }}
-    type: vdbench-{{ kind }}-{{ trunc_uuid }}
-    {%- else -%}
+    {% if scale -%}
     app: vdbench-{{ trunc_uuid }}-{{ scale }}
     type: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+    {%- else -%}
+    app: vdbench-{{ trunc_uuid }}
+    type: vdbench-{{ kind }}-{{ trunc_uuid }}
     {%- endif %}
     benchmark-uuid: {{ uuid }}
     benchmark-runner-workload: vdbench
@@ -91,10 +91,10 @@ spec:
   {%- endif %}
   {%- if pin_node1 or scale_node %}
   nodeSelector:
-    {% if not scale -%}
-    kubernetes.io/hostname: {{ pin_node1 }}
-    {%- else -%}
+    {% if scale -%}
     kubernetes.io/hostname: {{ scale_node }}
+    {%- else -%}
+    kubernetes.io/hostname: {{ pin_node1 }}
     {%- endif %}
   {%- endif %}
   {%- if kind == 'kata' %}
@@ -118,10 +118,10 @@ spec:
       {%- endif %}
       {%- if odf_pvc == True %}
       volumeMounts:
-        {% if not scale -%}
-        - name: vdbench-pod-pvc-claim
-        {%- else -%}
+        {% if scale -%}
         - name: vdbench-pod-pvc-claim-{{ scale }}
+        {%- else -%}
+        - name: vdbench-pod-pvc-claim
         {%- endif %}
           mountPath: "/workload"
       {%- endif %}
@@ -168,10 +168,10 @@ spec:
         - name: TIMEOUT
           value: "{{ timeout }}"
       command: ["/bin/bash"]
-      {% if not scale -%}
-      args: ["-c", "$WORKLOAD_METHOD"]
-      {%- else -%}
+      {% if scale -%}
       args: ["-c", "python3.9 /state_signals_responder.py $REDIS_HOST $WORKLOAD_METHOD $TIMEOUT"]
+      {%- else -%}
+      args: ["-c", "$WORKLOAD_METHOD"]
       {%- endif %}
   restartPolicy: "Never"
   {%- if cluster != "kubernetes" %}
@@ -189,16 +189,15 @@ spec:
   {%- endif %}
   {%- if odf_pvc == True %}
   volumes:
-    {% if not scale -%}
-    - name: vdbench-pod-pvc-claim
-      namespace: {{ namespace }}
-      persistentVolumeClaim:
-        claimName: vdbench-pod-pvc-claim
-    {%- else -%}
+    {% if scale -%}
     - name: vdbench-pod-pvc-claim-{{ scale }}
       namespace: {{ namespace }}
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim-{{ scale }}
+    {%- else -%}
+    - name: vdbench-pod-pvc-claim
+      namespace: {{ namespace }}
+      persistentVolumeClaim:
+        claimName: vdbench-pod-pvc-claim
     {%- endif %}
   {%- endif %}
-

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -3,16 +3,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ namespace }}
+---
 {%- endif %}
 {%- if odf_pvc == True %}
----
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
-  {% if not scale -%}
-  name: vdbench-pvc-claim
-  {%- else -%}
+  {% if scale -%}
   name: vdbench-pvc-claim-{{ scale }}
+  {%- else -%}
+  name: vdbench-pvc-claim
   {%- endif %}
   namespace: {{ namespace }}
 spec:
@@ -22,24 +22,24 @@ spec:
   resources:
     requests:
       storage: {{ storage }}
-{%- endif %}
 ---
+{%- endif %}
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  {% if not scale -%}
-  name: vdbench-{{ kind }}-{{ trunc_uuid }}
-  {%- else -%}
+  {% if scale -%}
   name: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+  {%- else -%}
+  name: vdbench-{{ kind }}-{{ trunc_uuid }}
   {%- endif %}
   namespace: {{ namespace }}
   labels:
-    {% if not scale -%}
-    app: vdbench-{{ trunc_uuid }}
-    type: vdbench-{{ kind }}-{{ trunc_uuid }}
-    {%- else -%}
+    {% if scale -%}
     app: vdbench-{{ trunc_uuid }}-{{ scale }}
     type: vdbench-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
+    {%- else -%}
+    app: vdbench-{{ trunc_uuid }}
+    type: vdbench-{{ kind }}-{{ trunc_uuid }}
     {%- endif %}
     benchmark-uuid: {{ uuid }}
     benchmark-runner-workload: vdbench
@@ -52,10 +52,10 @@ spec:
     spec:
       {%- if pin_node1 or scale_node %}
       nodeSelector:
-        {% if not scale -%}
-        kubernetes.io/hostname: {{ pin_node1 }}
-        {%- else -%}
+        {% if scale -%}
         kubernetes.io/hostname: {{ scale_node }}
+        {%- else -%}
+        kubernetes.io/hostname: {{ pin_node1 }}
         {%- endif %}
       {%- endif %}
       domain:
@@ -89,14 +89,14 @@ spec:
 {%- if odf_pvc == True %}
         - name: data-volume
           persistentVolumeClaim:
-            {% if not scale -%}
-            claimName: vdbench-pvc-claim
-            {%- else -%}
+            {% if scale -%}
             claimName: vdbench-pvc-claim-{{ scale }}
+            {%- else -%}
+            claimName: vdbench-pvc-claim
             {%- endif %}
 {%- endif %}
         - containerDisk:
-            image: {{ centos_stream8_container_disk }}
+            image: {{ centos_stream_container_disk }}
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-
@@ -127,10 +127,10 @@ spec:
                 - export TIMEOUT={{ timeout }}
                 - export LOGS_DIR={{ LOGS_DIR }}
                 - echo @@~@@START-WORKLOAD@@~@@
-                {% if not scale -%}
-                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged {{ vdbench_image }} "$WORKLOAD_METHOD"
-                {%- else -%}
+                {% if scale -%}
                 - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e  MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e  PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged {{ vdbench_image }} python3.9 /state_signals_responder.py "$REDIS_HOST" "$WORKLOAD_METHOD" "$TIMEOUT"
+                {%- else -%}
+                - podman run --rm -e BLOCK_SIZES="$BLOCK_SIZES" -e IO_OPERATION="$IO_OPERATION" -e IO_THREADS="$IO_THREADS" -e FILES_IO="$FILES_IO" -e IO_RATE="$IO_RATE" -e MIX_PRECENTAGE="$MIX_PRECENTAGE" -e DURATION="$DURATION" -e PAUSE="$PAUSE" -e WARMUP="$WARMUP" -e FILES_SELECTION="$FILES_SELECTION" -e COMPRESSION_RATIO="$COMPRESSION_RATIO" -e RUN_FILLUP="$RUN_FILLUP" -e DIRECTORIES="$DIRECTORIES" -e FILES_PER_DIRECTORY="$FILES_PER_DIRECTORY" -e SIZE_PER_FILE="$SIZE_PER_FILE" -e REDIS_HOST="$REDIS_HOST" -e LOGS_DIR="$LOGS_DIR" -e TIMEOUT="$TIMEOUT" -v "/workload":"/workload" --privileged {{ vdbench_image }} "$WORKLOAD_METHOD"
                 {%- endif %}
                 - echo @@~@@END-WORKLOAD@@~@@
           name: cloudinitdisk

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -6,7 +6,7 @@ template_data:
     odf_pvc: {{ odf_pvc }}
     uuid: {{ uuid }}
     vdbench_image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
-    centos_stream8_container_disk: quay.io/ebattat/centos-stream8-container-disk:latest
+    centos_stream_container_disk: quay.io/ebattat/centos-stream8-container-disk:latest
   run_type:
     perf_ci:
       BLOCK_SIZES: oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64

--- a/benchmark_runner/common/virtctl/virtctl.py
+++ b/benchmark_runner/common/virtctl/virtctl.py
@@ -1,0 +1,87 @@
+
+import os
+from typeguard import typechecked
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.oc.oc import OC, VMStatus
+from benchmark_runner.main.environment_variables import environment_variables
+
+
+class Virtctl(OC):
+    """
+    Interface to virtctl command
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    @typechecked
+    @logger_time_stamp
+    def save_vm_log(self, vm_name: str, output_filename: str = '', namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        This method save vm log in log_path
+        :param vm_name: vm name with uuid
+        :param output_filename:
+        """
+        if not output_filename:
+            output_filename = os.path.join(self._run_artifacts, vm_name)
+        namespace = f'-n {namespace}' if namespace else ''
+        self.run(cmd=f"virtctl console {namespace} {vm_name} > {output_filename}", background=True)
+
+    @typechecked
+    @logger_time_stamp
+    def stop_vm_async(self, vm_name: str, namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        The method stop vm
+        @param vm_name:
+        @param namespace:
+        @return: command output
+        """
+        namespace = f'-n {namespace}' if namespace else ''
+        return self.run(cmd=f'virtctl stop {vm_name} {namespace}')
+
+    @typechecked
+    @logger_time_stamp
+    def stop_vm_sync(self, vm_name: str, namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        The method stop vm and wait till stopped
+        @param vm_name:
+        @return: True or Error
+        """
+        self.stop_vm_async(vm_name=vm_name, namespace=namespace)
+        return self.wait_for_vm_status(vm_name=vm_name, status=VMStatus.Stopped, namespace=namespace)
+
+    @typechecked
+    @logger_time_stamp
+    def start_vm_async(self, vm_name: str, namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        The method start vm
+        @param vm_name:
+        @param namespace:
+        @return: command output
+        """
+        namespace = f'-n {namespace}' if namespace else ''
+        return self.run(cmd=f'virtctl start {vm_name} {namespace}')
+
+    @typechecked
+    @logger_time_stamp
+    def start_vm_sync(self, vm_name: str, namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        The method start vm and wait till running
+        @param vm_name:
+        @return: True or Error
+        """
+        self.start_vm_async(vm_name=vm_name, namespace=namespace)
+        return self.wait_for_vm_status(vm_name=vm_name, status=VMStatus.Running, namespace=namespace)
+
+    @typechecked
+    @logger_time_stamp
+    def expose_vm(self, vm_name: str, namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        The method expose vm
+        @param vm_name:
+        """
+        namespace = f'-n {namespace}' if namespace else ''
+        self.run(cmd=f'virtctl expose vm {vm_name} --name {vm_name} {namespace} --port 27022 --target-port 22 --type NodePort')
+
+

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -25,11 +25,12 @@ class EnvironmentVariables:
             try:
                 with open(env) as f:
                     for line in f.readlines():
-                        key, found , value = line.strip().partition("=")
+                        key, found, value = line.strip().partition("=")
                         if not found:
                             print("ERROR: invalid line in {env}: {line.strip()}")
                             continue
-                        if key in os.environ: continue # prefer env to env file
+                        if key in os.environ:
+                            continue  # prefer env to env file
                         os.environ[key] = value
 
             except FileNotFoundError:
@@ -39,7 +40,7 @@ class EnvironmentVariables:
         # dynamic parameters - configure for local run
         # parameters for running workload
 
-        # This path is github actions runner path (benchmark-operator should be cloned here)
+        # This path is GitHub actions runner path (benchmark-operator should be cloned here)
         self._environment_variables_dict['runner_path'] = EnvironmentVariables.get_env('RUNNER_PATH', '/tmp')
         # This path is for vm/pod/prometheus run artifacts
         self._environment_variables_dict['run_artifacts'] = EnvironmentVariables.get_env('RUN_ARTIFACTS', os.path.join(self._environment_variables_dict['runner_path'], 'benchmark-runner-run-artifacts'))
@@ -84,7 +85,7 @@ class EnvironmentVariables:
                                                          'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql',
                                                          'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_kata_mssql_lso',
                                                          'vdbench_pod', 'vdbench_kata', 'vdbench_vm',
-                                                         'clusterbuster']
+                                                         'clusterbuster', 'bootstorm_vm']
         # Workloads namespaces
         self._environment_variables_dict['workload_namespaces'] = {
             'stressng': 'benchmark-operator',
@@ -92,6 +93,7 @@ class EnvironmentVariables:
             'uperf': 'benchmark-operator',
             'vdbench': 'benchmark-runner',
             'clusterbuster': 'clusterbuster',
+            'bootstorm': 'benchmark-runner'
         }
 
         # Update namespace
@@ -208,7 +210,7 @@ class EnvironmentVariables:
         self._environment_variables_dict['ocp_env_flavor'] = EnvironmentVariables.get_env('OCP_ENV_FLAVOR', 'FUNC')
         # IBM data
         self._environment_variables_dict['ibm_api_key'] = EnvironmentVariables.get_env('IBM_API_KEY', '')
-        # github token
+        # GitHub token
         self._environment_variables_dict['github_token'] = EnvironmentVariables.get_env('GITHUB_TOKEN', '')
         self._environment_variables_dict['worker_ids'] = EnvironmentVariables.get_env(f'WORKER_IDS', "")
         self._environment_variables_dict['provision_ip'] = EnvironmentVariables.get_env(f'PROVISION_IP', '')
@@ -225,9 +227,9 @@ class EnvironmentVariables:
         self._environment_variables_dict['provision_installer_path'] = EnvironmentVariables.get_env(f'PROVISION_INSTALLER_PATH', '')
         self._environment_variables_dict['provision_installer_cmd'] = EnvironmentVariables.get_env(f'PROVISION_INSTALLER_CMD', '')
         self._environment_variables_dict['provision_installer_log'] = EnvironmentVariables.get_env(f'PROVISION_INSTALLER_LOG', '')
-        # remote ssh timeout - 3 hours for installation time
+        # timeout 0<=: forever, >0: second (installer)
         self._environment_variables_dict['provision_timeout'] = EnvironmentVariables.get_env(f'PROVISION_TIMEOUT', '10800')
-        # General timeout - 1.5 hours wait for pod/vm/upload data to elasticsearch
+        # timeout 0<=: forever, >0: second
         self._environment_variables_dict['timeout'] = EnvironmentVariables.get_env(f'TIMEOUT', '3600')
 
         # Benchmark runner run artifacts url

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -1,0 +1,123 @@
+
+import os
+from multiprocessing import Process
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
+from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
+from benchmark_runner.common.oc.oc import VMStatus
+
+
+class BootstormVM(WorkloadsOperations):
+    """
+    This class run bootstorm vm
+    """
+    START_STAMP = '@@~@@START-WORKLOAD@@~@@'
+    END_STAMP = '@@~@@END-WORKLOAD@@~@@'
+
+    def __init__(self):
+        super().__init__()
+        self.__name = ''
+        self.__workload_name = ''
+        self.__es_index = ''
+        self.__kind = ''
+        self.__status = ''
+        self.__pod_name = ''
+        self.__vm_name = ''
+        self.__data_dict = {}
+
+    def __create_vm_scale(self, vm_num: str):
+        """
+        This method creates vms in parallel
+        """
+        self._oc._create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{vm_num}.yaml'))
+        self._oc.wait_for_vm_status(vm_name=f'bootstorm-vm-{self._trunc_uuid}-{vm_num}', status=VMStatus.Stopped)
+
+    def __run_vm_scale(self, vm_num: str):
+        """
+        This method runs vms in parallel
+        """
+        vm_name = f'bootstorm-vm-{self._trunc_uuid}-{vm_num}'
+        self.set_bootstorm_vm_start_time(vm_name=vm_name)
+        self._virtctl.start_vm_sync(vm_name=vm_name)
+        self.__data_dict = self.get_bootstorm_vm_elapse_time(vm_name=vm_name)
+        self.__status = 'complete' if self.__data_dict else 'failed'
+        if self._es_host:
+            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=self.__data_dict)
+            # verify that data upload to elastic search according to unique uuid
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+    def __delete_vm_scale(self, vm_num: str):
+        """
+        This method deletes vms in parallel
+        """
+        vm_name = f'bootstorm-vm-{self._trunc_uuid}-{vm_num}'
+        self._oc.delete_vm_sync(
+            yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{vm_num}.yaml'),
+            vm_name=vm_name)
+
+    @logger_time_stamp
+    def run(self):
+        """
+        This method runs the workload
+        :return:
+        """
+        try:
+            self.__name = self._workload
+            if self._run_type == 'test_ci':
+                self.__es_index = 'bootstorm-test-ci-results'
+            else:
+                self.__es_index = 'bootstorm-results'
+            self.__workload_name = self._workload.replace('_', '-')
+            self.__vm_name = f'{self.__workload_name}-{self._trunc_uuid}'
+            self.__kind = 'vm'
+            self._environment_variables_dict['kind'] = 'vm'
+            if not self._scale:
+                self._oc._create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'))
+                self._oc.wait_for_vm_status(vm_name=f'bootstorm-vm-{self._trunc_uuid}', status=VMStatus.Stopped)
+                self.set_bootstorm_vm_start_time(vm_name=self.__vm_name)
+                self._virtctl.start_vm_sync(vm_name=self.__vm_name)
+                self.__data_dict = self.get_bootstorm_vm_elapse_time(vm_name=self.__vm_name)
+                self.__status = 'complete' if self.__data_dict else 'failed'
+                if self._es_host:
+                    # upload several run results
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=self.__data_dict)
+                    # verify that data upload to elastic search according to unique uuid
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+                self._oc.delete_vm_sync(
+                    yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
+                    vm_name=self.__vm_name)
+            # scale
+            else:
+                # create namespace
+                self._oc._create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+                # create redis and state signals
+                proc = []
+                scale = int(self._scale)
+                self.__data_dict['scale'] = scale
+                for target in [self.__create_vm_scale, self.__run_vm_scale, self.__delete_vm_scale]:
+                    # create vms in parallel
+                    count = 0
+                    for scale_node in range(len(self._scale_node_list)):
+                        for scale_num in range(scale):
+                            count += 1
+                            p = Process(target=target, args=(str(count),))
+                            p.start()
+                            proc.append(p)
+                    for p in proc:
+                        p.join()
+                # delete namespace
+                self._oc._delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+        except ElasticSearchDataNotUploaded as err:
+            self._oc.delete_vm_sync(
+                yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
+                vm_name=self.__vm_name)
+            raise err
+        except Exception as err:
+            # save run artifacts logs
+            if self._es_host:
+                self.__data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
+                self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=self.__data_dict)
+                # verify that data upload to elastic search according to unique uuid
+                self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+            raise err

--- a/benchmark_runner/workloads/workloads_exceptions.py
+++ b/benchmark_runner/workloads/workloads_exceptions.py
@@ -12,3 +12,21 @@ class ODFNonInstalled(BenchmarkRunnerError):
     def __init__(self):
         self.message = "ODF is not installed, set 'ODF_PVC' to False"
         super(ODFNonInstalled, self).__init__(self.message)
+
+
+class MissingScaleNodes(BenchmarkRunnerError):
+    """
+    This class is error that Missing scale nodes
+    """
+    def __init__(self):
+        self.message = "Missing scale nodes"
+        super(MissingScaleNodes, self).__init__(self.message)
+
+
+class MissingRedis(BenchmarkRunnerError):
+    """
+    This class is error that Missing redis for scale synchronization
+    """
+    def __init__(self):
+        self.message = "Missing redis"
+        super(MissingRedis, self).__init__(self.message)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -12,6 +12,7 @@ This framework support the following embedded workloads:
 * [stressng](https://wiki.ubuntu.com/Kernel/Reference/stress-ng): running stressng workload in Pod, Kata or VM [Configuration](benchmark_runner/common/template_operations/templates/stressng)
 * [uperf](http://uperf.org/): running uperf workload in Pod, Kata or VM with [Configuration](benchmark_runner/common/template_operations/templates/uperf)
 * [vdbench](https://wiki.lustre.org/VDBench/): running vdbench workload in Pod, Kata or VM with [Configuration](benchmark_runner/common/template_operations/templates/vdbench)
+* [bootstorm](https://en.wiktionary.org/wiki/boot_storm): calculate VMs boot load time [Configuration](benchmark_runner/common/template_operations/templates/bootstorm)
 
 Benchmark-runner grafana dashboard example:
 ![](../../media/grafana.png)

--- a/docs/source/podman.md
+++ b/docs/source/podman.md
@@ -39,11 +39,11 @@ Choose one from the following list:
 
 **optional:** CLUSTER=$CLUSTER [ set CLUSTER='kubernetes' to run workload on a kubernetes cluster, default 'openshift' ]
 
-**optional:** SCALE=SCALE [For Vdbench only: Scale in each node]
+**optional:scale** SCALE=$SCALE [For Vdbench/Bootstorm: Scale in each node]
 
-**optional:** SCALE_NODES=SCALE_NODES [For Vdbench only: Scale's node]
+**optional:scale** SCALE_NODES=$SCALE_NODES [For Vdbench/Bootstorm: Scale's node]
 
-**optional:** REDIS=REDIS [For Vdbench only: redis for scale synchronization]
+**optional:scale** REDIS=$REDIS [For Vdbench only: redis for scale synchronization]
 
 **optional:** LSO_PATH=$LSO_PATH [LSO_PATH='/dev/sdb/' For hammerdb only: for using Local Storage Operator]
 

--- a/tests/integration/benchmark_runner/common/oc/test_oc_benchmark_operator.py
+++ b/tests/integration/benchmark_runner/common/oc/test_oc_benchmark_operator.py
@@ -90,7 +90,7 @@ def test_yaml_file_not_exist_error():
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.login()
     with pytest.raises(YAMLNotExist) as err:
-        oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng1.yaml'), pod_name='stressng-pod-workload', timeout=-1)
+        oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng1.yaml'), pod_name='stressng-pod-workload', timeout=1)
 
 
 def test_create_sync_pod_timeout_error():
@@ -101,7 +101,7 @@ def test_create_sync_pod_timeout_error():
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.login()
     with pytest.raises(PodNotCreateTimeout) as err:
-        oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod.yaml'), pod_name='stressng-pod-workload', timeout=-1)
+        oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod.yaml'), pod_name='stressng-pod-workload', timeout=1)
 
 
 def test_delete_sync_pod_timeout_error():
@@ -113,7 +113,7 @@ def test_delete_sync_pod_timeout_error():
     oc.login()
     oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod.yaml'), pod_name='stressng-pod-workload')
     with pytest.raises(PodTerminateTimeout) as err:
-        oc.delete_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod.yaml'), pod_name='stressng-pod-workload', timeout=-1)
+        oc.delete_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod.yaml'), pod_name='stressng-pod-workload', timeout=1)
 
 
 def test_get_long_short_uuid():
@@ -166,7 +166,6 @@ def test_wait_for_kata_create_initialized_ready_completed_system_metrics_deleted
     assert oc.wait_for_pod_completed(label='app=system-metrics-collector', workload=workload)
     assert oc.delete_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_kata.yaml'), pod_name='stressng-kata-workload')
 
-
 ###################################################### VM Tests ##################################################
 
 
@@ -178,7 +177,7 @@ def test_create_sync_vm_timeout_error():
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.login()
     with pytest.raises(VMNotCreateTimeout) as err:
-        oc.create_vm_sync(yaml=os.path.join(f'{templates_path}', 'stressng_vm.yaml'), vm_name='stressng-vm-workload', timeout=-1)
+        oc.create_vm_sync(yaml=os.path.join(f'{templates_path}', 'stressng_vm.yaml'), vm_name='stressng-vm-workload', timeout=1)
 
 
 @pytest.mark.skip(reason="Already verified in: test_vm_create_initialized_ready_completed_system_metrics_deleted ")
@@ -205,7 +204,7 @@ def test_wait_for_vm_created():
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.login()
     oc._create_async(yaml=os.path.join(f'{templates_path}', 'stressng_vm.yaml'))
-    assert oc.wait_for_vm_create(vm_name='stressng-vm-workload')
+    assert oc.wait_for_vm_creation(vm_name='stressng-vm-workload')
 
 
 def test_vm_create_initialized_ready_completed_system_metrics_deleted():

--- a/tests/integration/benchmark_runner/common/oc/test_oc_benchmark_runner.py
+++ b/tests/integration/benchmark_runner/common/oc/test_oc_benchmark_runner.py
@@ -1,7 +1,5 @@
 
 # Tests that run benchmark-runner workloads
-import os
-import time
 
 import pytest
 from benchmark_runner.common.oc.oc import OC
@@ -64,9 +62,9 @@ def before_after_each_test_fixture():
     print('Test End')
 
 
-def test_benchmark_runner_pod_create_initialized_ready_completed_deleted():
+def test_benchmark_runner_pod_create_initialized_ready_complete_delete():
     """
-    This method test wait for pod create, initialized, ready, completed
+    This method test wait for pod create, initialized, ready, complete, delete
     :return:
     """
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
@@ -77,9 +75,9 @@ def test_benchmark_runner_pod_create_initialized_ready_completed_deleted():
     assert oc.wait_for_pod_completed(label='app=vdbench', label_uuid=False, job=False, namespace=test_environment_variable['namespace'])
 
 
-def test_benchmark_runner_kata_create_initialized_ready_completed_deleted():
+def test_benchmark_runner_kata_create_initialized_ready_complete_delete():
     """
-    This method test wait for kata create, initialized, ready, completed
+    This method test wait for kata create, initialized, ready, complete, delete
     :return:
     """
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
@@ -88,24 +86,4 @@ def test_benchmark_runner_kata_create_initialized_ready_completed_deleted():
     assert oc.wait_for_initialized(label='app=vdbench', label_uuid=False, namespace=test_environment_variable['namespace'])
     assert oc.wait_for_ready(label='app=vdbench', label_uuid=False, namespace=test_environment_variable['namespace'])
     assert oc.wait_for_pod_completed(label='app=vdbench', label_uuid=False, job=False, namespace=test_environment_variable['namespace'])
-
-
-# capture vm output - Must run it with 'pytest -s'
-def test_benchmark_runner_vm_create_initialized_ready_completed_deleted():
-    """
-    This method test wait for vm create, initialized, ready, completed
-    :return:
-    """
-    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
-    oc.login()
-    vm_name = 'vdbench-vm'
-    assert oc.create_vm_sync(yaml=os.path.join(f'{templates_path}', 'vdbench_vm.yaml'), vm_name=vm_name, namespace=test_environment_variable['namespace'], timeout=600)
-    assert oc.wait_for_ready(label='app=vdbench', run_type='vm', label_uuid=False, namespace=test_environment_variable['namespace'],  timeout=600)
-    assert oc.delete_vm_sync(yaml=os.path.join(f'{templates_path}', 'vdbench_vm.yaml'), vm_name=vm_name, namespace=test_environment_variable['namespace'], timeout=600)
-    # Capture section
-    #output_filename = os.path.join(f'{templates_path}', 'vdbench_vm.log')
-    #vm_name = oc.get_vm(label='vdbench', namespace=test_environment_variable['namespace'])
-    #oc.save_vm_log(vm_name=vm_name, output_filename=output_filename, namespace=test_environment_variable['namespace'])
-    #assert oc.wait_for_vm_log_completed(vm_name=vm_name, end_stamp='@@~@@END-WORKLOAD@@~@@', output_filename=output_filename)
-    #assert oc.extract_vm_results(vm_name=vm_name, start_stamp=vm_name, end_stamp='@@~@@END-WORKLOAD@@~@@', output_filename=output_filename)
 

--- a/tests/integration/benchmark_runner/common/virtctl/test_virtctl_benchmark_runner.py
+++ b/tests/integration/benchmark_runner/common/virtctl/test_virtctl_benchmark_runner.py
@@ -1,0 +1,82 @@
+
+# Tests that run benchmark-runner workloads
+
+import pytest
+from benchmark_runner.common.oc.oc import OC
+from benchmark_runner.common.virtctl.virtctl import Virtctl
+from benchmark_runner.common.template_operations.render_yaml_from_template import render_yaml_file
+from tests.integration.benchmark_runner.test_environment_variables import *
+
+
+def __generate_yamls(workload: str, kind: str = 'vm'):
+    """
+    This method creates YAML files from templates, substituting environment variables.
+    :return:
+    """
+    yaml_template = f'{workload}_{kind}_template.yaml'
+    yaml_file = f'{workload}_{kind}.yaml'
+    data = render_yaml_file(dir_path=templates_path, yaml_file=yaml_template, environment_variable_dict=test_environment_variable)
+    with open(os.path.join(templates_path, yaml_file), 'w') as f:
+        f.write(data)
+
+
+def __delete_test_objects(workload: str, kind: str = 'vm'):
+    """
+    Delete objects and YAML files if they exist
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    oc.login()
+    # revert bach to default namespace
+    workload_name = f'{workload}-{kind}'
+    workload_yaml = f'{workload}_{kind}.yaml'
+    workload_log = f'{workload}_{kind}.log'
+    if oc.pod_exists(pod_name=workload_name, namespace=test_environment_variable['namespace']):
+        oc.delete_pod_sync(yaml=os.path.join(templates_path, workload_yaml), pod_name=workload_name)
+    if os.path.isfile(os.path.join(templates_path, workload_yaml)):
+        os.remove(os.path.join(templates_path, workload_yaml))
+    if os.path.isfile(os.path.join(templates_path, workload_log)):
+        os.remove(os.path.join(templates_path, workload_log))
+
+
+@pytest.fixture(autouse=True)
+def before_after_each_test_fixture():
+    """
+    This method creates and deletes YAML files and test objects before and after each test
+    :return:
+    """
+    # before all test: setup
+    test_environment_variable['namespace'] = 'benchmark-runner'
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    oc.login()
+    oc.delete_namespace(namespace=test_environment_variable['namespace'])
+    __generate_yamls(workload='vdbench')
+    yield
+    # After all tests
+    __delete_test_objects(workload='vdbench')
+    oc.delete_namespace(namespace=test_environment_variable['namespace'])
+    # revert to defaults namespace
+    test_environment_variable['namespace'] = 'benchmark-operator'
+    print('Test End')
+
+
+# capture vm output - Must run it with 'pytest -s'
+def test_benchmark_runner_vm_create_ready_stop_start_expose_delete():
+    """
+    This method test wait for vm create, ready, stop, start, delete
+    :return:
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    oc.login()
+    virtctl = Virtctl()
+    vm_name = 'vdbench-vm'
+    assert oc.create_vm_sync(yaml=os.path.join(f'{templates_path}', 'vdbench_vm.yaml'), vm_name=vm_name, namespace=test_environment_variable['namespace'], timeout=600)
+    assert oc.wait_for_ready(label='app=vdbench', run_type='vm', label_uuid=False, namespace=test_environment_variable['namespace'],  timeout=600)
+    assert virtctl.stop_vm_sync(vm_name=vm_name, namespace=test_environment_variable['namespace'])
+    assert virtctl.start_vm_sync(vm_name=vm_name, namespace=test_environment_variable['namespace'])
+    virtctl.expose_vm(vm_name=vm_name, namespace=test_environment_variable['namespace'])
+    vm_node = oc.get_vm_node(vm_name=vm_name, namespace=test_environment_variable['namespace'])
+    assert vm_node
+    assert oc.get_nodes_addresses()[vm_node]
+    assert oc.get_exposed_vm_port(vm_name=vm_name, namespace=test_environment_variable['namespace'])
+    assert oc.delete_vm_sync(yaml=os.path.join(f'{templates_path}', 'vdbench_vm.yaml'), vm_name=vm_name, namespace=test_environment_variable['namespace'], timeout=600)
+

--- a/tests/integration/benchmark_runner/templates/vdbench_vm_template.yaml
+++ b/tests/integration/benchmark_runner/templates/vdbench_vm_template.yaml
@@ -67,7 +67,7 @@ spec:
           persistentVolumeClaim:
             claimName: vdbench-pvc-claim
         - containerDisk:
-            image: quay.io/ebattat/centos-stream8-vdbench5.04.07-container-disk:latest
+            image: quay.io/ebattat/centos-stream8-container-disk:latest
           name: containerdisk
         - cloudInitNoCloud:
             userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -29,7 +29,7 @@ class GoldenFiles:
                                                          'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_kata_mariadb',
                                                          'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_kata_postgres',
                                                          'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_kata_mssql',
-                                                         'vdbench_pod', 'vdbench_kata', 'vdbench_vm']
+                                                         'vdbench_pod', 'vdbench_kata', 'vdbench_vm', 'bootstorm_vm']
 
     def __clear_directory_yaml(self, dir):
         if os.path.isdir(dir):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -91,4 +91,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -111,4 +111,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -89,4 +89,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -109,4 +109,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -4,8 +4,8 @@ kind: Namespace
 metadata:
   name: benchmark-runner
 ---
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -91,4 +91,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -111,4 +111,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -89,4 +89,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -109,4 +109,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -4,8 +4,8 @@ kind: Namespace
 metadata:
   name: benchmark-runner
 ---
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -91,4 +91,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -111,4 +111,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -89,4 +89,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -109,4 +109,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -4,8 +4,8 @@ kind: Namespace
 metadata:
   name: benchmark-runner
 ---
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,0 +1,54 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bootstorm-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: bootstorm-deadbeef
+    type: bootstorm-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: bootstorm
+spec:
+  running: false
+  template:
+    metadata:
+     labels:
+        kubevirt.io/vm: bootstorm
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pin-node-1
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 10Mi
+          limits:
+            memory: 1Gi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: quay.io/ebattat/fedora36-container-disk:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -91,4 +91,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -111,4 +111,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -89,4 +89,3 @@ spec:
       storageClassName: ocs-storagecluster-ceph-rbd
     source:
       blank: {}
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -109,4 +109,3 @@ spec:
       namespace: benchmark-runner
       persistentVolumeClaim:
         claimName: vdbench-pod-pvc-claim
-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -4,8 +4,8 @@ kind: Namespace
 metadata:
   name: benchmark-runner
 ---
-kind: PersistentVolumeClaim
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner


### PR DESCRIPTION
[Bootstorm workload VM support](https://en.wiktionary.org/wiki/boot_storm)

1. Add bootstorm vm support using Fedora36 container disk [Fedora36: 5GB vs Centos stream8: 10GB]
2. Add bootstorm vm scale support using multi thread.
3. Add Virtctl class for virtctl commands: start, stop, expose, console [Split it from OC class]
4. Update bootstorm workload support in README and Readthedocs
5. Enable bootstorm_vm support in Func CI nightly [Perf CI will be enabled after Func CI success]
6. Add integration tests for bootstorm functionality 
7. Split namespace in scale run