### PR TITLE
Fix push grafana json issue

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -377,14 +377,13 @@ jobs:
           git checkout main
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
+          git config pull.rebase false  # merge
+
           git add "$GITHUB_WORKSPACE"/benchmark_runner/grafana/perf/dashboard.json
           git commit -m "Update grafana json file"
 
-          # Pull the latest changes from the remote main branch
-          git pull origin main
-
-          # Push the changes to the remote main branch
-          git push origin main
+          git pull main
+          git push main
 
       - name: Check if adding new products versions in main.libsonnet
         id: libsonnet_check_changes
@@ -397,11 +396,9 @@ jobs:
           git checkout main
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
+          git config pull.rebase false  # merge 
           git add "$GITHUB_WORKSPACE"/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
           git commit -m "Update grafana json file"
 
-          # Pull the latest changes from the remote main branch
-          git pull origin main
-
-          # Push the changes to the remote main branch
-          git push origin main
+          git pull main
+          git push main

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -288,7 +288,7 @@ jobs:
           pip install bumpversion
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
-          git config pull.rebase false  # merge (the default strategy)
+          git config pull.rebase false  # merge
           bumpversion patch
           # GITHUB_REPOSITORY already taken => GIT_REPOSITORY
           git commit .bumpversion.cfg setup.py -m "bump version to exist version v$version"
@@ -433,14 +433,13 @@ jobs:
           git checkout main
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
+          git config pull.rebase false  # merge
+
           git add "$GITHUB_WORKSPACE"/benchmark_runner/grafana/perf/dashboard.json
           git commit -m "Update grafana json file"
 
-          # Pull the latest changes from the remote main branch
-          git pull origin main
-
-          # Push the changes to the remote main branch
-          git push origin main
+          git pull main
+          git push main
 
       - name: Check if adding new products versions in main.libsonnet
         id: libsonnet_check_changes
@@ -453,11 +452,9 @@ jobs:
           git checkout main
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
+          git config pull.rebase false  # merge 
           git add "$GITHUB_WORKSPACE"/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
           git commit -m "Update grafana json file"
 
-          # Pull the latest changes from the remote main branch
-          git pull origin main
-
-          # Push the changes to the remote main branch
-          git push origin main
+          git pull main
+          git push main


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
When running the following code
```
          git checkout main
          git config --global user.email "${{ secrets.EMAIL }}"
          git config --global user.name  "${{ secrets.USER_NAME }}"
          git add "$GITHUB_WORKSPACE"/benchmark_runner/grafana/perf/dashboard.json
          git commit -m "Update grafana json file"

          # Pull the latest changes from the remote main branch
          git pull origin main

          # Push the changes to the remote main branch
          git push
```
Got the following error:
```
Already on 'main'
M	***
M	***
Your branch is up to date with 'origin/main'.
[main ec0e359] Update grafana json file
 1 file changed, 2[16](https://github.com/redhat-performance/benchmark-runner/actions/runs/6150535588/job/16691527592#step:8:17) insertions(+), 3[18](https://github.com/redhat-performance/benchmark-runner/actions/runs/6150535588/job/16691527592#step:8:19) deletions(-)
From https://github.com/redhat-performance/benchmark-runner
 * branch            main       -> FETCH_HEAD
   fb5cb9c..91004a0  main       -> origin/main
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
hint: your next pull:
hint: 
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
fatal: Need to specify how to reconcile divergent branches.
Error: Process completed with exit code 128 
```
[Error link](https://github.com/redhat-performance/benchmark-runner/actions/runs/6150535588/job/16691527592)

Adding the following fix:

```
git push origin main
```
## For security reasons, all pull requests need to be approved first before running any automated CI
