### PR TITLE
fix vdbench pod privileged issue

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -204,6 +204,17 @@ class OC(SSH):
 
     @typechecked
     @logger_time_stamp
+    def apply_security_privileged(self, namespace: str = environment_variables.environment_variables_dict['namespace']):
+        """
+        This method apply security privileged for namespace
+        @param namespace:
+        @return:
+        """
+        return self.run(f"{self.__cli} create serviceaccount -n {namespace} {namespace}; "
+                        f"{self.__cli} adm policy add-scc-to-user -n {namespace} privileged -z {namespace}")
+
+    @typechecked
+    @logger_time_stamp
     def create_async(self, yaml: str, is_check: bool = False):
         """
         This method create yaml in async

--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -162,6 +162,9 @@ class TemplateOperations:
             except TemplateSyntaxError as err:
                 raise SyntaxError(f"Error while rendering {template_file}: {err}")
             answer[filename] = f"{template.render(render_data)}\n"
+            # namespace
+            if os.path.isfile(os.path.join(workload_dir_path, 'internal_data', f'namespace_template.yaml')):
+                answer['namespace.yaml'] = render_yaml_file(dir_path=os.path.join(workload_dir_path, 'internal_data'), yaml_file='namespace_template.yaml', environment_variable_dict=self.__environment_variables_dict)
             if scale:
                 answer['namespace.yaml'] = render_yaml_file(dir_path=os.path.join(self.__dir_path, 'scale'), yaml_file='namespace.yaml', environment_variable_dict=self.__environment_variables_dict)
                 if redis:

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/namespace_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/namespace_template.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -1,10 +1,3 @@
-{%- if not scale %}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ namespace }}
----
-{%- endif %}
 {%- if cluster == "kubernetes" %}
 apiVersion: v1
 kind: PersistentVolume
@@ -83,14 +76,6 @@ metadata:
     benchmark-runner-workload: vdbench
 spec:
   {%- if cluster != "kubernetes" %}
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/benchmark_runner/workloads/vdbench_pod.py
+++ b/benchmark_runner/workloads/vdbench_pod.py
@@ -80,6 +80,9 @@ class VdbenchPod(WorkloadsOperations):
             else:
                 self.__es_index = 'vdbench-results'
             self._environment_variables_dict['kind'] = self.__kind
+            # create namespace
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            self._oc.apply_security_privileged()
             if not self._scale:
                 self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), pod_name=self.__pod_name)
                 self._oc.wait_for_initialized(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False)
@@ -139,8 +142,8 @@ class VdbenchPod(WorkloadsOperations):
                     else:
                         pod_name = name
                     self._oc.delete_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
-                # delete namespace
-                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            # delete namespace
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_pod_sync(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -18,14 +13,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -30,14 +25,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -17,14 +12,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -29,14 +24,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -18,14 +13,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -30,14 +25,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -17,14 +12,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -29,14 +24,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -18,14 +13,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -30,14 +25,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -17,14 +12,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -29,14 +24,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -18,14 +13,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -30,14 +25,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_False/vdbench_pod.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 ---
 apiVersion: v1
 kind: Pod
@@ -17,14 +12,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_pod_ODF_PVC_True/vdbench_pod.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pod-pvc-claim
@@ -29,14 +24,6 @@ metadata:
     benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
     benchmark-runner-workload: vdbench
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
   selector:
     matchLabels:
       app: vdbench

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Fix:

OCP [4.13.0-ec.3](https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-dev-preview/release/4.13.0-ec.3) fix vdbench pod/kata PSA error:
Error from server (Forbidden): error when creating "vdbench_pod.yaml": pods "vdbench-pod-7bea7061" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "vdbench-pod" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "vdbench-pod" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "vdbench-pod" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "vdbench-pod" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")

By adding to namespace.yaml

```
  labels:
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/warn: privileged
```

Running the following oc commands against namespace:
```
oc create serviceaccount -n benchmark-runner benchmark-runner
oc adm policy add-scc-to-user -n benchmark-runner privileged -z benchmark-runner
```