### PR TITLE
update vdbench limit memory to 64GB

### DIFF
--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -41,7 +41,7 @@ template_data:
       # size in MB
       SIZE_PER_FILE: 10
       limits_cpu: 2
-      limits_memory: 32Gi
+      limits_memory: 64Gi
       requests_cpu: 2
       requests_memory: 4Gi
       storage: 64Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -34,7 +34,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 32Gi
+          memory: 64Gi
       env:
         - name: BLOCK_SIZES
           value: "oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -46,7 +46,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 32Gi
+          memory: 64Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -32,7 +32,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 32Gi
+          memory: 64Gi
       env:
         - name: BLOCK_SIZES
           value: "oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -44,7 +44,7 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 32Gi
+          memory: 64Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"


### PR DESCRIPTION
After setting [vdbench virtiofsd threadpoolsize to 16 threads](https://github.com/redhat-performance/benchmark-runner/pull/528), starting get error due to memory leak in [vdbench kata workload](https://github.com/redhat-performance/benchmark-runner/actions/runs/3852505493/jobs/6564688160).
Meaning that 32GB is not enough and we need at least 64GB.

When running vdbench block size: **64_cache**, it required 54GB ram.  