### PR TITLE
enable prometheus metrics for vdbench

### DIFF
--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -225,7 +225,7 @@ class WorkloadsOperations:
         """
         This method create pod run artifacts
         :param pod_name: pod name
-        :return: run results dict
+        :return: run results list of dicts
         """
         result_list = []
         pod_log_file = self._create_pod_log(pod=pod_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ myst-parser==0.17.0
 openshift-client==1.0.17
 prometheus-api-client==0.5.1
 pandas
-paramiko==2.10.1
+paramiko==3.0.0
 PyGitHub==1.55
 PyYAML==6.0
 sphinx==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'azure==4.0.0',
         'boto3==1.26.1',  # s3
         'botocore==1.29.1',  # s3
-        'cryptography==39.0.1',  # Remove once https://github.com/paramiko/paramiko/issues/2038 gets fixed.
+        'cryptography==39.0.1',  # for paramiko
         'elasticsearch==7.16.1',
         'elasticsearch_dsl==7.4.0',  # for deep search
         'jinja2==3.0.3',
@@ -53,7 +53,7 @@ setup(
         'openshift-client==1.0.17',  # clusterbuster && prometheus metrics
         'prometheus-api-client==0.5.1',  # clusterbuster && prometheus metrics
         'pandas',  # required latest
-        'paramiko==2.10.1',
+        'paramiko==3.0.0',
         'PyGitHub==1.55',  # update secrets
         'PyYAML==6.0',
         'sphinx==4.5.0',  # readthedocs


### PR DESCRIPTION
Fixes:

1. Vdbench workload: Run Prometheus [queries](https://github.com/redhat-performance/benchmark-runner/blob/main/benchmark_runner/common/prometheus/metrics-default.yaml) for fetching CPU and memory for namespace benchmark-runner. 
2. Update Paramiko from 2.10.1 to 3.0.0 due to the following warning:
cryptographydeprecationwarning: blowfish has been deprecated "class": algorithms.blowfish, 
[This warning is happened after update cryptography==39.0.1 from 36.0.2]