### PR TITLE
update perf to ocp4.12

### DIFF
--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -73,11 +73,6 @@ jobs:
         ssh -t provision "chmod +x /tmp/remove_image.sh;/tmp/./remove_image.sh;rm -f /tmp/remove_image.sh"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Copy config to provision  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
         scp -r "$RUNNER_PATH/.kube/config" provision:"$CONTAINER_KUBECONFIG_PATH"
-    - name: ⌛ Build & Upload 🐋 to quay.io - latest benchmark-operator
-      run: |
-        sudo docker build --build-arg VERSION=latest -t quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:latest .
-        sudo docker login quay.io -u ${{ secrets.QAUYIO_ROBOT_USER }} -p ${{ secrets.QAUYIO_ROBOT_TOKEN }}
-        sudo docker push quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:latest
   
   workload:
     name: workload

--- a/.github/workflows/Weekly_Func_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Installer_CI.yml
@@ -84,7 +84,7 @@ jobs:
           echo '>>>>>>>>>>>>>>>>>>>>>>>>>> OCP end step: ${{ matrix.step }}   >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
       - name: ▶ Rerun OCP assisted install after failure
         env:
-          INSTALL_OCP_VERSION: "latest-4.11"
+          INSTALL_OCP_VERSION: "latest-4.12.0-rc"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.FUNC_WORKER_IDS }}

--- a/.github/workflows/Weekly_Func_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Operator_CI.yml
@@ -120,7 +120,7 @@ jobs:
         run: echo "install_resource_time=$INSTALL_OCP_RESOURCE_MINUTES_TIME" >> $GITHUB_OUTPUT
       - name: ☉ Rerun OCP Operator Reources install after failure
         env:
-          CNV_VERSION: "4.11"
+          CNV_VERSION: "4.12"
           ODF_VERSION: "4.11"
           NUM_ODF_DISK: "1"
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
@@ -64,7 +64,7 @@ jobs:
           END
       - name: ▶ OCP assisted installer
         env:
-          INSTALL_OCP_VERSION: "latest-4.11"
+          INSTALL_OCP_VERSION: "latest-4.12.0-rc"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.PERF_WORKER_IDS }}
@@ -87,7 +87,7 @@ jobs:
           echo '>>>>>>>>>>>>>>>>>>>>>>>>>> OCP end step: ${{ matrix.step }}   >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
       - name: ▶ Rerun OCP assisted install after failure
         env:
-          INSTALL_OCP_VERSION: "latest-4.11"
+          INSTALL_OCP_VERSION: "latest-4.12.0-rc"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.PERF_WORKER_IDS }}

--- a/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
@@ -77,8 +77,8 @@ jobs:
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
       - name: ☉ install ${{ matrix.resource }} Operator 
         env:
-          CNV_VERSION: "4.11"
-          ODF_VERSION: "4.10"
+          CNV_VERSION: "4.12"
+          ODF_VERSION: "4.11"
           NUM_ODF_DISK : "4"
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -120,8 +120,8 @@ jobs:
         run: echo "install_resource_time=$INSTALL_OCP_RESOURCE_MINUTES_TIME" >> $GITHUB_OUTPUT
       - name: ☉ Rerun OCP Operator Resources install after failure
         env:
-          CNV_VERSION: "4.11"
-          ODF_VERSION: "4.10"
+          CNV_VERSION: "4.12"
+          ODF_VERSION: "4.11"
           NUM_ODF_DISK: "4"
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
This PR updates Performance environment from OCP 4.11 to OCP 4.12.
 
Using the following versions:

1. OCP latest-4.12.0-rc (4.12.0-rc.6)
2. ODF 4.11 (4.11.4)
3. CNV 4.12 (4.12.0-777)