### PR TITLE
fix oc get version

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -44,7 +44,7 @@ class OC(SSH):
         This method return ocp server version
         :return:
         """
-        return self.run(f"{self.__cli} version -ojson | jq -r '.openshiftVersion'")
+        return self.run(f"{self.__cli} get clusterversion version -o jsonpath='{{.status.desired.version}}'")
 
     def get_cnv_version(self):
         """


### PR DESCRIPTION
Fix:

Update oc get version using -o jsonpath instead of jq parser due to change in json hierarchy