### PR TITLE
split namespace from workload for bootstorm and vdbench VMs

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
@@ -1,10 +1,3 @@
-{%- if not scale %}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ namespace }}
----
-{%- endif %}
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/namespace_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/namespace_template.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+
+

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -1,10 +1,3 @@
-{% if not scale %}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ namespace }}
----
-{%- endif %}
 {%- if odf_pvc == True %}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -126,6 +126,8 @@ class BootstormVM(WorkloadsOperations):
             self.__vm_name = f'{self.__workload_name}-{self._trunc_uuid}'
             self.__kind = 'vm'
             self._environment_variables_dict['kind'] = 'vm'
+            # create namespace
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
             if not self._scale:
                 self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'))
                 self._oc.wait_for_vm_status(vm_name=f'bootstorm-vm-{self._trunc_uuid}', status=VMStatus.Stopped)
@@ -148,8 +150,6 @@ class BootstormVM(WorkloadsOperations):
                     vm_name=self.__vm_name)
             # scale
             else:
-                # create namespace
-                self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
                 # create run bulks
                 bulks = tuple(self.split_run_bulks(iterable=range(self._scale * len(self._scale_node_list)), limit=self._threads_limit))
                 # create, run and delete vms
@@ -165,8 +165,8 @@ class BootstormVM(WorkloadsOperations):
                         # sleep between bulks
                         time.sleep(self._bulk_sleep_time)
                         proc = []
-                # delete namespace
-                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            # delete namespace
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_vm_sync(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),

--- a/benchmark_runner/workloads/vdbench_pod.py
+++ b/benchmark_runner/workloads/vdbench_pod.py
@@ -107,8 +107,6 @@ class VdbenchPod(WorkloadsOperations):
             # scale
             else:
                 self.__scale = int(self._scale)
-                # create namespace
-                self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
                 # create redis and state signals
                 sync_pods = {'redis': 'redis', 'state_signals_exporter_pod': 'state-signals-exporter'}
                 for pod, name in sync_pods.items():

--- a/benchmark_runner/workloads/vdbench_vm.py
+++ b/benchmark_runner/workloads/vdbench_vm.py
@@ -84,6 +84,8 @@ class VdbenchVM(WorkloadsOperations):
             self.__vm_name = f'{self.__workload_name}-{self._trunc_uuid}'
             self.__kind = 'vm'
             self._environment_variables_dict['kind'] = 'vm'
+            # create namespace
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
             if not self._scale:
                 self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
                 self._oc.wait_for_ready(label=f'app=vdbench-{self._trunc_uuid}', run_type='vm', label_uuid=False)
@@ -109,8 +111,6 @@ class VdbenchVM(WorkloadsOperations):
             # scale
             else:
                 self.__scale = int(self._scale)
-                # create namespace
-                self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
                 # create redis and state signals
                 sync_pods = {'redis': 'redis', 'state_signals_exporter_pod': 'state-signals-exporter'}
                 for pod, name in sync_pods.items():
@@ -144,8 +144,8 @@ class VdbenchVM(WorkloadsOperations):
                     else:
                         pod_name = name
                     self._oc.delete_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
-                # delete namespace
-                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            # delete namespace
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_vm_sync(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -1,9 +1,3 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -1,9 +1,4 @@
 
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -1,10 +1,5 @@
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: benchmark-runner
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vdbench-pvc-claim


### PR DESCRIPTION
Fixes:

Vdbench vm: split namespace from workload
bootstorm vm:  split namespace from workload