### PR TITLE
Remove open pr

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -175,7 +175,7 @@ jobs:
         WORKER_DISK_IDS: ${{ secrets.PERF_WORKER_DISK_IDS }}
         TIMEOUT: 8000
         SCALE: 2
-        BOOTSTROM_SCALE: 100
+        BOOTSTORM_SCALE: 80
         WINDOWS_SCALE: 40
         THREADS_LIMIT: 20
         RUN_TYPE: 'perf_ci'
@@ -192,7 +192,7 @@ jobs:
             # bootstorm_vm_scale: no need redis for synchronization but need SCALE and THREADS_LIMIT
             if [[ '${{ matrix.workload }}' == 'bootstorm_vm_scale' ]]
             then
-              SCALE=$BOOTSTROM_SCALE
+              SCALE=$BOOTSTORM_SCALE
             elif [[ '${{ matrix.workload }}' == 'windows_vm_scale' ]]
             then
               SCALE=$WINDOWS_SCALE

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -6,7 +6,7 @@ name: Perf Env PR Test CI
 
 on:
   pull_request_target:
-    types: [labeled, opened, synchronize]
+    types: [labeled, synchronize]
     branches: [ main ]
   workflow_dispatch:
 


### PR DESCRIPTION
Fixed:
Not need to run GitHub actions against PR when its opened.
It will run auto after changing the label to ok-to-test