### PR TITLE
Update timeout to solve vdbench scale

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -174,7 +174,7 @@ jobs:
         REDIS: ${{ secrets.REDIS }}
         WORKER_DISK_IDS: ${{ secrets.PERF_WORKER_DISK_IDS }}
         WORKER_DISK_PREFIX: ${{ secrets.PERF_WORKER_DISK_PREFIX }}
-        TIMEOUT: 8000
+        TIMEOUT: 10800
         SCALE: 2
         BOOTSTORM_SCALE: 80
         WINDOWS_SCALE: 40


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Update timeout 8000 to 10800 for solving vdbench scale timeout [issue](https://github.com/redhat-performance/benchmark-runner/actions/runs/6347957579/job/17243742678)

## For security reasons, all pull requests need to be approved first before running any automated CI
