### PR TITLE
revert delete vms flow

### DIFF
--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -49,11 +49,18 @@ class BootstormVM(WorkloadsOperations):
             # verify that data upload to elastic search according to unique uuid
             self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
 
-    def __delete_all_vms(self):
+    def __delete_vm_scale(self, vm_num: str):
         """
-        This method deletes all VMs
+        This method deletes VMs async in parallel
         """
-        self._oc.delete_all_vms()
+        self._oc.delete_async(
+            yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_{vm_num}.yaml'))
+
+    def __wait_for_delete_vm_scale(self, vm_num: str):
+        """
+        This method waits for VMs delete in parallel
+        """
+        self._oc.wait_for_vm_delete(vm_name=f'bootstorm-vm-{self._trunc_uuid}-{vm_num}')
 
     @logger_time_stamp
     def run(self):
@@ -93,7 +100,7 @@ class BootstormVM(WorkloadsOperations):
                 # create run bulks
                 bulks = tuple(self.split_run_bulks(iterable=range(self._scale * len(self._scale_node_list)), limit=self._threads_limit))
                 # create, run and delete vms
-                for target in (self.__create_vm_scale, self.__run_vm_scale):
+                for target in (self.__create_vm_scale, self.__run_vm_scale, self.__delete_vm_scale, self.__wait_for_delete_vm_scale):
                     proc = []
                     for bulk in bulks:
                         for vm_num in bulk:
@@ -105,8 +112,7 @@ class BootstormVM(WorkloadsOperations):
                         # sleep between bulks
                         time.sleep(self._bulk_sleep_time)
                         proc = []
-                # delete all vms and namespace
-                self.__delete_all_vms()
+                # delete namespace
                 self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_vm_sync(


### PR DESCRIPTION
This is the best way to delete large volume of vms.
1. When using 'oc delete vm --all', no validation that all vms are deleted and also it took a while.
2. When deleting vms in bulks, it the slow choice because each time it delete only a specific bulk of vms, all the other keep running.