### PR TITLE
decrease bootstorm vm memory

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
@@ -8,11 +8,11 @@ template_data:
     fedora_container_disk: quay.io/ebattat/fedora37-container-disk:latest
   run_type:
     perf_ci:
-      limits_memory: 200Mi
-      requests_memory: 200Mi
+      limits_memory: 180Mi
+      requests_memory: 180Mi
     default:
-      limits_memory: 200Mi
-      requests_memory: 200Mi
+      limits_memory: 180Mi
+      requests_memory: 180Mi
   kind:
     vm:
       run_type:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -38,9 +38,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 200Mi
+            memory: 180Mi
           limits:
-            memory: 200Mi
+            memory: 180Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:


### PR DESCRIPTION

The main reason for decreasing memory is that when running 600 vms get vm with failed status
Decrease bootstorm vm to minimal required memory 180MB for scale run
