### PR TITLE
ocp4.12 increase uperf memory

### DIFF
--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -28,7 +28,7 @@ template_data:
       limits_cpu: 4
       limits_memory: 16Gi
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
   kind:
     vm:
       run_type:

--- a/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
@@ -51,7 +51,7 @@ template_data:
           sockets: 1
           cores: 4
           limits_memory: 8Gi
-          requests_memory: 500Mi
+          requests_memory: 8Gi
           net_queues: 4
     default:
       run_type:
@@ -62,6 +62,6 @@ template_data:
           requests_memory: 8Gi
         default:
           limits_cpu: 4
-          limits_memory: 16Gi
+          limits_memory: 8Gi
           requests_cpu: 10m
-          requests_memory: 10Mi
+          requests_memory: 8Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -54,7 +54,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:
@@ -72,7 +72,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -54,7 +54,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:
@@ -72,7 +72,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -54,7 +54,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:
@@ -72,7 +72,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -54,7 +54,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:
@@ -72,7 +72,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -24,7 +24,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 500Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       # general options

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -43,7 +43,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -23,17 +23,17 @@ spec:
       client_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       server_resources:
         requests:
           cpu: 10m
-          memory: 10Mi
+          memory: 8Gi
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 8Gi
       pin: True
       pin_server: "pin-node-1"
       pin_client: "pin-node-2"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -54,7 +54,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:
@@ -72,7 +72,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -54,7 +54,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:
@@ -72,7 +72,7 @@ spec:
        limits:
          memory: 8Gi
        requests:
-         memory: 500Mi
+         memory: 8Gi
        network:
          front_end: masquerade
          multiqueue:


### PR DESCRIPTION
Update limit/request memory to 8GB for Uperf pod/vm on functional environment 