### PR TITLE
Bump ClusterBuster to v1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.2.0-rc.3-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.2.0-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
Fix analysis output to generate correct runtimeclass names, rather than the name of the artifact directory.

xref https://github.com/RobertKrawitz/OpenShift4-tools/pull/125
xref https://github.com/RobertKrawitz/OpenShift4-tools/releases/tag/v1.2.0-kata-ci
