### PR TITLE
add pr synchronize type

### DIFF
--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -6,7 +6,7 @@ name: Perf Env PR Test CI
 
 on:
   pull_request_target:
-    types: [labeled, opened]
+    types: [labeled, opened, synchronize]
     branches: [ main ]
   workflow_dispatch:
 


### PR DESCRIPTION
Fixed:

Adding synchronize type to run GitHub actions workflow PR.
This will run GitHub actions when pushing new code to existing labeled ok-to-test PR