### PR TITLE
Update Prometheus VM memory metrics

### DIFF
--- a/benchmark_runner/common/prometheus/metrics-default.yaml
+++ b/benchmark_runner/common/prometheus/metrics-default.yaml
@@ -1,4 +1,5 @@
 
+
 # container CPU/Memory
 
 - query: (sum(irate(container_cpu_usage_seconds_total{container!="",namespace="benchmark-runner", mode!="idle"}[2m])) by (node)) > 0
@@ -7,4 +8,12 @@
 - query: sum(container_memory_rss{namespace="benchmark-runner"} and on (node) kube_node_role{role="worker"}) by (node) > 0
   metricName: containerMemory-benchmark-runner
 
+- query: container_memory_cache{pod=~"virt-launcher.*", container="compute"}
+  metricName: VM Memory Cache
+
+- query: container_memory_working_set_bytes{pod=~"virt-launcher.*", container="compute"}
+  metricName: VM Memory working set bytes
+
+- query: container_memory_max_usage_bytes{pod=~"virt-launcher.*", container="compute"}
+  metricName: VM Memory Max Usage Bytes
 

--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -225,7 +225,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
       + stateTimeline.fieldConfig.defaults.withMappings([
         stateTimeline.valueMapping.RegexMap.withOptions(
         //START_VALUE_MAPPING_227
-				 {"0": {"index": 0, "text": "fail"}, "1": {"index": 1, "text": "pass"}, "102": {"index": 13, "text": "1.0.2"}, "110": {"index": 14, "text": "1.1.0"}, "120": {"index": 15, "text": "1.2.0"}, "121": {"index": 16, "text": "1.2.1"}, "130": {"index": 45, "text": "1.3.0"}, "131": {"index": 117, "text": "1.3.1"}, "132": {"index": 76, "text": "1.3.2"}, "133": {"index": 77, "text": "1.3.3"}, "140": {"index": 118, "text": "1.4.0"}, "483": {"index": 0, "text": "4.8.3"}, "484": {"index": 1, "text": "4.8.4"}, "485": {"index": 2, "text": "4.8.5"}, "486": {"index": 3, "text": "4.8.6"}, "487": {"index": 4, "text": "4.8.7"}, "488": {"index": 5, "text": "4.8.8"}, "3025": {"index": 86, "text": "3.0.2-5"}, "3026": {"index": 119, "text": "3.0.2-6"}, "4102": {"index": 33, "text": "4.10.2"}, "4104": {"index": 34, "text": "4.10.4"}, "4105": {"index": 35, "text": "4.10.5"}, "4106": {"index": 36, "text": "4.10.6"}, "4108": {"index": 37, "text": "4.10.8"}, "4109": {"index": 38, "text": "4.10.9"}, "4114": {"index": 54, "text": "4.11.4"}, "4115": {"index": 55, "text": "4.11.5"}, "4116": {"index": 56, "text": "4.11.6"}, "4117": {"index": 57, "text": "4.11.7"}, "4118": {"index": 58, "text": "4.11.8"}, "4119": {"index": 59, "text": "4.11.9"}, "4120": {"index": 68, "text": "4.12.0"}, "4121": {"index": 69, "text": "4.12.1"}, "4122": {"index": 70, "text": "4.12.2"}, "4124": {"index": 80, "text": "4.12.4"}, "4130": {"index": 106, "text": "4.13.0"}, "4131": {"index": 109, "text": "4.13.1"}, "4132": {"index": 110, "text": "4.13.2"}, "4133": {"index": 111, "text": "4.13.3"}, "4814": {"index": 6, "text": "4.8.14"}, "4932": {"index": 8, "text": "4.9.3-2"}, "4947": {"index": 9, "text": "4.9.4-7"}, "4955": {"index": 10, "text": "4.9.5-5"}, "4961": {"index": 11, "text": "4.9.6-1"}, "4972": {"index": 12, "text": "4.9.7-2"}, "41002": {"index": 30, "text": "4.10.0-rc.2"}, "41003": {"index": 31, "text": "4.10.0-rc.3"}, "41007": {"index": 32, "text": "4.10.0-rc.7"}, "41010": {"index": 39, "text": "4.10.10"}, "41011": {"index": 40, "text": "4.10.11"}, "41012": {"index": 41, "text": "4.10.12"}, "41013": {"index": 42, "text": "4.10.13"}, "41014": {"index": 43, "text": "4.10.14"}, "41015": {"index": 44, "text": "4.10.15"}, "41016": {"index": 21, "text": "4.10.1-6"}, "41021": {"index": 28, "text": "4.10.2-1"}, "41023": {"index": 29, "text": "4.10.2-3"}, "41054": {"index": 49, "text": "4.10.5-4"}, "41066": {"index": 48, "text": "4.10.6-6"}, "41110": {"index": 60, "text": "4.11.10"}, "41111": {"index": 61, "text": "4.11.11"}, "41112": {"index": 62, "text": "4.11.12"}, "41113": {"index": 63, "text": "4.11.13"}, "41114": {"index": 64, "text": "4.11.14"}, "41144": {"index": 78, "text": "4.11.4-4"}, "41159": {"index": 79, "text": "4.11.5-9"}, "41206": {"index": 65, "text": "4.12.0.6"}, "41207": {"index": 66, "text": "4.12.0.7"}, "41208": {"index": 67, "text": "4.12.0.8"}, "41218": {"index": 73, "text": "4.12.1-8"}, "41224": {"index": 85, "text": "4.12.2-4"}, "41304": {"index": 102, "text": "4.13.0-rc.4"}, "41305": {"index": 103, "text": "4.13.0-rc.5"}, "41307": {"index": 104, "text": "4.13.0-rc.7"}, "41308": {"index": 105, "text": "4.13.0-rc.8"}, "49211": {"index": 7, "text": "4.9.2-11"}, "410129": {"index": 22, "text": "4.10.1-29"}, "410136": {"index": 23, "text": "4.10.1-36"}, "410160": {"index": 24, "text": "4.10.1-60"}, "410170": {"index": 25, "text": "4.10.1-70"}, "410197": {"index": 26, "text": "4.10.1-97"}, "411115": {"index": 52, "text": "4.11.1-15"}, "411121": {"index": 51, "text": "4.11.1-21"}, "411135": {"index": 46, "text": "4.11.1-35"}, "411142": {"index": 47, "text": "4.11.1-42"}, "411605": {"index": 53, "text": "4.11.6-5"}, "412116": {"index": 74, "text": "4.12.1-16"}, "412119": {"index": 84, "text": "4.12.1-19"}, "412122": {"index": 75, "text": "4.12.1-22"}, "412139": {"index": 82, "text": "4.12.1-39"}, "412140": {"index": 81, "text": "4.12.1-40"}, "412317": {"index": 121, "text": "4.12.3-17"}, "413014": {"index": 101, "text": "4.13.0-ec.4"}, "413118": {"index": 113, "text": "4.13.1-18"}, "413140": {"index": 114, "text": "4.13.1-40"}, "4100683": {"index": 17, "text": "4.10.0-683"}, "4100688": {"index": 18, "text": "4.10.0-688"}, "4100700": {"index": 19, "text": "4.10.0-700"}, "4100729": {"index": 20, "text": "4.10.0-729"}, "4101101": {"index": 27, "text": "4.10.1-101"}, "4110137": {"index": 50, "text": "4.11.0-137"}, "4120173": {"index": 83, "text": "4.12.0-173"}, "4120777": {"index": 71, "text": "4.12.0-777"}, "4120781": {"index": 72, "text": "4.12.0-781"}, "4131154": {"index": 115, "text": "4.13.1-154"}, "41301586": {"index": 88, "text": "4.13.0-1586"}, "41301649": {"index": 89, "text": "4.13.0-1649"}, "41301666": {"index": 91, "text": "4.13.0-1666"}, "41301689": {"index": 90, "text": "4.13.0-1689"}, "41301782": {"index": 92, "text": "4.13.0-1782"}, "41301856": {"index": 93, "text": "4.13.0-1856"}, "41301938": {"index": 94, "text": "4.13.0-1938"}, "41301943": {"index": 95, "text": "4.13.0-1943"}, "41302115": {"index": 96, "text": "4.13.0-2115"}, "41302176": {"index": 97, "text": "4.13.0-2176"}, "41302229": {"index": 98, "text": "4.13.0-2229"}, "41302251": {"index": 99, "text": "4.13.0-2251"}, "41302269": {"index": 100, "text": "4.13.0-2269"}, "4130ec3": {"index": 87, "text": "4.13.0-ec.3"}, "CNV": {"index": 112, "text": "CNV"}, "KATA": {"index": 116, "text": "KATA"}, "OCP": {"index": 108, "text": "OCP"}, "ODF": {"index": 120, "text": "ODF"}, "Product Versions": {"index": 107, "text": "Product Versions"}, "4136": {"index": 122, "text": "4.13.6"}, "413360": {"index": 123, "text": "4.13.3-60"}, "41244": {"index": 126, "text": "4.12.4-4"}, "4134": {"index": 130, "text": "4.13.4"}, "4131206": {"index": 131, "text": "4.13.1-206"}, "4131214": {"index": 132, "text": "4.13.1-214"}, "41323": {"index": 133, "text": "4.13.2-3"}, "413273": {"index": 134, "text": "4.13.2-73"}, "41338": {"index": 135, "text": "4.13.3-8"}, "413267": {"index": 136, "text": "4.13.2-67"}, "4137": {"index": 137, "text": "4.13.7"}, "4133166": {"index": 138, "text": "4.13.3-166"}, "141": {"index": 139, "text": "1.4.1"}, "41252": {"index": 140, "text": "4.12.5-2"}, "4138": {"index": 141, "text": "4.13.8"}, "4133203": {"index": 142, "text": "4.13.3-203"}, "4139": {"index": 143, "text": "4.13.9"}, "413426": {"index": 145, "text": "4.13.4-26"}, "4133266": {"index": 146, "text": "4.13.3-266"}, "41311": {"index": 147, "text": "4.13.11"}, "4134140": {"index": 148, "text": "4.13.4-140"}, "41272": {"index": 149, "text": "4.12.7-2"}, "41312": {"index": 150, "text": "4.13.12"}, "4134192": {"index": 151, "text": "4.13.4-192"}} 
+				 {"0": {"index": 0, "text": "fail"}, "1": {"index": 1, "text": "pass"}, "102": {"index": 13, "text": "1.0.2"}, "110": {"index": 14, "text": "1.1.0"}, "120": {"index": 15, "text": "1.2.0"}, "121": {"index": 16, "text": "1.2.1"}, "130": {"index": 45, "text": "1.3.0"}, "131": {"index": 117, "text": "1.3.1"}, "132": {"index": 76, "text": "1.3.2"}, "133": {"index": 77, "text": "1.3.3"}, "140": {"index": 118, "text": "1.4.0"}, "483": {"index": 0, "text": "4.8.3"}, "484": {"index": 1, "text": "4.8.4"}, "485": {"index": 2, "text": "4.8.5"}, "486": {"index": 3, "text": "4.8.6"}, "487": {"index": 4, "text": "4.8.7"}, "488": {"index": 5, "text": "4.8.8"}, "3025": {"index": 86, "text": "3.0.2-5"}, "3026": {"index": 119, "text": "3.0.2-6"}, "4102": {"index": 33, "text": "4.10.2"}, "4104": {"index": 34, "text": "4.10.4"}, "4105": {"index": 35, "text": "4.10.5"}, "4106": {"index": 36, "text": "4.10.6"}, "4108": {"index": 37, "text": "4.10.8"}, "4109": {"index": 38, "text": "4.10.9"}, "4114": {"index": 54, "text": "4.11.4"}, "4115": {"index": 55, "text": "4.11.5"}, "4116": {"index": 56, "text": "4.11.6"}, "4117": {"index": 57, "text": "4.11.7"}, "4118": {"index": 58, "text": "4.11.8"}, "4119": {"index": 59, "text": "4.11.9"}, "4120": {"index": 68, "text": "4.12.0"}, "4121": {"index": 69, "text": "4.12.1"}, "4122": {"index": 70, "text": "4.12.2"}, "4124": {"index": 80, "text": "4.12.4"}, "4130": {"index": 106, "text": "4.13.0"}, "4131": {"index": 109, "text": "4.13.1"}, "4132": {"index": 110, "text": "4.13.2"}, "4133": {"index": 111, "text": "4.13.3"}, "4814": {"index": 6, "text": "4.8.14"}, "4932": {"index": 8, "text": "4.9.3-2"}, "4947": {"index": 9, "text": "4.9.4-7"}, "4955": {"index": 10, "text": "4.9.5-5"}, "4961": {"index": 11, "text": "4.9.6-1"}, "4972": {"index": 12, "text": "4.9.7-2"}, "41002": {"index": 30, "text": "4.10.0-rc.2"}, "41003": {"index": 31, "text": "4.10.0-rc.3"}, "41007": {"index": 32, "text": "4.10.0-rc.7"}, "41010": {"index": 39, "text": "4.10.10"}, "41011": {"index": 40, "text": "4.10.11"}, "41012": {"index": 41, "text": "4.10.12"}, "41013": {"index": 42, "text": "4.10.13"}, "41014": {"index": 43, "text": "4.10.14"}, "41015": {"index": 44, "text": "4.10.15"}, "41016": {"index": 21, "text": "4.10.1-6"}, "41021": {"index": 28, "text": "4.10.2-1"}, "41023": {"index": 29, "text": "4.10.2-3"}, "41054": {"index": 49, "text": "4.10.5-4"}, "41066": {"index": 48, "text": "4.10.6-6"}, "41110": {"index": 60, "text": "4.11.10"}, "41111": {"index": 61, "text": "4.11.11"}, "41112": {"index": 62, "text": "4.11.12"}, "41113": {"index": 63, "text": "4.11.13"}, "41114": {"index": 64, "text": "4.11.14"}, "41144": {"index": 78, "text": "4.11.4-4"}, "41159": {"index": 79, "text": "4.11.5-9"}, "41206": {"index": 65, "text": "4.12.0.6"}, "41207": {"index": 66, "text": "4.12.0.7"}, "41208": {"index": 67, "text": "4.12.0.8"}, "41218": {"index": 73, "text": "4.12.1-8"}, "41224": {"index": 85, "text": "4.12.2-4"}, "41304": {"index": 102, "text": "4.13.0-rc.4"}, "41305": {"index": 103, "text": "4.13.0-rc.5"}, "41307": {"index": 104, "text": "4.13.0-rc.7"}, "41308": {"index": 105, "text": "4.13.0-rc.8"}, "49211": {"index": 7, "text": "4.9.2-11"}, "410129": {"index": 22, "text": "4.10.1-29"}, "410136": {"index": 23, "text": "4.10.1-36"}, "410160": {"index": 24, "text": "4.10.1-60"}, "410170": {"index": 25, "text": "4.10.1-70"}, "410197": {"index": 26, "text": "4.10.1-97"}, "411115": {"index": 52, "text": "4.11.1-15"}, "411121": {"index": 51, "text": "4.11.1-21"}, "411135": {"index": 46, "text": "4.11.1-35"}, "411142": {"index": 47, "text": "4.11.1-42"}, "411605": {"index": 53, "text": "4.11.6-5"}, "412116": {"index": 74, "text": "4.12.1-16"}, "412119": {"index": 84, "text": "4.12.1-19"}, "412122": {"index": 75, "text": "4.12.1-22"}, "412139": {"index": 82, "text": "4.12.1-39"}, "412140": {"index": 81, "text": "4.12.1-40"}, "412317": {"index": 121, "text": "4.12.3-17"}, "413014": {"index": 101, "text": "4.13.0-ec.4"}, "413118": {"index": 113, "text": "4.13.1-18"}, "413140": {"index": 114, "text": "4.13.1-40"}, "4100683": {"index": 17, "text": "4.10.0-683"}, "4100688": {"index": 18, "text": "4.10.0-688"}, "4100700": {"index": 19, "text": "4.10.0-700"}, "4100729": {"index": 20, "text": "4.10.0-729"}, "4101101": {"index": 27, "text": "4.10.1-101"}, "4110137": {"index": 50, "text": "4.11.0-137"}, "4120173": {"index": 83, "text": "4.12.0-173"}, "4120777": {"index": 71, "text": "4.12.0-777"}, "4120781": {"index": 72, "text": "4.12.0-781"}, "4131154": {"index": 115, "text": "4.13.1-154"}, "41301586": {"index": 88, "text": "4.13.0-1586"}, "41301649": {"index": 89, "text": "4.13.0-1649"}, "41301666": {"index": 91, "text": "4.13.0-1666"}, "41301689": {"index": 90, "text": "4.13.0-1689"}, "41301782": {"index": 92, "text": "4.13.0-1782"}, "41301856": {"index": 93, "text": "4.13.0-1856"}, "41301938": {"index": 94, "text": "4.13.0-1938"}, "41301943": {"index": 95, "text": "4.13.0-1943"}, "41302115": {"index": 96, "text": "4.13.0-2115"}, "41302176": {"index": 97, "text": "4.13.0-2176"}, "41302229": {"index": 98, "text": "4.13.0-2229"}, "41302251": {"index": 99, "text": "4.13.0-2251"}, "41302269": {"index": 100, "text": "4.13.0-2269"}, "4130ec3": {"index": 87, "text": "4.13.0-ec.3"}, "CNV": {"index": 112, "text": "CNV"}, "KATA": {"index": 116, "text": "KATA"}, "OCP": {"index": 108, "text": "OCP"}, "ODF": {"index": 120, "text": "ODF"}, "Product Versions": {"index": 107, "text": "Product Versions"}, "4136": {"index": 122, "text": "4.13.6"}, "413360": {"index": 123, "text": "4.13.3-60"}, "41244": {"index": 126, "text": "4.12.4-4"}, "4134": {"index": 130, "text": "4.13.4"}, "4131206": {"index": 131, "text": "4.13.1-206"}, "4131214": {"index": 132, "text": "4.13.1-214"}, "41323": {"index": 133, "text": "4.13.2-3"}, "413273": {"index": 134, "text": "4.13.2-73"}, "41338": {"index": 135, "text": "4.13.3-8"}, "413267": {"index": 136, "text": "4.13.2-67"}, "4137": {"index": 137, "text": "4.13.7"}, "4133166": {"index": 138, "text": "4.13.3-166"}, "141": {"index": 139, "text": "1.4.1"}, "41252": {"index": 140, "text": "4.12.5-2"}, "4138": {"index": 141, "text": "4.13.8"}, "4133203": {"index": 142, "text": "4.13.3-203"}, "4139": {"index": 143, "text": "4.13.9"}, "413426": {"index": 145, "text": "4.13.4-26"}, "4133266": {"index": 146, "text": "4.13.3-266"}, "41310": {"index": 147, "text": "4.13.10"}, "413482": {"index": 148, "text": "4.13.4-82"}, "41263": {"index": 149, "text": "4.12.6-3"}, "41311": {"index": 150, "text": "4.13.11"}, "4134140": {"index": 151, "text": "4.13.4-140"}, "41272": {"index": 152, "text": "4.12.7-2"}, "41312": {"index": 153, "text": "4.13.12"}, "4134192": {"index": 154, "text": "4.13.4-192"}}
  		//END_VALUE_MAPPING_227
  		)
         + stateTimeline.valueMapping.RegexMap.withType('value')
@@ -488,7 +488,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTargetBlank(true)
               + stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&viewPanel=32&from=now-45d&to=now')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&viewPanel=128')
 
             ])
 
