### PR TITLE
disable PostgreSQL autovacuum

### DIFF
--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml
@@ -73,6 +73,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -131,6 +133,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
           {%- if storage_type == 'lso' or odf_pvc == True %}
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -30,6 +30,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,6 +82,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -43,6 +43,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -93,6 +95,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -15,6 +15,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,6 +63,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -28,6 +28,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,6 +76,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -30,6 +30,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,6 +82,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -43,6 +43,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -93,6 +95,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -15,6 +15,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,6 +63,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -28,6 +28,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,6 +76,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -30,6 +30,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,6 +82,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -43,6 +43,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -93,6 +95,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -15,6 +15,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,6 +63,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -28,6 +28,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,6 +76,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -30,6 +30,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,6 +82,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -43,6 +43,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -93,6 +95,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -15,6 +15,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,6 +63,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
       volumes:
         - name: postgres-custom-config
           configMap:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -28,6 +28,8 @@ data:
     local   all             all                                     trust
     # IPv4 local connections:
     host    all             all             all            trust
+  custom.perf.conf: |
+    autovacuum = 'off'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,6 +76,9 @@ spec:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf
               subPath: custom.pg_hba.conf #should be the name used in the ConfigMap
+            - name: postgres-custom-config
+              mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
+              subPath: custom.perf.conf #should be the name used in the ConfigMap
             - name: postgres-persistent-storage
               mountPath: /var/lib/pgsql/data
               readOnly: false


### PR DESCRIPTION
This PR disable PostgreSQL autovacuum for solving slowness when running 32 threads using LSO.