### PR TITLE
Fix the check for kata installation complete

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_kata.py
+++ b/benchmark_runner/common/ocp_resources/create_kata.py
@@ -66,9 +66,9 @@ class CreateKata(CreateOCPResourceOperations):
                 # Next, we have to wait for the kata bits to actually install
                 self.wait_for_ocp_resource_create(resource='kata',
                                                   verify_cmd="oc get kataconfig -ojsonpath='{.items[0].status.installationStatus.IsInProgress}'",
-                                                  status='false')
-                total_nodes_count = self.__oc.run(cmd="oc get kataconfig -ojsonpath='{.items[0].status.total_nodes_count}'")
-                completed_nodes_count = self.__oc.run(cmd="oc get kataconfig -ojsonpath='{.items[0].status.installationStatus.completed.completed_nodes_count}'")
+                                                  status='False')
+                total_nodes_count = self.__oc.run(cmd="oc get kataconfig -ojsonpath='{.items[0].status.totalNodesCount}'")
+                completed_nodes_count = self.__oc.run(cmd="oc get kataconfig -ojsonpath='{.items[0].status.installationStatus.completed.completedNodesCount}'")
                 if total_nodes_count != completed_nodes_count:
                     raise KataInstallationFailed(f'not all nodes installed successfully total {total_nodes_count} != completed {completed_nodes_count}')
             elif resource.endswith('.sh'):


### PR DESCRIPTION
Also fix the check for completed nodes; the field names were wrong.  It succeeded because both the total and completed node counts were always empty.