### PR TITLE
Update Clusterbuster to v1.2.1-kata-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.2.0-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.2.1-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
Clusterbuster release notes (xref https://github.com/RobertKrawitz/OpenShift4-tools/releases/tag/v1.2.1-kata-ci):

* cpusoaker should run all cases in each runtimeclass sequentially rather than interleaved. The problem with interleaving them is that the Prometheus metrics gathered during a run may partially reflect the previous run, as Prometheus gathers data over a 30 second interval, which may result in incorrect per-pod memory calculation if one runtimeclass consumes much more memory per pod than another.

Grafana output was showing both runc and kata pods consuming over 300 MiB of RAM per-pod, which is not correct (Kata pods should consume about 350 MB more than runc pods, which should consume about 10 MB).

Manual test results:

```Memory/pod (MiB), N pods
# Pods  runc    kata
20      10.937  360.918
40      10.745  361.642
60      11.237  372.752
80      11.838  362.970
100     12.133  363.224
120     10.720  363.333
140     10.722  364.531
160     10.997  364.316
180     10.825
200     11.102
```

Without fix:
```
Memory/pod (MiB), N pods
# Pods  runc    kata
20      10.753  374.601
40      181.082 368.069
60      241.118 362.293
80      272.183 368.448
100     10.725  361.447
120     302.318 363.415
140     311.888 363.458
160     198.127 363.776
180     324.010 363.702
200     328.689 363.823
```