### PR TITLE
OCP4.12: fix vm memory in generate file

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -54,8 +54,7 @@ class OC(SSH):
         This method return odf version
         :return:
         """
-        return self.run(f"{self.__cli} get csv -n openshift-storage "
-                        f"-ojsonpath='{{.items[0].spec.labels.full_version}}'")
+        return self.run(f"{self.__cli} get csv -n openshift-storage -ojsonpath='{{.items[0].spec.labels.full_version}}'")
 
     def get_kata_version(self):
         """

--- a/tests/integration/benchmark_runner/templates/stressng_kata_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_kata_template.yaml
@@ -28,7 +28,7 @@ spec:
       pin_node: "{{ pin_node1 }}"
       resources: true # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # cpu stressor options

--- a/tests/integration/benchmark_runner/templates/stressng_pod_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_pod_template.yaml
@@ -27,7 +27,7 @@ spec:
       pin_node: "{{ pin_node1 }}"
       resources: true # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # cpu stressor options

--- a/tests/integration/benchmark_runner/templates/stressng_vm_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_vm_template.yaml
@@ -36,14 +36,14 @@ spec:
       kind: vm
       client_vm:
         dedicatedcpuplacement: false
-        sockets: 1
-        cores: 2
+        sockets: 4
+        cores: 1
         threads: 1
         image: quay.io/kubevirt/fedora-container-disk-images:34
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/integration/benchmark_runner/templates/vdbench_kata_template.yaml
+++ b/tests/integration/benchmark_runner/templates/vdbench_kata_template.yaml
@@ -36,7 +36,7 @@ spec:
   resources:
     requests:
       cpu: 10m
-      memory: 10Mi
+      memory: 500Mi
     limits:
       cpu: 2
       memory: 4Gi

--- a/tests/integration/benchmark_runner/templates/vdbench_pod_template.yaml
+++ b/tests/integration/benchmark_runner/templates/vdbench_pod_template.yaml
@@ -35,7 +35,7 @@ spec:
   resources:
     requests:
       cpu: 10m
-      memory: 10Mi
+      memory: 500Mi
     limits:
       cpu: 2
       memory: 4Gi

--- a/tests/integration/benchmark_runner/templates/vdbench_vm_template.yaml
+++ b/tests/integration/benchmark_runner/templates/vdbench_vm_template.yaml
@@ -57,7 +57,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 500Mi
           limits:
             cpu: 2
             memory: 4Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -52,9 +52,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:
@@ -70,9 +70,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -52,9 +52,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:
@@ -70,9 +70,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -52,9 +52,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:
@@ -70,9 +70,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -52,9 +52,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:
@@ -70,9 +70,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,13 +38,13 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 10Mi
+            memory: 500Mi
           limits:
-            memory: 1Gi
+            memory: 500Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: quay.io/ebattat/fedora36-container-disk:latest
+          image: quay.io/ebattat/fedora37-container-disk:latest
         name: containerdisk
       - cloudInitNoCloud:
           userData: |-

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 500Mi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 10Mi
+          memory: 500Mi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -52,9 +52,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:
@@ -70,9 +70,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -52,9 +52,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:
@@ -70,9 +70,9 @@ spec:
        threads: 1
        image: quay.io/kubevirt/fedora-container-disk-images:34
        limits:
-         memory: 16Gi
+         memory: 8Gi
        requests:
-         memory: 10Mi
+         memory: 500Mi
        network:
          front_end: masquerade
          multiqueue:


### PR DESCRIPTION
Fixed
Update golden file after updating the memory in vm template
Update memory for [integration tests](https://github.com/redhat-performance/benchmark-runner/tree/main/tests/integration/benchmark_runner/templates)