### PR TITLE
PostgreSQL VM autovacuum off

### DIFF
--- a/.github/workflows/Func_Env_Build_Test_CI.yml
+++ b/.github/workflows/Func_Env_Build_Test_CI.yml
@@ -77,8 +77,8 @@ jobs:
           cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl
           cp $RUNNER_PATH/oc /usr/local/bin/oc
           
-          # clone benchmark-operator v1.0.1
-          git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
+          # clone benchmark-operator v1.0.2
+          git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
           
           # run pytest - only unittest
           pytest -v tests/unittest/
@@ -155,7 +155,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
         
         # clone benchmark-operator
-        git clone https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
+        git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
         # run pytest
         pytest -v tests --cov=benchmark_runner --cov-report=term-missing
         coverage run -m pytest -v tests

--- a/.github/workflows/Func_Env_PR_Test_CI.yml
+++ b/.github/workflows/Func_Env_PR_Test_CI.yml
@@ -79,8 +79,8 @@ jobs:
           cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl
           cp $RUNNER_PATH/oc /usr/local/bin/oc
           
-          # clone benchmark-operator v1.0.1
-          git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
+          # clone benchmark-operator v1.0.2
+          git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
           
           # run pytest - only unittest
           pytest -v tests/unittest/
@@ -156,8 +156,8 @@ jobs:
         cp $RUNNER_PATH/virtctl /usr/local/bin/virtctl 
         rm -rf $RUNNER_PATH/virtctl
         
-        # clone benchmark-operator v1.0.1
-        git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
+        # clone benchmark-operator v1.0.2
+        git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
 
         # run pytest
         pytest
@@ -215,8 +215,8 @@ jobs:
        cp $RUNNER_PATH/kubectl /usr/local/bin/kubectl
        cp $RUNNER_PATH/oc /usr/local/bin/oc
 
-       # clone benchmark-operator v1.0.1
-       git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
+       # clone benchmark-operator v1.0.2
+       git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator $RUNNER_PATH/benchmark-operator
        
        # run main
        PYTHONPATH=. python benchmark_runner/main/main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN mkdir -p ~/.ssh/
 RUN mkdir -p /tmp/run_artifacts
 
 # download benchmark-operator to /tmp default path
-RUN git clone -b v1.0.1 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
+RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
 RUN git clone -b v1.1.7-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \

--- a/HOW_TO.md
+++ b/HOW_TO.md
@@ -287,7 +287,7 @@ Boilerplate data that is independent of workload has been moved to `common.yaml`
       1. Pass all mandatory parameters in [benchmark_runner/main/environment_variables.py](benchmark_runner/main/environment_variables.py) or set their equivalent variables in the environment (command line options override environment variables):
          1. `--workload` (`WORKLOAD`) = e.g. stressng_pod
          2. `--runner-path` (`RUNNER_PATH`) = path to local cloned benchmark-operator (e.g. /home/user/)
-            1. git clone https://github.com/cloud-bulldozer/benchmark-operator  (inside `runner_path`)
+            1. git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator  (inside `runner_path`)
          3. `--kubeadmin_password` (`KUBEADMIN_PASSWORD`)
          4. `--pin-node-benchmark-operator` (`PIN_NODE_BENCHMARK_OPERATOR`) - benchmark-operator node selector
          5. `--pin-node1` (`PIN_NODE1`) - workload first node selector
@@ -305,7 +305,7 @@ Boilerplate data that is independent of workload has been moved to `common.yaml`
       3. Verify that benchmark-runner run the workload
    2. Run workload through integration/unittest tests [using pytest]
       1. Need to set all mandatory parameters in [tests/integration/benchmark_runner/test_environment_variables.py](tests/integration/benchmark_runner/test_environment_variables.py) in the environment.
-            1. git clone https://github.com/cloud-bulldozer/benchmark-operator (inside 'RUNNER_PATH')
+            1. git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator (inside 'RUNNER_PATH')
          2. `KUBEADMIN_PASSWORD`
          3. `PIN_NODE1` - workload first node selector
          4. `ELASTICSEARCH` - elasticsearch url without http prefix

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ podman run --rm -e WORKLOAD=$WORKLOAD -e KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD 
 SAVE RUN ARTIFACTS LOCAL:
 1. add `-e SAVE_ARTIFACTS_LOCAL='True'` or `--save-artifacts-local=true`
 2. add `-v /tmp:/tmp`
-3. git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
+3. git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 ### Run vdbench workload in Pod using OpenShift
 ![](media/benchmark-runner-demo.gif)

--- a/docs/source/develop.md
+++ b/docs/source/develop.md
@@ -209,7 +209,7 @@ virtual environment:
         1. Need to configure all mandatory parameters in [benchmark_runner/main/environment_variables.py](benchmark_runner/main/environment_variables.py)
             1. `workloads` = e.g. stressng_pod
             2. `runner_path` = path to local cloned benchmark-operator (e.g. /home/user/)
-                1. git clone https://github.com/cloud-bulldozer/benchmark-operator  (inside 'runner_path')
+                1. git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator  (inside 'runner_path')
             3. `kubeadmin_password`
             4. `pin_node_benchmark_operator` - benchmark-operator node selector
             5. `pin_node1` - workload first node selector
@@ -221,7 +221,7 @@ virtual environment:
     2. Run workload through integration/unittest tests [using pytest]
         1. Need to configure all mandatory parameters [tests/integration/benchmark_runner/test_environment_variables.py](tests/integration/benchmark_runner/test_environment_variables.py)
             1. `runner_path` = path to local cloned benchmark-operator (e.g. /home/user/)
-                1. git clone https://github.com/cloud-bulldozer/benchmark-operator (inside 'runner_path')
+                1. git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator (inside 'runner_path')
             2. `kubeadmin_password`
             3. `pin_node1` - workload first node selector
             4. `elasticsearch` - elasticsearch url without http prefix

--- a/docs/source/podman.md
+++ b/docs/source/podman.md
@@ -59,4 +59,4 @@ podman run --rm -e WORKLOAD=$WORKLOAD -e KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD 
 SAVE RUN ARTIFACTS LOCAL:
 1. add `-e SAVE_ARTIFACTS_LOCAL='True'` or `--save-artifacts-local=true`
 2. add `-v /tmp:/tmp`
-3. git clone https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
+3. git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator


### PR DESCRIPTION
Fixes:

autovacuum off in PostgreSQL VM, depend on benchmark-operator [PR](https://github.com/cloud-bulldozer/benchmark-operator/pull/801)

git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator =>  [autovacuum off](https://github.com/cloud-bulldozer/benchmark-operator/blob/095443730bd9a5e5fb0bd128fe18119a7cc8dfda/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2#L61) in PostgreSQL VM