### PR TITLE
ocp412 increase hammerdb vm memory

### DIFF
--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -73,4 +73,4 @@ template_data:
           sockets: 1
           cores: 4
           vm_limits_memory: 16Gi
-          vm_requests_memory: 500Mi
+          vm_requests_memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -82,7 +82,7 @@ spec:
         limits:
           memory: 16Gi
         requests:
-          memory: 500Mi
+          memory: 16Gi
         network:
           front_end: masquerade
           multiqueue:


### PR DESCRIPTION
Fixed:

This PR fixed hammerdb vm memory issue in OCP4.12 by increasing it to 16GB from 500Mi
Before the fix the vm was stuck during running