### PR TITLE
install latest-4.13.0-rc

### DIFF
--- a/.github/workflows/Weekly_Func_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Installer_CI.yml
@@ -64,7 +64,7 @@ jobs:
           END
       - name: ▶ OCP assisted installer
         env:
-          INSTALL_OCP_VERSION: "latest-4.13.0-ec"
+          INSTALL_OCP_VERSION: "latest-4.13.0-rc"
           OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
           echo '>>>>>>>>>>>>>>>>>>>>>>>>>> OCP end step: ${{ matrix.step }}   >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
       - name: ▶ Rerun OCP assisted install after failure
         env:
-          INSTALL_OCP_VERSION: "latest-4.13.0-ec"
+          INSTALL_OCP_VERSION: "latest-4.13.0-rc"
           OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
@@ -64,7 +64,7 @@ jobs:
           END
       - name: ▶ OCP assisted installer
         env:
-          INSTALL_OCP_VERSION: "latest-4.13.0-ec"
+          INSTALL_OCP_VERSION: "latest-4.13.0-rc"
           OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
           echo '>>>>>>>>>>>>>>>>>>>>>>>>>> OCP end step: ${{ matrix.step }}   >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
       - name: ▶ Rerun OCP assisted install after failure
         env:
-          INSTALL_OCP_VERSION: "latest-4.13.0-ec"
+          INSTALL_OCP_VERSION: "latest-4.13.0-rc"
           OC_CLIENT_VERSION: "4.12.0-0.okd-2023-02-18-033438"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/benchmark_runner/common/assisted_installer/assisted_installer_latest_version.py
+++ b/benchmark_runner/common/assisted_installer/assisted_installer_latest_version.py
@@ -44,7 +44,8 @@ class AssistedInstallerVersions:
     def get_latest_version(self, latest_version: str):
         """
         This method get the latest version from json data
-        :param latest_version: 4.XX or 4.XX.0-rc
+        :param latest_version: 4.XX or 4.XX.0-rc/ec/fc
+        rc=release candidate| ec=engineering candidate| fc=feature candidate
         :return:
         """
         release_list = []

--- a/benchmark_runner/common/clouds/IBM/ibm_operations.py
+++ b/benchmark_runner/common/clouds/IBM/ibm_operations.py
@@ -327,7 +327,7 @@ class IBMOperations:
     @logger_time_stamp
     def update_ocp_github_credentials(self):
         """
-        This method update github secrets kubeconfig and kubeadmin_password
+        This method update GitHub secrets kubeconfig and kubeadmin_password
         :return:
         """
         self.__github_operations.create_secret(secret_name=f'{self.__ocp_env_flavor}_KUBECONFIG', unencrypted_value=self.__get_kubeconfig())


### PR DESCRIPTION
Fix:
There is [4.13 release candidate version](https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.13.0-rc.3)

** Upgrade Perf CI to install **latest-4.13.0-rc** (release candidate) instead of **latest-4.13.0-ec** (engineering candidate)