### PR TITLE
Fix VM results parsing

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -984,15 +984,15 @@ class OC(SSH):
             output_filename = os.path.join(self._run_artifacts, vm_name)
         results_list = []
         with open(output_filename) as infile:
-            copy = False
+            # VM logs results start
+            start = False
             for line in infile:
-                if start_stamp in line:
-                    copy = True
+                if start_stamp in line or 'podman' in line and not start:
+                    start = True
                     continue
                 elif end_stamp in line:
-                    copy = False
-                    continue
-                elif copy:
+                    return results_list
+                elif start:
                     # Filter 'cloud-init' and CSV lines only
                     if 'cloud-init' in line and ',' in line:
                         if vm_name in line:

--- a/benchmark_runner/common/ocp_resources/create_ocp_resource.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource.py
@@ -24,7 +24,8 @@ class CreateOCPResource:
         self.__oc.populate_additional_template_variables(self.__environment_variables_dict)
         self.__worker_disk_ids = self.__environment_variables_dict.get('worker_disk_ids', '')
         if self.__worker_disk_ids:
-            self.__worker_disk_ids = self.__worker_disk_ids.replace('"','')
+            # Solved GitHub Actions issue that env variable detect as string instead of dict/ list
+            self.__worker_disk_ids = self.__worker_disk_ids.replace('"', '')
             self.__worker_disk_ids = ast.literal_eval(self.__worker_disk_ids)
 
     @staticmethod


### PR DESCRIPTION
Fix:

When start stamp didnt appear in the logs that causing parsing issue, adding another start stamp when podman call start.
This issue is happened when running vdbench VM is parallel. 