### PR TITLE
remove skip ocp remove

### DIFF
--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -183,7 +183,7 @@ def main():
         ibm_operations = IBMOperations(user=provision_user)
         ibm_operations.ibm_connect()
         install_step = environment_variables_dict.get('install_step', '')
-        if not ibm_operations.version_already_installed() and install_step == 'run_ibm_ocp_installer':
+        if install_step == 'run_ibm_ocp_installer':
             install_ocp(ibm_operations=ibm_operations, step=install_step)
         elif install_step == 'verify_install_complete':
             install_ocp(ibm_operations=ibm_operations, step=install_step)


### PR DESCRIPTION
Fix:
Removing skip install when version is already installed, its useful when no changes in OCP version but not useful when operator install [failed](https://github.com/redhat-performance/benchmark-runner/actions/runs/4246889829/jobs/7384270891), so no way to rerun the installer from GitHub Actions, cause to rerun it manually from bastion machine.

** We run the installer as weekly basis, so there is version change, meaning that the skip is not useful.