### PR TITLE
reduce bootstorm vm Fedora37 memory

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
@@ -8,11 +8,11 @@ template_data:
     fedora_container_disk: quay.io/ebattat/fedora37-container-disk:latest
   run_type:
     perf_ci:
-      limits_memory: 500Mi
-      requests_memory: 500Mi
+      limits_memory: 200Mi
+      requests_memory: 200Mi
     default:
-      limits_memory: 500Mi
-      requests_memory: 500Mi
+      limits_memory: 200Mi
+      requests_memory: 200Mi
   kind:
     vm:
       run_type:

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -72,9 +72,11 @@ class EnvironmentVariables:
         self._environment_variables_dict['scale'] = EnvironmentVariables.get_env('SCALE', '')
         # list of nodes per pod/vm, scale number per node, e.g: [ 'master-1', 'master-2' ] - run 1 pod/vm in each node
         self._environment_variables_dict['scale_nodes'] = EnvironmentVariables.get_env('SCALE_NODES', "")
-        self._environment_variables_dict['redis'] = EnvironmentVariables.get_env('REDIS', '')
-        self._environment_variables_dict['threads_limit'] = EnvironmentVariables.get_env('THREADS_LIMIT', '')
         self._environment_variables_dict['bulk_sleep_time'] = EnvironmentVariables.get_env('BULK_SLEEP_TIME', '3')
+        # CPU processors = threads limit
+        self._environment_variables_dict['threads_limit'] = EnvironmentVariables.get_env('THREADS_LIMIT', '')
+        # redis for synchronization
+        self._environment_variables_dict['redis'] = EnvironmentVariables.get_env('REDIS', '')
 
         # default parameter - change only if needed
         # Parameters below related to 'run_workload()'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 500Mi
+            memory: 200Mi
           limits:
-            memory: 500Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:


### PR DESCRIPTION
Current scale limit is 300 VMs, 100 VMs per node due to memory consumption.
That the reason for reducing bootstorm vm memory request/limit from 500Mi to 200Mi.
