### PR TITLE
Fix Kata create issue

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -142,6 +142,21 @@ class OC(SSH):
         """
         return self._get_kata_default_channel_field('currentCSVDesc.annotations."operatorframework.io/suggested-namespace"')
 
+    def set_kata_threads_pool(self, thread_pool_size: str):
+        """
+        This methods sets kata thread-pool-size in every worker node
+        @param thread_pool_size:
+        @return:
+        """
+        self.run(fr"""{self.__cli} get nodes -l node-role.kubernetes.io/worker= -o jsonpath="{{range .items[*]}}{{.metadata.name}}{{'\\n'}}{{end}}" |  xargs -I{{}} oc debug node/{{}} -- chroot /host sh -c "mkdir -p /etc/kata-containers; cp /usr/share/kata-containers/defaults/configuration.toml /etc/kata-containers/; sed -i 's/thread-pool-size=1/thread-pool-size={thread_pool_size}/' /etc/kata-containers/configuration.toml" """)
+
+    def delete_kata_threads_pool(self):
+        """
+        This methods deletes kata thread-pool-size from every worker node
+        @return:
+        """
+        self.run(fr"""{self.__cli} get nodes -l node-role.kubernetes.io/worker= -o jsonpath="{{range .items[*]}}{{.metadata.name}}{{'\\n'}}{{end}}" |  xargs -I{{}} oc debug node/{{}} -- chroot /host sh -c "rm -f /etc/kata-containers/configuration.toml" """)
+
     @typechecked
     def populate_additional_template_variables(self, env: dict):
         """

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_pod_template.yaml
@@ -58,11 +58,7 @@ metadata:
   namespace: {{ namespace }}
   annotations:
     {%- if kind == 'kata' %}
-    {% if VIRTIOFSD_THREADS -%}
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size={{ VIRTIOFSD_THREADS }}"]'
-    {%- else -%}
     io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
-    {%- endif -%}
     {%- endif %}
   labels:
     {% if scale -%}

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -7,7 +7,6 @@ template_data:
     uuid: {{ uuid }}
     vdbench_image: quay.io/ebattat/centos-stream8-vdbench5.04.07-pod:v1.0.13
     centos_stream_container_disk: quay.io/ebattat/centos-stream8-container-disk:latest
-    VIRTIOFSD_THREADS: 16
   run_type:
     perf_ci:
       BLOCK_SIZES: oltp1,oltp2,oltphw,odss2,odss128,4_cache,64_cache,4,64,4_cache,64_cache,4,64

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -66,6 +66,8 @@ class EnvironmentVariables:
 
         # Workaround for Kata CPU offline problem in 4.9/4.10
         self._environment_variables_dict['kata_cpuoffline_workaround'] = EnvironmentVariables.get_boolean_from_environment('KATA_CPUOFFLINE_WORKAROUND', False)
+        # Kata thread-pool-size, default 16
+        self._environment_variables_dict['kata_thread_pool_size'] = EnvironmentVariables.get_boolean_from_environment('KATA_THREAD_POOL_SIZE', '16')
 
         # Scale Per Node
         self._environment_variables_dict['scale'] = EnvironmentVariables.get_env('SCALE', '')

--- a/benchmark_runner/workloads/vdbench_pod.py
+++ b/benchmark_runner/workloads/vdbench_pod.py
@@ -83,6 +83,8 @@ class VdbenchPod(WorkloadsOperations):
             # create namespace
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
             self._oc.apply_security_privileged()
+            if self.__kind == 'kata':
+                self._oc.set_kata_threads_pool(thread_pool_size=self._kata_thread_pool_size)
             if not self._scale:
                 self._oc.create_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), pod_name=self.__pod_name)
                 self._oc.wait_for_initialized(label=f'app=vdbench-{self._trunc_uuid}', label_uuid=False)
@@ -142,6 +144,8 @@ class VdbenchPod(WorkloadsOperations):
                     self._oc.delete_pod_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{pod}.yaml'), pod_name=pod_name)
             # delete namespace
             self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            if self.__kind == 'kata':
+                self._oc.delete_kata_threads_pool()
         except ElasticSearchDataNotUploaded as err:
             self._oc.delete_pod_sync(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -57,6 +57,7 @@ class WorkloadsOperations:
         self._scale = self._environment_variables_dict.get('scale', '')
         self._redis = self._environment_variables_dict.get('redis', '')
         self._threads_limit = self._environment_variables_dict.get('threads_limit', '')
+        self._kata_thread_pool_size = self._environment_variables_dict.get('kata_thread_pool_size', '')
         if self._scale:
             self._scale = int(self._scale)
             self._scale_nodes = self._environment_variables_dict.get('scale_nodes', '')

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -18,7 +18,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -18,7 +18,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -18,7 +18,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_False/vdbench_pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_kata_ODF_PVC_True/vdbench_pod.yaml
@@ -18,7 +18,7 @@ metadata:
   name: vdbench-kata-deadbeef
   namespace: benchmark-runner
   annotations:
-    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io","--thread-pool-size=16"]'
+    io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["-o","allow_direct_io"]'
   labels:
     app: vdbench-deadbeef
     type: vdbench-kata-deadbeef


### PR DESCRIPTION
Fix:
This issue is started when upgrading 4.13.0-ec (based Rhel 8.6) to 4.13.0-rc (based Rhel 9.2).
The root cause is that the annotations: "--thread-pool-size=16"  is not working properly on Rhel9. 

The workaround is to update  "--thread-pool-size=16" in every node and not through annotations.