### PR TITLE
fix large template file issue

### DIFF
--- a/ci_pod/nginx/ibm_conf.conf
+++ b/ci_pod/nginx/ibm_conf.conf
@@ -126,11 +126,12 @@ server {
         server_name $JUPYTERLAB_URL;
 
         location / {
-
                 # First attempt to serve request as file, then
                 # as directory, then fall back to displaying a 404.
                 proxy_pass http://localhost:8888;
                 proxy_set_header      Host $host;
+                # display template > 1MB
+                client_max_body_size 64m;
         }
         # solved kernel issue: https://github.com/jupyter/notebook/issues/625
         location /api/kernels/ {


### PR DESCRIPTION
Fix:

1. When displayed large Jupyterlab > 1MB templates got the following error:
```
File Save Error for presentation.ipynb
Invalid response: 413
```
Solved it according to the following [recommendation](https://github.com/nds-org/esiphub/issues/18)

Adding the following parameter to Jupyterlab section in nginx conf:
`client_max_body_size 64m;`
