### PR TITLE
Fix elasticsearch index widget

### DIFF
--- a/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
+++ b/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
@@ -305,15 +305,14 @@ class ElasticSearchOperations:
             raise Exception('Empty parameters: index/ start_datetime/ end_datetime')
 
     @logger_time_stamp
-    def get_all_result_index(self):
+    def get_all_indexes(self):
         """
-        This method returns sorted elasticsearch indexes that contains results
+        This method returns sorted elasticsearch indexes
         @return:
         """
-        index_results = []
+        indexes = []
         # Fetch all indices
         indices = self.__es.cat.indices(format="json")
         for index in indices:
-            if 'results' in index['index']:
-                index_results.append(index['index'])
-        return sorted(index_results)
+            indexes.append(index['index'])
+        return sorted(indexes)

--- a/benchmark_runner/jupyterlab/templates/elasticsearch_operations/elasticsearch_widgets.py
+++ b/benchmark_runner/jupyterlab/templates/elasticsearch_operations/elasticsearch_widgets.py
@@ -39,14 +39,22 @@ class ElasticSearchWidgets:
         """
         return elastic_index
 
+    def get_perfci_indexes(self):
+        """
+        This method returns sorted perfci elasticsearch indexes that contains 'results' or 'status'
+        @return:
+        """
+        # Use list comprehension to filter strings containing 'result' or 'status'
+        return [item for item in self.__elasticsearch.get_all_indexes() if 'result' in item or 'status' in item]
+
     def index_dropdown(self):
         """
         index dropdown widget
         @return:
         """
         dropdown = widgets.Dropdown(
-            options=self.__elasticsearch.get_all_result_index(),
-            value=self.__elasticsearch.get_all_result_index()[0],
+            options=self.get_perfci_indexes(),
+            value=self.get_perfci_indexes()[0],
             description='Choose INDEX & DATES:',
             style={'description_width': 'initial'},
             layout=widgets.Layout(width='500px')

--- a/tests/integration/benchmark_runner/common/elasticsearch/test_elasticsearch_operations.py
+++ b/tests/integration/benchmark_runner/common/elasticsearch/test_elasticsearch_operations.py
@@ -64,13 +64,13 @@ def test_get_delete_ids_elasticsearch_last_day():
     assert len(elastic.get_index_ids_between_dates(index=TEST_INDEX_NAME, start_datetime=day_before_timestamp, end_datetime=current_timestamp)) == 0
 
 
-def test_get_all_result_index():
+def test_get_all_indexes():
     """
-    This method gets all result index
+    This method gets all indexes
     @return:
     """
     elastic = ElasticSearchOperations(es_host=test_environment_variable.get('elasticsearch', ''),
                                       es_port=test_environment_variable.get('elasticsearch_port', ''),
                                       es_user=test_environment_variable.get('elasticsearch_user', ''),
                                       es_password=test_environment_variable.get('elasticsearch_password', ''))
-    assert len(elastic.get_all_result_index()) > 1
+    assert len(elastic.get_all_indexes()) > 1


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Missing status index due to missing 'status' in filtering.
Fix get_all_indexes() method to return all the indexes and filtered perfci index results in elasticsearch widget class

## For security reasons, all pull requests need to be approved first before running any automated CI
