### PR TITLE
oc client version 4.12.0-0.okd-2023-02-18-033438

### DIFF
--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -175,7 +175,7 @@ jobs:
         TIMEOUT: 8000
         SCALE: 2
         RUN_TYPE: 'test_ci'
-        ENABLE_PROMETHEUS_SNAPSHOT: 'True'
+        ENABLE_PROMETHEUS_SNAPSHOT: 'False'
       run: |
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -267,6 +267,7 @@ jobs:
         ELASTICSEARCH_PASSWORD: ${{ secrets.PERF_ELASTICSEARCH_PASSWORD }}
         RUNNER_PATH: ${{ secrets.RUNNER_PATH }}
         CONTAINER_KUBECONFIG_PATH: ${{ secrets.CONTAINER_KUBECONFIG_PATH }}
+        RUN_TYPE: 'perf_ci'
       run: |
         # get repository last id
         declare -a repositories=('redhat-performance/benchmark-runner' 'cloud-bulldozer/benchmark-operator' 'cloud-bulldozer/benchmark-wrapper')
@@ -299,7 +300,7 @@ jobs:
         # Check for workload failure or success => return pass/failed
         if [[ "${{needs.workload.outputs.job_status}}" == "failure" || "${{needs.workload.outputs.job_status}}" == "cancelled" ]]; then status="failed"; else status="pass"; fi
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Update CI status $status >>>>>>>>>>>>>>>>>>>>>>>>>>'
-        podman run --rm -e KUBEADMIN_PASSWORD="$KUBEADMIN_PASSWORD" -e PIN_NODE_BENCHMARK_OPERATOR="$PIN_NODE_BENCHMARK_OPERATOR" -e PIN_NODE1="$PIN_NODE1" -e PIN_NODE2="$PIN_NODE2" -e ELASTICSEARCH="$ELASTICSEARCH" -e ELASTICSEARCH_PORT="$ELASTICSEARCH_PORT" -e ELASTICSEARCH_USER="$ELASTICSEARCH_USER" -e ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" -e BUILD_VERSION="$build_version" -e CI_STATUS="$status" -e CI_MINUTES_TIME="$ci_minutes_time" -e BENCHMARK_RUNNER_ID="$BENCHMARK_RUNNER_ID" -e BENCHMARK_OPERATOR_ID="$BENCHMARK_OPERATOR_ID" -e BENCHMARK_WRAPPER_ID="$BENCHMARK_WRAPPER_ID" -e RUN_TYPE="perf_ci" -e TIMEOUT="3600" -e log_level="INFO" -v "$KUBECONFIG_PATH":"$CONTAINER_KUBECONFIG_PATH" --privileged "quay.io/ebattat/benchmark-runner:latest"
+        podman run --rm -e KUBEADMIN_PASSWORD="$KUBEADMIN_PASSWORD" -e PIN_NODE_BENCHMARK_OPERATOR="$PIN_NODE_BENCHMARK_OPERATOR" -e PIN_NODE1="$PIN_NODE1" -e PIN_NODE2="$PIN_NODE2" -e ELASTICSEARCH="$ELASTICSEARCH" -e ELASTICSEARCH_PORT="$ELASTICSEARCH_PORT" -e ELASTICSEARCH_USER="$ELASTICSEARCH_USER" -e ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" -e BUILD_VERSION="$build_version" -e CI_STATUS="$status" -e CI_MINUTES_TIME="$ci_minutes_time" -e BENCHMARK_RUNNER_ID="$BENCHMARK_RUNNER_ID" -e BENCHMARK_OPERATOR_ID="$BENCHMARK_OPERATOR_ID" -e BENCHMARK_WRAPPER_ID="$BENCHMARK_WRAPPER_ID" -e RUN_TYPE="$RUN_TYPE" -e TIMEOUT="3600" -e log_level="INFO" -v "$KUBECONFIG_PATH":"$CONTAINER_KUBECONFIG_PATH" --privileged "quay.io/ebattat/benchmark-runner:latest"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Remove image on provision >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
         echo "if [[ \"\$(sudo podman images -q quay.io/ebattat/benchmark-runner 2> /dev/null)\" != \"\" ]]; then sudo podman rmi -f \$(sudo podman images -q quay.io/ebattat/benchmark-runner 2> /dev/null); fi" > "$RUNNER_PATH/remove_image.sh"
         scp -r "$RUNNER_PATH/remove_image.sh" provision:"/tmp/remove_image.sh"

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           # Install Dockerfile content for pytest
           # install oc/kubectl
