### PR TITLE
Fix GitHub Actions PR vulnerability

### DIFF
--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -6,6 +6,7 @@ name: Perf Env PR Test CI
 
 on:
   pull_request_target:
+    types: [labeled, opened]
     branches: [ main ]
   workflow_dispatch:
 
@@ -22,6 +23,8 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+    # minimize potential vulnerabilities
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -7,4 +7,4 @@ moto==2.2.16
 pandas
 pytest
 PyYAML==6.0
-typeguard
+typeguard==2.12.1


### PR DESCRIPTION
Fix:

Adding ok-to-test label for running GitHub actions should prevent PR vulnerability