### PR TITLE
vm termination fix

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
@@ -57,7 +57,7 @@ spec:
             memory: {{ requests_memory }}
           limits:
             memory: {{ limits_memory }}
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: {{ fedora_container_disk }}

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -84,7 +84,7 @@ spec:
           limits:
             cpu: {{ limits_cpu }}
             memory: {{ requests_memory }}
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
 {%- if odf_pvc == True %}
         - name: data-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -49,7 +49,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - containerDisk:
             image: quay.io/ebattat/centos-stream8-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -62,7 +62,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - name: data-volume
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -49,7 +49,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - containerDisk:
             image: quay.io/ebattat/centos-stream8-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -62,7 +62,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - name: data-volume
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -49,7 +49,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - containerDisk:
             image: quay.io/ebattat/centos-stream8-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -62,7 +62,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - name: data-volume
           persistentVolumeClaim:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -41,7 +41,7 @@ spec:
             memory: 180Mi
           limits:
             memory: 180Mi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:
           image: quay.io/ebattat/fedora37-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -49,7 +49,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - containerDisk:
             image: quay.io/ebattat/centos-stream8-container-disk:latest

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -62,7 +62,7 @@ spec:
           limits:
             cpu: 2
             memory: 4Gi
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
         - name: data-volume
           persistentVolumeClaim:


### PR DESCRIPTION
Fix:

**The issue:** 
When terminating 600 VMs, some of the VMs stuck while terminating.
There is no way to terminate those VMs, the only way is to reinstall the cluster.

Known issue: https://github.com/kubernetes/kubernetes/issues/113426

**The solution:**
According to CNV developer we should update TerminationGracePeriodSeconds from 0 to 180

**The Explanation:**
By setting TerminationGracePeriodSeconds to 0 you've given your VM literally 0 seconds to complete shutdown gracefully. KubeVirt has no choice but to immediately send a kill command to your VM the instant the yaml is removed.

We suggest trying a number larger than 0 (180 should suffice) so the VM has time to complete I/O and shutdown properly before the timeout is reached and a kill signal is sent by the system.
