### PR TITLE
reduce bootstorm vms from 600 to 300 vms

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -188,7 +188,7 @@ jobs:
             if [[ '${{ matrix.workload }}' == 'bootstorm_vm_scale' ]]
             then
               REDIS=''
-              SCALE=200
+              SCALE=100
               THREADS_LIMIT=20
             fi
             workload=$(awk -F_ '{print $1"_"$2}' <<< '${{ matrix.workload }}')

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -72,7 +72,7 @@ class EnvironmentVariables:
         self._environment_variables_dict['scale'] = EnvironmentVariables.get_env('SCALE', '')
         # list of nodes per pod/vm, scale number per node, e.g: [ 'master-1', 'master-2' ] - run 1 pod/vm in each node
         self._environment_variables_dict['scale_nodes'] = EnvironmentVariables.get_env('SCALE_NODES', "")
-        self._environment_variables_dict['bulk_sleep_time'] = EnvironmentVariables.get_env('BULK_SLEEP_TIME', '3')
+        self._environment_variables_dict['bulk_sleep_time'] = EnvironmentVariables.get_env('BULK_SLEEP_TIME', '30')
         # CPU processors = threads limit
         self._environment_variables_dict['threads_limit'] = EnvironmentVariables.get_env('THREADS_LIMIT', '')
         # redis for synchronization


### PR DESCRIPTION
Fix:

Reduce bootstorm scale vms from 600 to 300 vms due to termination issue:
https://github.com/kubevirt/kubevirt/pull/8803

Issue:
Vms are stuck on terminations state, only reinstall cluster solved it.

The workaround till getting a solution:
Reduce the vm scale to 100 vms per node solve the issue.