### PR TITLE
fix vm memory issue

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
@@ -5,14 +5,14 @@ template_data:
     pin_node: {{ pin_node1 }}
     odf_pvc: {{ odf_pvc }}
     uuid: {{ uuid }}
-    fedora_container_disk: quay.io/ebattat/fedora36-container-disk:latest
+    fedora_container_disk: quay.io/ebattat/fedora37-container-disk:latest
   run_type:
     perf_ci:
-      limits_memory: 1Gi
-      requests_memory: 10Mi
+      limits_memory: 500Mi
+      requests_memory: 500Mi
     default:
-      limits_memory: 1Gi
-      requests_memory: 10Mi
+      limits_memory: 500Mi
+      requests_memory: 500Mi
   kind:
     vm:
       run_type:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -73,4 +73,4 @@ template_data:
           sockets: 1
           cores: 4
           vm_limits_memory: 16Gi
-          vm_requests_memory: 10Mi
+          vm_requests_memory: 500Mi

--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -28,7 +28,7 @@ template_data:
       limits_cpu: 4
       limits_memory: 16Gi
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
   kind:
     vm:
       run_type:

--- a/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
@@ -50,8 +50,8 @@ template_data:
         default:
           sockets: 1
           cores: 4
-          limits_memory: 16Gi
-          requests_memory: 10Mi
+          limits_memory: 8Gi
+          requests_memory: 500Mi
           net_queues: 4
     default:
       run_type:


### PR DESCRIPTION
Fixed:
Vm workloads stressng and uperf started failed in OCP4.12/CNV4.12.0-769 due to low requests_memory: 10Mi, when increasing it to 500Mi issue was solved.
That cause also for issue to login to the vm by ssh or virtctl console