### PR TITLE
increase fedora vm memory

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/bootstorm_data_template.yaml
@@ -8,11 +8,11 @@ template_data:
     fedora_container_disk: quay.io/ebattat/fedora37-container-disk:latest
   run_type:
     perf_ci:
-      limits_memory: 180Mi
-      requests_memory: 180Mi
+      limits_memory: 512Mi
+      requests_memory: 512Mi
     default:
-      limits_memory: 180Mi
-      requests_memory: 180Mi
+      limits_memory: 512Mi
+      requests_memory: 512Mi
   kind:
     vm:
       run_type:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_False/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_bootstorm_vm_ODF_PVC_True/bootstorm_vm.yaml
@@ -32,9 +32,9 @@ spec:
             name: cloudinitdisk
         resources:
           requests:
-            memory: 180Mi
+            memory: 512Mi
           limits:
-            memory: 180Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 180
       volumes:
       - containerDisk:


### PR DESCRIPTION
Fix:

Increase fedora vm memory from 180MB to 512MB, for reducing the boot time.