### PR TITLE
reduce fedora VMs number

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -175,7 +175,7 @@ jobs:
         WORKER_DISK_IDS: ${{ secrets.PERF_WORKER_DISK_IDS }}
         TIMEOUT: 8000
         SCALE: 2
-        BOOTSTROM_SCALE: 100
+        BOOTSTORM_SCALE: 80
         WINDOWS_SCALE: 40
         THREADS_LIMIT: 20
         RUN_TYPE: 'perf_ci'
@@ -192,7 +192,7 @@ jobs:
             # bootstorm_vm_scale: no need redis for synchronization but need SCALE and THREADS_LIMIT
             if [[ '${{ matrix.workload }}' == 'bootstorm_vm_scale' ]]
             then
-              SCALE=$BOOTSTROM_SCALE
+              SCALE=$BOOTSTORM_SCALE
             elif [[ '${{ matrix.workload }}' == 'windows_vm_scale' ]]
             then
               SCALE=$WINDOWS_SCALE


### PR DESCRIPTION
Fixed:
Currently we use 100GB from 128GB when running 100 fedora VMs.
That cause to not stable results in regressions.
The recommendation is to reduce the number of VMs to 80.