### PR TITLE
Update to clusterbuster-v1.2.2-kata-ci.  See those release notes for explanation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/run_artifacts
 RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
-RUN git clone -b v1.2.1-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
+RUN git clone -b v1.2.2-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \
     && dnf install -y hostname bc procps-ng
 
 # Add main


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Update clusterbuster to v1.2.2 release to fix fio and uperf workloads not running.  This happened because the workloads requiring a different image did not have their tags updated in Clusterbuster to pull the correct image, and when an image tag thought to be unused was removed, these workloads broke in CI.


## For security reasons, all pull requests need to be approved first before running any automated CI
