### PR TITLE
fix python3.10 ctype error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ Run dnf config-manager --set-enabled powertools \
 
 # Prerequisite for Python installation
 ARG python_full_version=3.10.8
-RUN dnf install openssl-devel bzip2-devel wget -y
+RUN dnf install openssl-devel bzip2-devel wget libffi-devel -y
 
 # Install Python
 RUN wget https://www.python.org/ftp/python/${python_full_version}/Python-${python_full_version}.tgz \


### PR DESCRIPTION
This PR fix the following error in bootstorm workload due to Prometheus requirement:

```
 File "/usr/local/lib/python3.10/site-packages/benchmark_runner/workloads/bootstorm_vm.py", line 10, in <module>
    from benchmark_runner.common.prometheus.prometheus_metrics_operations import PrometheusMetricsOperation
  File "/usr/local/lib/python3.10/site-packages/benchmark_runner/common/prometheus/prometheus_metrics_operations.py", line 6, in <module>
    from prometheus_api_client import PrometheusConnect
  File "/usr/local/lib/python3.10/site-packages/prometheus_api_client/__init__.py", line 7, in <module>
    from .metric import Metric  # noqa F401
  File "/usr/local/lib/python3.10/site-packages/prometheus_api_client/metric.py", line 4, in <module>
    import pandas
  File "/usr/local/lib/python3.10/site-packages/pandas/__init__.py", line 22, in <module>
    from pandas.compat import is_numpy_dev as _is_numpy_dev  # pyright: ignore # noqa:F401
  File "/usr/local/lib/python3.10/site-packages/pandas/compat/__init__.py", line 18, in <module>
    from pandas.compat.numpy import (
  File "/usr/local/lib/python3.10/site-packages/pandas/compat/numpy/__init__.py", line 4, in <module>
    from pandas.util.version import Version
  File "/usr/local/lib/python3.10/site-packages/pandas/util/__init__.py", line 8, in <module>
    from pandas.core.util.hashing import (  # noqa:F401
  File "/usr/local/lib/python3.10/site-packages/pandas/core/util/hashing.py", line 24, in <module>
    from pandas.core.dtypes.common import (
  File "/usr/local/lib/python3.10/site-packages/pandas/core/dtypes/common.py", line 27, in <module>
    from pandas.core.dtypes.base import _registry as registry
  File "/usr/local/lib/python3.10/site-packages/pandas/core/dtypes/base.py", line 24, in <module>
    from pandas.errors import AbstractMethodError
  File "/usr/local/lib/python3.10/site-packages/pandas/errors/__init__.py", line 6, in <module>
    import ctypes
  File "/usr/local/lib/python3.10/ctypes/__init__.py", line 8, in <module>
    from _ctypes import Union, Structure, Array
ModuleNotFoundError: No module named '_ctypes' 
```

[Full error logs](https://github.com/redhat-performance/benchmark-runner/actions/runs/4140849792/jobs/7159897217)