### PR TITLE
Set virtiofsd_threadpoolsize appropriately for vdbench

### DIFF
--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -65,7 +65,11 @@ metadata:
   namespace: {{ namespace }}
   annotations:
     {%- if kind == 'kata' %}
+    {% if VIRTIOFSD_THREADS -%}
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size={{ VIRTIOFSD_THREADS }}"]'
+    {%- else -%}
     io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    {%- endif -%}
     {%- endif %}
   labels:
     {% if scale -%}

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -48,6 +48,7 @@ template_data:
       BLOCK_SIZES: 64,oltp1
       IO_OPERATION: write,oltp1
       IO_THREADS: 16,3
+      VIRTIOFSD_THREADS: 16
       FILES_IO: random,oltp1
       IO_RATE: max,max
       # used for mixed workload 0-100

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -7,6 +7,7 @@ template_data:
     uuid: {{ uuid }}
     vdbench_image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
     centos_stream_container_disk: quay.io/ebattat/centos-stream8-container-disk:latest
+    VIRTIOFSD_THREADS: 16
   run_type:
     perf_ci:
       BLOCK_SIZES: oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64
@@ -48,7 +49,6 @@ template_data:
       BLOCK_SIZES: 64,oltp1
       IO_OPERATION: write,oltp1
       IO_THREADS: 16,3
-      VIRTIOFSD_THREADS: 16
       FILES_IO: random,oltp1
       IO_RATE: max,max
       # used for mixed workload 0-100

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -11,7 +11,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -23,7 +23,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -11,7 +11,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -23,7 +23,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -11,7 +11,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -23,7 +23,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -11,7 +11,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -23,7 +23,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef


### PR DESCRIPTION
Set the threadpool size to the most I/O threads that will be used in a vdbench run.  If this improves performance, the same change will be made for perf-ci.

This is motivated by unexpected severe performance loss in vdbench runs on sandboxed containers (Kata) as compared to runc and OSV VMs.  Clusterbuster I/O runs do not show a similar loss of performance, and I hypothesize that this is the reason why.