### PR TITLE
add scale stamp for url

### DIFF
--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -70,7 +70,7 @@ class BootstormVM(WorkloadsOperations):
         self._virtctl.start_vm_async(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}')
         self._virtctl.wait_for_vm_status(vm_name=vm_name, status=VMStatus.Running)
         self._data_dict = self._get_bootstorm_vm_elapsed_time(vm_name=vm_name)
-        self._data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self._workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
+        self._data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self._workload_name, is_file=True)}-scale-{self._time_stamp_format}.tar.gz')
         self._status = 'complete' if self._data_dict else 'failed'
         self._prometheus_metrics_operation.finalize_prometheus()
         metric_results = self._prometheus_metrics_operation.run_prometheus_queries()


### PR DESCRIPTION
Fix:

The issue is that the logs in S3 contains scale stamp but not in Elastic.
That cause that all bootstorm S3 urls are not working. 
Adding scale stamp in URL logs for Elastic solved this issue. 