### PR TITLE
Bump clusterbuster version to v1.2.0-rc.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.2.0-rc.1-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.2.0-rc.2-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
Fix trivial typo in image name resulting in image pull failure.
The error: 
`clusterbuster-0-cpusoaker-0-dpjdk                                 0/1     ImagePullBackOf`

Clusterbuster [PR](https://github.com/RobertKrawitz/OpenShift4-tools/pull/122)