@@ -642,7 +642,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTargetBlank(true)
               + stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&editPanel=33&from=now-45d&to=now')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&viewPanel=129')
 
             ])
 
@@ -816,7 +816,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&editPanel=33&from=now-45d&to=now')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&viewPanel=129')
 
             ])
 
@@ -955,10 +955,10 @@ g.dashboard.new('PerfCI-Regression-Summary')
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTargetBlank(true)
               + stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=34'),
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=133'),
 
-              stateTimeline.link.withTitle('scale artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=35')
+              stateTimeline.link.withTitle('scale  log link')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=195')
 
             ])
 
@@ -1027,48 +1027,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ////
 
-
-              elasticsearch.withAlias('Total {{term kind.keyword}} Memory (GB) [384GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
-                + elasticsearch.bucketAggs.Terms.withId('6')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('5')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-
-              + elasticsearch.withHide(false)
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('total_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-
-              ])
-
-              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('B')
-              +elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-              elasticsearch.withAlias('Total {{term kind.keyword}} %CPU [240 cores]')
+              elasticsearch.withAlias('Total %CPU [240 cores]: 1 {{term kind.keyword}}')
 
               + elasticsearch.withBucketAggs([
 
@@ -1102,11 +1061,58 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('C')
+              +elasticsearch.withRefId('B')
               +elasticsearch.withTimeField('timestamp'),
 
               ////
 
+              elasticsearch.withAlias('{{field}} [GB]')
+
+              + elasticsearch.withBucketAggs([
+
+                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
+                + elasticsearch.bucketAggs.Terms.withId('6')
+                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
+                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
+                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
+                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
+                + elasticsearch.bucketAggs.Terms.withType('terms'),
+
+                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
+                + elasticsearch.bucketAggs.DateHistogram.withId('5')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
+                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
+
+
+              ])
+
+
+              + elasticsearch.withHide(false)
+
+              + elasticsearch.withMetrics([
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Cache')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory working set bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('2')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Max Usage Bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('3')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+
+              ])
+
+              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:'vm' AND Run:$vdbench_type AND ocp_version:$ocp_version")
+              +elasticsearch.withRefId('C')
+              +elasticsearch.withTimeField('timestamp'),
+
+              ////
 
               elasticsearch.withAlias('{{term Run.keyword}} : {{term Threads}}th :{{term scale}} {{term kind.keyword}}s')
 
@@ -1164,14 +1170,14 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
+              +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
               +elasticsearch.withRefId('D')
               +elasticsearch.withTimeField('timestamp'),
 
 
               ////
 
-              elasticsearch.withAlias('Total {{term kind.keyword}} Memory (GB) [384GB]')
+              elasticsearch.withAlias('Total %CPU [240 cores]: {{term scale}} {{term kind.keyword}}')
 
               + elasticsearch.withBucketAggs([
 
@@ -1183,40 +1189,8 @@ g.dashboard.new('PerfCI-Regression-Summary')
                 + elasticsearch.bucketAggs.Terms.settings.withSize('10')
                 + elasticsearch.bucketAggs.Terms.withType('terms'),
 
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('5')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-
-              + elasticsearch.withHide(false)
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('total_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-
-              ])
-
-              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('E')
-              +elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-              elasticsearch.withAlias('Total {{term kind.keyword}} %CPU [240 cores]')
-
-              + elasticsearch.withBucketAggs([
-
-                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
-                + elasticsearch.bucketAggs.Terms.withId('2')
+                elasticsearch.bucketAggs.Terms.withField('scale')
+                + elasticsearch.bucketAggs.Terms.withId('3')
                 + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
                 + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
                 + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
@@ -1245,10 +1219,59 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
+              +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
+              +elasticsearch.withRefId('E')
+              +elasticsearch.withTimeField('timestamp'),
+
+            ////
+
+             elasticsearch.withAlias('{{field}} [GB]')
+
+              + elasticsearch.withBucketAggs([
+
+                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
+                + elasticsearch.bucketAggs.Terms.withId('6')
+                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
+                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
+                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
+                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
+                + elasticsearch.bucketAggs.Terms.withType('terms'),
+
+                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
+                + elasticsearch.bucketAggs.DateHistogram.withId('5')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
+                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
+
+
+              ])
+
+
+              + elasticsearch.withHide(false)
+
+              + elasticsearch.withMetrics([
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Cache')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory working set bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('2')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Max Usage Bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('3')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+
+              ])
+
+              +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:'vm' AND Run:$vdbench_type AND ocp_version:$ocp_version")
               +elasticsearch.withRefId('F')
               +elasticsearch.withTimeField('timestamp'),
 
+              ////
 
 
 
@@ -1256,7 +1279,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             ////
 
-            g.panel.stateTimeline.new('vdbench Latency  (sec)')
+            g.panel.stateTimeline.new('vdbench Latency (sec)')
             + stateTimeline.queryOptions.withDatasource('Elasticsearch-vdbench-results')
 
 
@@ -1299,10 +1322,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTargetBlank(true)
               + stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=34'),
-
-              stateTimeline.link.withTitle('scale artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=35')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&editPanel=133&from=now-45d&to=now')
 
             ])
 
@@ -1369,49 +1389,10 @@ g.dashboard.new('PerfCI-Regression-Summary')
               +elasticsearch.withRefId('A')
               +elasticsearch.withTimeField('timestamp'),
 
-            ////
-
-
-              elasticsearch.withAlias('"Total {{term kind.keyword}} Memory (GB) [384GB]')
-              + elasticsearch.withBucketAggs([
-
-                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('5')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-              ])
-
-              + elasticsearch.withHide(false)
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('total_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-
-              ])
-
-              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('B')
-              +elasticsearch.withTimeField('timestamp'),
 
             ////
 
-
-
-            elasticsearch.withAlias('Total {{term kind.keyword}} %CPU [240 cores]')
+            elasticsearch.withAlias('Total %CPU [240 cores]: 1 {{term kind.keyword}}')
               + elasticsearch.withBucketAggs([
 
                 elasticsearch.bucketAggs.Terms.withField('kind.keyword')
@@ -1441,11 +1422,58 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('D')
+              +elasticsearch.withRefId('B')
               +elasticsearch.withTimeField('timestamp'),
 
             ////
 
+             elasticsearch.withAlias('{{field}} [GB]')
+
+              + elasticsearch.withBucketAggs([
+
+                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
+                + elasticsearch.bucketAggs.Terms.withId('6')
+                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
+                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
+                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
+                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
+                + elasticsearch.bucketAggs.Terms.withType('terms'),
+
+                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
+                + elasticsearch.bucketAggs.DateHistogram.withId('5')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
+                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
+
+
+              ])
+
+
+              + elasticsearch.withHide(false)
+
+              + elasticsearch.withMetrics([
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Cache')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory working set bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('2')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Max Usage Bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('3')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+
+              ])
+
+              +elasticsearch.withQuery("!SCALE AND !Run.keyword='fillup' AND kind:'vm' AND Run:$vdbench_type AND ocp_version:$ocp_version")
+              +elasticsearch.withRefId('C')
+              +elasticsearch.withTimeField('timestamp'),
+
+              ////
 
             elasticsearch.withAlias('{{term Run.keyword}} : {{term Threads}}th :{{term scale}} {{term kind.keyword}}s')
               + elasticsearch.withBucketAggs([
@@ -1501,52 +1529,24 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('C')
+              +elasticsearch.withRefId('D')
               +elasticsearch.withTimeField('timestamp'),
 
             ////
 
+             elasticsearch.withAlias('Total %CPU [240 cores]: {{term scale}} {{term kind.keyword}}')
 
-            elasticsearch.withAlias('Total {{term kind.keyword}} Memory (GB) [384GB]')
               + elasticsearch.withBucketAggs([
 
                 elasticsearch.bucketAggs.Terms.withField('kind.keyword')
-                + elasticsearch.bucketAggs.Terms.withId('3')
+                + elasticsearch.bucketAggs.Terms.withId('2')
                 + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
                 + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
                 + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
                 + elasticsearch.bucketAggs.Terms.settings.withSize('10')
                 + elasticsearch.bucketAggs.Terms.withType('terms'),
 
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('5')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-              ])
-
-              + elasticsearch.withHide(false)
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('total_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('E')
-              +elasticsearch.withTimeField('timestamp'),
-
-            ////
-
-            elasticsearch.withAlias('Total {{term kind.keyword}} %CPU [240 cores]')
-              + elasticsearch.withBucketAggs([
-
-                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
+                elasticsearch.bucketAggs.Terms.withField('scale')
                 + elasticsearch.bucketAggs.Terms.withId('3')
                 + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
                 + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
@@ -1574,11 +1574,58 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:$kind AND Run:$vdbench_type AND ocp_version:$ocp_version")
-              +elasticsearch.withRefId('F')
-              +elasticsearch.withTimeField('timestamp')
+              +elasticsearch.withRefId('E')
+              +elasticsearch.withTimeField('timestamp'),
 
             ////
 
+             elasticsearch.withAlias('{{field}} [GB]')
+
+              + elasticsearch.withBucketAggs([
+
+                elasticsearch.bucketAggs.Terms.withField('kind.keyword')
+                + elasticsearch.bucketAggs.Terms.withId('6')
+                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
+                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
+                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
+                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
+                + elasticsearch.bucketAggs.Terms.withType('terms'),
+
+                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
+                + elasticsearch.bucketAggs.DateHistogram.withId('5')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withMinDocCount('0')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTimeZone('utc')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withTrimEdges('0')
+                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
+
+
+              ])
+
+
+              + elasticsearch.withHide(false)
+
+              + elasticsearch.withMetrics([
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Cache')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory working set bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('2')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Max Usage Bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('3')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+
+              ])
+
+              +elasticsearch.withQuery("SCALE AND !Run.keyword='fillup' AND kind:'vm' AND Run:$vdbench_type AND ocp_version:$ocp_version")
+              +elasticsearch.withRefId('F')
+              +elasticsearch.withTimeField('timestamp'),
+
+              ////
 
 
             ])
@@ -1639,7 +1686,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
 
@@ -1851,7 +1898,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
 
@@ -2033,7 +2080,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
 
@@ -2324,7 +2371,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
             + stateTimeline.options.withAlignValue('center')
@@ -2793,7 +2840,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
             + stateTimeline.options.withAlignValue('left')
@@ -3247,7 +3294,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
             + stateTimeline.options.withAlignValue('left')
@@ -3450,7 +3497,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=36')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
             + stateTimeline.options.withAlignValue('left')
@@ -3672,7 +3719,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=37')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=1659592686997&to=1663480686997&viewPanel=166')
 
             ])
 
@@ -4068,7 +4115,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=37')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
 
@@ -4500,7 +4547,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=37')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
 
@@ -4620,7 +4667,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=37')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=150')
 
             ])
 
@@ -4779,7 +4826,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTargetBlank(true)
               + stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=38')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/regression-summary?orgId=1&from=now-45d&to=now&viewPanel=190')
 
             ])
 