-          oc_version=4.11.0-0.okd-2022-10-15-073651
+          oc_version=4.12.0-0.okd-2023-02-18-033438
           curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
           tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
           rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
@@ -138,7 +138,7 @@ jobs:
       run: |
         # Install Dockerfile content for pytest
         # install oc/kubectl
-        oc_version=4.11.0-0.okd-2022-10-15-073651
+        oc_version=4.12.0-0.okd-2023-02-18-033438
         curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
         tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
         rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           # Install Dockerfile content for pytest
           # install oc/kubectl
-          oc_version=4.11.0-0.okd-2022-10-15-073651
+          oc_version=4.12.0-0.okd-2023-02-18-033438
           curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
           tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
           rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
@@ -142,7 +142,7 @@ jobs:
       run: |
         # Install Dockerfile content for pytest
         # install oc/kubectl
-        oc_version=4.11.0-0.okd-2022-10-15-073651
+        oc_version=4.12.0-0.okd-2023-02-18-033438
         curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
         tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
         rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz
@@ -208,7 +208,7 @@ jobs:
      run: |
        # Install Dockerfile content for pytest
        # install oc/kubectl
-       oc_version=4.11.0-0.okd-2022-10-15-073651
+       oc_version=4.12.0-0.okd-2023-02-18-033438
        curl -L "https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz" -o "$RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz"
        tar -xzvf $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz -C $RUNNER_PATH/
        rm $RUNNER_PATH/openshift-client-linux-${oc_version}.tar.gz

--- a/.github/workflows/Weekly_Func_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Installer_CI.yml
@@ -65,6 +65,7 @@ jobs:
       - name: ▶ OCP assisted installer
         env:
           INSTALL_OCP_VERSION: "latest-4.13.0-ec"
+          OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.PERF_WORKER_IDS }}
@@ -88,6 +89,7 @@ jobs:
       - name: ▶ Rerun OCP assisted install after failure
         env:
           INSTALL_OCP_VERSION: "latest-4.13.0-ec"
+          OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.PERF_WORKER_IDS }}

--- a/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
@@ -65,6 +65,7 @@ jobs:
       - name: ▶ OCP assisted installer
         env:
           INSTALL_OCP_VERSION: "latest-4.12"
+          OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.PERF_WORKER_IDS }}
@@ -88,6 +89,7 @@ jobs:
       - name: ▶ Rerun OCP assisted install after failure
         env:
           INSTALL_OCP_VERSION: "latest-4.12"
+          OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           WORKER_IDS: ${{ secrets.PERF_WORKER_IDS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN wget https://www.python.org/ftp/python/${python_full_version}/Python-${pytho
 RUN python3.10 -m pip --no-cache-dir install --upgrade pip && pip --no-cache-dir install benchmark-runner --upgrade
 
 # install oc/kubectl client tools for OpenShift/Kubernetes
-ARG oc_version=4.11.0-0.okd-2022-10-15-073651
+ARG oc_version=4.12.0-0.okd-2023-02-18-033438
 RUN  curl -L https://github.com/openshift/okd/releases/download/${oc_version}/openshift-client-linux-${oc_version}.tar.gz -o  ~/openshift-client-linux-${oc_version}.tar.gz \
      && tar -xzvf  ~/openshift-client-linux-${oc_version}.tar.gz -C  ~/ \
      && rm -rf ~/openshift-client-linux-${oc_version}.tar.gz \

--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -183,7 +183,7 @@ def main():
         ibm_operations = IBMOperations(user=provision_user)
         ibm_operations.ibm_connect()
         install_step = environment_variables_dict.get('install_step', '')
-        if not ibm_operations.version_already_installed() and install_step == 'run_ibm_ocp_installer':
+        if install_step == 'run_ibm_ocp_installer':
             install_ocp(ibm_operations=ibm_operations, step=install_step)
         elif install_step == 'verify_install_complete':
             install_ocp(ibm_operations=ibm_operations, step=install_step)


### PR DESCRIPTION
Fixes:

Upgrade oc client version to 4.12.0-0.okd-2023-02-18-033438 from 4.11.0-0.okd-2022-10-15-073651
Got permission issue when using oc client version 4.11.0-0.okd-2022-10-15-073651 against OCP 4.13.0-ec.3:

```
$ oc debug node/worker-0
error: PodSecurity violation error:
```