### PR TITLE
update clusterbuster uperf grafonnet

### DIFF
--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -3517,10 +3517,10 @@ g.dashboard.new('PerfCI-Regression-Summary')
               ])
 
               + elasticsearch.withMetrics([
-                elasticsearch.metrics.MetricAggregationWithSettings.Max.withField('max_time_op')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withId('6')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.settings.withScript('_value*1000')
-                + elasticsearch.metrics.MetricAggregationWithSettings.Max.withType('max')
+                elasticsearch.metrics.MetricAggregationWithSettings.Average.withField('avg_time_op')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.withId('1')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.settings.withScript('_value*1000000')
+                + elasticsearch.metrics.MetricAggregationWithSettings.Average.withType('avg')
 
               ])
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. Change clusterbuster to use avg_time_op instead of max_time_op
2. Use microseconds (X1000000)
## For security reasons, all pull requests need to be approved first before running any automated CI
