### PR TITLE
ocp412 increase hammerdb pod memory

### DIFF
--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -37,7 +37,7 @@ template_data:
       limits_cpu: 4
       limits_memory: 16Gi
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
   extra:
     mariadb:
       db_image: centos-stream8-mariadb103-container-disk:latest

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -25,7 +25,7 @@ template_data:
       limits_cpu: 16
       limits_memory: 16Gi
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
     default:
       db_num_workers: 2
       db_warehouses: 2
@@ -33,7 +33,7 @@ template_data:
       database_limits_cpu: 4
       database_limits_memory: 16Gi
       database_requests_cpu: 10m
-      database_requests_memory: 10Mi
+      database_requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       requests_cpu: 10m

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -71,7 +71,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -84,7 +84,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -63,7 +63,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -65,7 +65,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -78,7 +78,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_False/mariadb.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -65,7 +65,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -31,7 +31,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -44,7 +44,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -46,7 +46,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -59,7 +59,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 16
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -71,7 +71,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -84,7 +84,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -63,7 +63,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -65,7 +65,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -78,7 +78,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_False/mariadb.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -65,7 +65,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -31,7 +31,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -44,7 +44,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -46,7 +46,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -59,7 +59,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/mariadb.yaml
@@ -71,7 +71,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/mariadb.yaml
@@ -84,7 +84,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/mssql.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/mssql.yaml
@@ -63,7 +63,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_False/postgres.yaml
@@ -65,7 +65,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -25,7 +25,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_postgres_ODF_PVC_True/postgres.yaml
@@ -78,7 +78,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_False/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_False/mariadb.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mariadb"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/mariadb.yaml
@@ -65,7 +65,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/mssql.yaml
@@ -31,7 +31,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "mssql"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/mssql.yaml
@@ -44,7 +44,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 16Gi
           limits:
             cpu: 4
             memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_False/postgres.yaml
@@ -46,7 +46,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -23,7 +23,7 @@ spec:
       pin_node: "pin-node-1"
       resources: True # enable for resources requests/limits
       requests_cpu: 10m
-      requests_memory: 10Mi
+      requests_memory: 16Gi
       limits_cpu: 4
       limits_memory: 16Gi
       db_type: "pg"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_ODF_PVC_True/postgres.yaml
@@ -59,7 +59,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 16Gi
             limits:
               cpu: 4
               memory: 16Gi


### PR DESCRIPTION
Fixed:

This PR fixed hammerdb pod memory issue in OCP4.12 by increasing it to 16GB from 10Mi
Before the fix the database pod was stuck during running
For more details see [GitHub actions logs](https://github.com/redhat-performance/benchmark-runner/actions/runs/3774866868/jobs/6417598331).