@@ -4941,148 +4988,6 @@ g.dashboard.new('PerfCI-Regression-Summary')
               + elasticsearch.withRefId('D')
               + elasticsearch.withTimeField('timestamp'),
 
-              ////
-
-              elasticsearch.withAlias('Memory(GB) [384GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('total_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('F')
-              + elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-              elasticsearch.withAlias('Memory Worker-0 (GB) [128GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('worker-0_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('E')
-              + elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-
-              elasticsearch.withAlias('Memory Worker-1 (GB) [128GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('worker-1_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('G')
-              + elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-
-
-              elasticsearch.withAlias('Memory Worker-2 (GB) [128GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('worker-2_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('H')
-              + elasticsearch.withTimeField('timestamp'),
 
               ////
 
@@ -5118,7 +5023,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('I')
+              + elasticsearch.withRefId('E')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
@@ -5154,7 +5059,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('J')
+              + elasticsearch.withRefId('F')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
@@ -5190,7 +5095,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('K')
+              + elasticsearch.withRefId('G')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
@@ -5225,11 +5130,53 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('L')
+              + elasticsearch.withRefId('H')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
 
+              elasticsearch.withAlias('{{field}} [GB]')
+
+              + elasticsearch.withBucketAggs([
+                elasticsearch.bucketAggs.Terms.withField('scale')
+                + elasticsearch.bucketAggs.Terms.withId('3')
+                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
+                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
+                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
+                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
+                + elasticsearch.bucketAggs.Terms.withType('terms'),
+
+                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
+                + elasticsearch.bucketAggs.DateHistogram.withId('2')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
+                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
+
+
+              ])
+
+              + elasticsearch.withHide(false)
+
+              + elasticsearch.withMetrics([
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Cache')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory working set bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('2')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Max Usage Bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('3')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+
+              ])
+
+              + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
+              + elasticsearch.withRefId('I')
+              + elasticsearch.withTimeField('timestamp'),
+
+              ////
 
               elasticsearch.withAlias('VMs #')
 
@@ -5259,7 +5206,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('M')
+              + elasticsearch.withRefId('J')
               + elasticsearch.withTimeField('timestamp')
 
               ////
@@ -5331,7 +5278,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
             + stateTimeline.panelOptions.withLinks([
               stateTimeline.link.withTargetBlank(true)
               + stateTimeline.link.withTitle('artifacts link')
-              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=39')
+              + stateTimeline.link.withUrl('https://grafana-perf-chmf5l4sh776bznl3b.ibm.rhperfscale.org/d/T4775LKnzzmichey/perfci-regression-summary?orgId=1&from=now-45d&to=now&viewPanel=194')
 
             ])
 
@@ -5493,148 +5440,6 @@ g.dashboard.new('PerfCI-Regression-Summary')
               + elasticsearch.withRefId('D')
               + elasticsearch.withTimeField('timestamp'),
 
-              ////
-
-              elasticsearch.withAlias('Memory(GB) [384GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('total_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000/2')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('F')
-              + elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-              elasticsearch.withAlias('Memory Worker-0 (GB) [128GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('worker-0_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:240 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('E')
-              + elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-
-              elasticsearch.withAlias('Memory Worker-1 (GB) [128GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('worker-1_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000/2')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('G')
-              + elasticsearch.withTimeField('timestamp'),
-
-              ////
-
-
-
-              elasticsearch.withAlias('Memory Worker-2 (GB) [128GB]')
-
-              + elasticsearch.withBucketAggs([
-                elasticsearch.bucketAggs.Terms.withField('scale')
-                + elasticsearch.bucketAggs.Terms.withId('3')
-                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
-                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
-                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
-                + elasticsearch.bucketAggs.Terms.withType('terms'),
-
-                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
-                + elasticsearch.bucketAggs.DateHistogram.withId('2')
-                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
-                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
-
-
-              ])
-
-              + elasticsearch.withHide(false)
-
-              + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('worker-2_Memory')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value/1000000000/2')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
-
-              ])
-
-              + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('H')
-              + elasticsearch.withTimeField('timestamp'),
 
               ////
 
@@ -5670,7 +5475,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('I')
+              + elasticsearch.withRefId('E')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
@@ -5706,7 +5511,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('J')
+              + elasticsearch.withRefId('F')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
@@ -5742,7 +5547,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('K')
+              + elasticsearch.withRefId('G')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
@@ -5777,11 +5582,54 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('L')
+              + elasticsearch.withRefId('H')
               + elasticsearch.withTimeField('timestamp'),
 
               ////
 
+
+              elasticsearch.withAlias('{{field}} [GB]')
+
+              + elasticsearch.withBucketAggs([
+                elasticsearch.bucketAggs.Terms.withField('scale')
+                + elasticsearch.bucketAggs.Terms.withId('3')
+                + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
+                + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
+                + elasticsearch.bucketAggs.Terms.settings.withOrderBy('_term')
+                + elasticsearch.bucketAggs.Terms.settings.withSize('10')
+                + elasticsearch.bucketAggs.Terms.withType('terms'),
+
+                elasticsearch.bucketAggs.DateHistogram.withField('timestamp')
+                + elasticsearch.bucketAggs.DateHistogram.withId('2')
+                + elasticsearch.bucketAggs.DateHistogram.settings.withInterval('auto')
+                + elasticsearch.bucketAggs.DateHistogram.withType('date_histogram')
+
+
+              ])
+
+              + elasticsearch.withHide(false)
+
+              + elasticsearch.withMetrics([
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Cache')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory working set bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('2')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('VM Memory Max Usage Bytes')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('3')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value/1000000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max'),
+
+              ])
+
+              + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
+              + elasticsearch.withRefId('I')
+              + elasticsearch.withTimeField('timestamp'),
+
+              ////
 
               elasticsearch.withAlias('VMs #')
 
@@ -5811,7 +5659,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withQuery('scale:120 AND ocp_version:$ocp_version')
-              + elasticsearch.withRefId('M')
+              + elasticsearch.withRefId('J')
               + elasticsearch.withTimeField('timestamp')
 
               ////

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -7,7 +7,6 @@ from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, 
 from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
 from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
 from benchmark_runner.common.oc.oc import VMStatus
-from benchmark_runner.common.prometheus.prometheus_metrics_operations import PrometheusMetricsOperation
 
 
 class BootstormVM(WorkloadsOperations):
@@ -24,7 +23,6 @@ class BootstormVM(WorkloadsOperations):
         self._vm_name = ''
         self._data_dict = {}
         self._bootstorm_start_time = {}
-        self._prometheus_metrics_operation = PrometheusMetricsOperation()
 
     @logger_time_stamp
     def _set_bootstorm_vm_start_time(self, vm_name: str = ''):
@@ -61,9 +59,36 @@ class BootstormVM(WorkloadsOperations):
         self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}_{vm_num}.yaml'))
         self._oc.wait_for_vm_status(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}', status=VMStatus.Stopped)
 
+    def _run_vm(self):
+        """
+        This method runs one VM, upload results to Elasticsearch, and destroys VM synchronously
+        @return:
+        """
+        self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}.yaml'))
+        self._oc.wait_for_vm_status(vm_name=f'{self._workload_name}-{self._trunc_uuid}', status=VMStatus.Stopped)
+        self._set_bootstorm_vm_start_time(vm_name=self._vm_name)
+        self._virtctl.start_vm_sync(vm_name=self._vm_name)
+        self._data_dict = self._get_bootstorm_vm_elapsed_time(vm_name=self._vm_name)
+        self._data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url,
+                                                            f'{self._get_run_artifacts_hierarchy(workload_name=self._workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
+        self._status = 'complete' if self._data_dict else 'failed'
+        self._prometheus_metrics_operation.finalize_prometheus()
+        metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+        prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
+        self._data_dict.update(prometheus_result)
+        if self._es_host:
+            # upload several run results
+            self._upload_to_elasticsearch(index=self._es_index, kind=self._kind, status=self._status,
+                                          result=self._data_dict)
+            # verify that data upload to elastic search according to unique uuid
+            self._verify_elasticsearch_data_uploaded(index=self._es_index, uuid=self._uuid)
+        self._oc.delete_vm_sync(
+            yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}.yaml'),
+            vm_name=self._vm_name)
+
     def _run_vm_scale(self, vm_num: str):
         """
-        This method starts VMs in parallel and wait for login to be enabled
+        This method runs VMs in parallel and wait for login to be enabled
         """
         vm_name = f'{self._workload_name}-{self._trunc_uuid}-{vm_num}'
         self._set_bootstorm_vm_start_time(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}')
@@ -74,7 +99,7 @@ class BootstormVM(WorkloadsOperations):
         self._status = 'complete' if self._data_dict else 'failed'
         self._prometheus_metrics_operation.finalize_prometheus()
         metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
-        prometheus_result = self.parse_prometheus_metrics(data=metric_results)
+        prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
         self._data_dict.update(prometheus_result)
         # upload to elasticsearch
         if self._es_host:
@@ -108,6 +133,19 @@ class BootstormVM(WorkloadsOperations):
         """
         self._oc.wait_for_vm_delete(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}')
 
+    def _initialize_run(self):
+        """
+        Initialize prometheus start time, vm name, kind and create benchmark-runner namespace for bootstorm vms
+        """
+        self._prometheus_metrics_operation.init_prometheus()
+        self._name = self._workload
+        self._workload_name = self._workload.replace('_', '-')
+        self._vm_name = f'{self._workload_name}-{self._trunc_uuid}'
+        self._kind = 'vm'
+        self._environment_variables_dict['kind'] = 'vm'
+        # create namespace
+        self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
     @logger_time_stamp
     def run(self):
         """
@@ -115,38 +153,13 @@ class BootstormVM(WorkloadsOperations):
         :return:
         """
         try:
-            self._prometheus_metrics_operation.init_prometheus()
-            self._name = self._workload
+            self._initialize_run()
             if self._run_type == 'test_ci':
                 self._es_index = 'bootstorm-test-ci-results'
             else:
                 self._es_index = 'bootstorm-results'
-            self._workload_name = self._workload.replace('_', '-')
-            self._vm_name = f'{self._workload_name}-{self._trunc_uuid}'
-            self._kind = 'vm'
-            self._environment_variables_dict['kind'] = 'vm'
-            # create namespace
-            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
             if not self._scale:
-                self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}.yaml'))
-                self._oc.wait_for_vm_status(vm_name=f'{self._workload_name}-{self._trunc_uuid}', status=VMStatus.Stopped)
-                self._set_bootstorm_vm_start_time(vm_name=self._vm_name)
-                self._virtctl.start_vm_sync(vm_name=self._vm_name)
-                self._data_dict = self._get_bootstorm_vm_elapsed_time(vm_name=self._vm_name)
-                self._data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self._workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-                self._status = 'complete' if self._data_dict else 'failed'
-                self._prometheus_metrics_operation.finalize_prometheus()
-                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
-                prometheus_result = self.parse_prometheus_metrics(data=metric_results)
-                self._data_dict.update(prometheus_result)
-                if self._es_host:
-                    # upload several run results
-                    self._upload_to_elasticsearch(index=self._es_index, kind=self._kind, status=self._status, result=self._data_dict)
-                    # verify that data upload to elastic search according to unique uuid
-                    self._verify_elasticsearch_data_uploaded(index=self._es_index, uuid=self._uuid)
-                self._oc.delete_vm_sync(
-                    yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}.yaml'),
-                    vm_name=self._vm_name)
+                self._run_vm()
             # scale
             else:
                 # create run bulks

--- a/benchmark_runner/workloads/vdbench_vm.py
+++ b/benchmark_runner/workloads/vdbench_vm.py
@@ -27,7 +27,6 @@ class VdbenchVM(WorkloadsOperations):
         self.__vm_name = ''
         self.__scale = ''
         self.__data_dict = {}
-        self.__prometheus_metrics_operation = PrometheusMetricsOperation()
 
     def __create_vm_scale(self, vm_num: str):
         """
@@ -45,9 +44,9 @@ class VdbenchVM(WorkloadsOperations):
         self.__vm_name = self._create_vm_log(labels=[f'{self.__workload_name}-{self._trunc_uuid}-{vm_num}'])
         self.__status = self._oc.wait_for_vm_log_completed(vm_name=self.__vm_name, end_stamp=self.END_STAMP)
         self.__status = 'complete' if self.__status else 'failed'
-        self.__prometheus_metrics_operation.finalize_prometheus()
-        metric_results = self.__prometheus_metrics_operation.run_prometheus_queries()
-        prometheus_result = self.parse_prometheus_metrics(data=metric_results)
+        self._prometheus_metrics_operation.finalize_prometheus()
+        metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+        prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
         # save run artifacts logs
         result_list = self._create_vm_run_artifacts(vm_name=f'{self.__workload_name}-{self._trunc_uuid}-{vm_num}', start_stamp=self.START_STAMP, end_stamp=self.END_STAMP, log_type='.csv')
         if self._es_host:
@@ -74,7 +73,7 @@ class VdbenchVM(WorkloadsOperations):
         :return:
         """
         try:
-            self.__prometheus_metrics_operation.init_prometheus()
+            self._prometheus_metrics_operation.init_prometheus()
             self.__name = self._workload
             if self._run_type == 'test_ci':
                 self.__es_index = 'vdbench-test-ci-results'
@@ -95,9 +94,9 @@ class VdbenchVM(WorkloadsOperations):
                 self.__status = 'complete' if self.__status else 'failed'
                 # save run artifacts logs
                 result_list = self._create_vm_run_artifacts(vm_name=self.__vm_name, start_stamp=self.START_STAMP, end_stamp=self.END_STAMP, log_type='.csv')
-                self.__prometheus_metrics_operation.finalize_prometheus()
-                metric_results = self.__prometheus_metrics_operation.run_prometheus_queries()
-                prometheus_result = self.parse_prometheus_metrics(data=metric_results)
+                self._prometheus_metrics_operation.finalize_prometheus()
+                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+                prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
                 if self._es_host:
                     # upload several run results
                     for result in result_list:

--- a/benchmark_runner/workloads/windows_vm.py
+++ b/benchmark_runner/workloads/windows_vm.py
@@ -23,41 +23,16 @@ class WindowsVM(BootstormVM):
         :return:
         """
         try:
-            self._prometheus_metrics_operation.init_prometheus()
-            self._name = self._workload
+            self._initialize_run()
             if self._run_type == 'test_ci':
                 self._es_index = 'windows-test-ci-results'
             else:
                 self._es_index = 'windows-results'
-            self._workload_name = self._workload.replace('_', '-')
-            self._vm_name = f'{self._workload_name}-{self._trunc_uuid}'
-            self._kind = 'vm'
-            self._environment_variables_dict['kind'] = 'vm'
-            # create namespace
-            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
             # create windows dv
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'windows_dv.yaml'))
             self._oc.wait_for_dv_status(status='Succeeded')
             if not self._scale:
-                self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}.yaml'))
-                self._oc.wait_for_vm_status(vm_name=f'{self._workload_name}-{self._trunc_uuid}', status=VMStatus.Stopped)
-                self._set_bootstorm_vm_start_time(vm_name=self._vm_name)
-                self._virtctl.start_vm_sync(vm_name=self._vm_name)
-                self._data_dict = self._get_bootstorm_vm_elapsed_time(vm_name=self._vm_name)
-                self._data_dict['run_artifacts_url'] = os.path.join(self._run_artifacts_url, f'{self._get_run_artifacts_hierarchy(workload_name=self._workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
-                self._status = 'complete' if self._data_dict else 'failed'
-                self._prometheus_metrics_operation.finalize_prometheus()
-                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
-                prometheus_result = self.parse_prometheus_metrics(data=metric_results)
-                self._data_dict.update(prometheus_result)
-                if self._es_host:
-                    # upload several run results
-                    self._upload_to_elasticsearch(index=self._es_index, kind=self._kind, status=self._status, result=self._data_dict)
-                    # verify that data upload to elastic search according to unique uuid
-                    self._verify_elasticsearch_data_uploaded(index=self._es_index, uuid=self._uuid)
-                self._oc.delete_vm_sync(
-                    yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}.yaml'),
-                    vm_name=self._vm_name)
+                self._run_vm()
             # scale
             else:
                 # create run bulks

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -18,6 +18,7 @@ from benchmark_runner.common.prometheus.prometheus_snapshot import PrometheusSna
 from benchmark_runner.common.prometheus.prometheus_snapshot_exceptions import PrometheusSnapshotError
 from benchmark_runner.common.template_operations.template_operations import TemplateOperations
 from benchmark_runner.common.clouds.IBM.ibm_operations import IBMOperations
