### PR TITLE
Clusterbuster v1.2.0 rc.1 kata ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.2.0-rc.0-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.2.0-rc.1-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
Rebase ClusterBuster to v1.2.0-rc.1-kata-ci.  The motivation is to minimize the pod privilege except as required, and when required, to create pod namespaces in such a way as to permit privileged pod creation where enforced by OpenShift.

- Changes since v1.2.0-rc.0-kata-ci:
  - Fixed regression: missing --force-cleanup-i-know-this-is-dangerous
  - Created new tags for the container image to separate the branch from mainline development.
- Extensive changes since v1.1.7:
  - Fix pod privilege issues going forward
  - Improved robustness, particularly in case of failure
  - Improved reliability of reporting in the case of run failures
  - More reliable log collection
  - All pod-side workloads converted to Python:
    - cpusoaker will give lower performance numbers due to use of Python vs. perl; results cannot be compared against v1.1
    - memory consumption will likely be lower with cpusoaker test
  - Pod monitoring is more efficient
  - Support for Multus
  - Support ARM

Except as noted (cpusoaker performance results), this release should be compatible with v1.1.7 for purposes of CI.