### PR TITLE
vdbench remove memory limit

### DIFF
--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -114,7 +114,9 @@ spec:
           memory: {{ requests_memory }}
         limits:
           cpu: {{ limits_cpu }}
+{%- if not kind == 'kata' %}
           memory: {{ limits_memory }}
+{%- endif %}
       {%- if cluster == "kubernetes" %}
       volumeMounts:
         - name: vdbench-pod-vol

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -34,7 +34,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
       env:
         - name: BLOCK_SIZES
           value: "64,oltp1"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -46,7 +46,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -34,7 +34,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 64Gi
       env:
         - name: BLOCK_SIZES
           value: "oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -46,7 +46,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 64Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -34,7 +34,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
       env:
         - name: BLOCK_SIZES
           value: "64,oltp1"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -46,7 +46,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -34,7 +34,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
       env:
         - name: BLOCK_SIZES
           value: "64,oltp1"

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -46,7 +46,6 @@ spec:
           memory: 4Gi
         limits:
           cpu: 2
-          memory: 4Gi
       volumeMounts:
         - name: vdbench-pod-pvc-claim
           mountPath: "/workload"


### PR DESCRIPTION
Fix:

Remove memory limit of vdbench_kata due to memory leak issue when run kata in parallel in Perf-CI