### PR TITLE
reduce windows scale to 40

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -176,7 +176,7 @@ jobs:
         TIMEOUT: 8000
         SCALE: 2
         BOOTSTROM_SCALE: 100
-        WINDOWS_SCALE: 50
+        WINDOWS_SCALE: 40
         THREADS_LIMIT: 20
         RUN_TYPE: 'perf_ci'
         ENABLE_PROMETHEUS_SNAPSHOT: 'True'


### PR DESCRIPTION
Fix:

Reduce to 40 windows VMs per node because 50 VMs cause to insufficient memory error,