### PR TITLE
remove opened pr

### DIFF
--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -6,7 +6,7 @@ name: Perf Env PR Test CI
 
 on:
   pull_request_target:
-    types: [labeled, opened, synchronize]
+    types: [labeled, synchronize]
     branches: [ main ]
   workflow_dispatch:
 


### PR DESCRIPTION
Fixed:
Not need to run GitHub actions against PR when its opened.
It will run auto after changing the label to ok-to-test