### PR TITLE
Bump clusterbuster to v1.2.0-rc.3-kata-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.2.0-rc.2-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.2.0-rc.3-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
Changes since v1.2.0-rc.2-kata-ci:
- Fix drop cache pod in fio and files workload to properly tell clusterbuster to set privilege on the container.
- Fix run-kata-perf-suite to properly create the command line to analyze-clusterbuster-results.
- Retrieve pod description if sync pod fails to start.