### PR TITLE
Fixed parsing of release candidate version

### DIFF
--- a/benchmark_runner/common/clouds/IBM/ibm_operations.py
+++ b/benchmark_runner/common/clouds/IBM/ibm_operations.py
@@ -191,7 +191,12 @@ class IBMOperations:
         assisted_installer_versions = AssistedInstallerVersions()
         if self.LATEST in self.__install_ocp_version:
             openshift_version_data = self.__install_ocp_version.split('-')
-            return assisted_installer_versions.get_latest_version(latest_version=openshift_version_data[1])
+            # release candidate version
+            if 'rc' in self.__install_ocp_version:
+                return assisted_installer_versions.get_latest_version(latest_version=f'{openshift_version_data[1]}-{openshift_version_data[2]}')
+            # release version
+            else:
+                return assisted_installer_versions.get_latest_version(latest_version=openshift_version_data[1])
         else:
             return self.__install_ocp_version
 

--- a/tests/integration/benchmark_runner/common/assisted_installer/test_assisted_installer_latest_version.py
+++ b/tests/integration/benchmark_runner/common/assisted_installer/test_assisted_installer_latest_version.py
@@ -7,8 +7,9 @@ def test_get_release_latest_version():
     This method returns the latest version
     @return:
     """
+    RELEASE_VERSION_LENGTH = 3
     assisted_installer_versions = AssistedInstallerVersions()
-    assert len(assisted_installer_versions.get_latest_version(latest_version='4.11').split('.')) == 3
+    assert len(assisted_installer_versions.get_latest_version(latest_version='4.11').split('.')) == RELEASE_VERSION_LENGTH
 
 
 def test_get_release_candidate_latest_version():
@@ -16,5 +17,6 @@ def test_get_release_candidate_latest_version():
     This method returns the latest version
     @return:
     """
+    RELEASE_CANDIDATE_VERSION_LENGTH = 4
     assisted_installer_versions = AssistedInstallerVersions()
-    assert len(assisted_installer_versions.get_latest_version(latest_version='4.11.0-rc').split('.')) == 4
+    assert len(assisted_installer_versions.get_latest_version(latest_version='4.11.0-rc').split('.')) == RELEASE_CANDIDATE_VERSION_LENGTH


### PR DESCRIPTION
Fixed release candidate 'latest-4.12.0-rc' parsing, when extract the latest release candidate version.