+from benchmark_runner.common.prometheus.prometheus_metrics_operations import PrometheusMetricsOperation
 
 
 class WorkloadsOperations:
@@ -96,6 +97,7 @@ class WorkloadsOperations:
         if self._enable_prometheus_snapshot:
             self._snapshot = PrometheusSnapshot(oc=self._oc, artifacts_path=self._run_artifacts_path, verbose=True)
         self._prometheus_snap_interval = self._environment_variables_dict.get('prometheus_snap_interval', '')
+        self._prometheus_metrics_operation = PrometheusMetricsOperation()
 
     def __get_workload_file_name(self, workload):
         """
@@ -425,30 +427,6 @@ class WorkloadsOperations:
         length = len(iterable)
         for ndx in range(0, length, limit):
             yield iterable[ndx:min(ndx + limit, length)]
-
-    @staticmethod
-    @logger_time_stamp
-    def parse_prometheus_metrics(data):
-        """
-        This method parses prometheus metrics and return summary result
-        @return:
-        """
-        result_dict = {}
-        for query, data_list in data.items():
-            if 'containerCPU-benchmark-runner' in query:
-                suffix = 'CPU'
-            elif 'containerMemory-benchmark-runner' in query:
-                suffix = 'Memory'
-            total = 0
-            max = 0
-            for item in data_list:
-                for val in item['values']:
-                    if float(val[1]) > max:
-                        max = round(float(val[1]), 3)
-                total = total + max
-                result_dict[f"{item['metric']['node']}_{suffix}"] = max
-                result_dict[f'total_{suffix}'] = total
-        return result_dict
 
     @logger_time_stamp
     def clear_nodes_cache(self):


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. Adding **VM memory metrics** to bootstrom and vdbench workloads by running the following prometheus queries:
```
- query: container_memory_cache{pod=~"virt-launcher.*", container="compute"}
  metricName: VM Memory Cache

- query: container_memory_working_set_bytes{pod=~"virt-launcher.*", container="compute"}
  metricName: VM Memory working set bytes

- query: container_memory_max_usage_bytes{pod=~"virt-launcher.*", container="compute"}
  metricName: VM Memory Max Usage Bytes

```
2. Adding **VM memory metrics** to Grafana Dashboard by adding Grafonnet code in main.libsonnet.
## For security reasons, all pull requests need to be approved first before running any automated CI
