### PR TITLE
fix odf deletion prefix

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -33,7 +33,7 @@ class CreateODF(CreateOCPResourceOperations):
                     result_dict = {}
                     for node, disk_ids in self.__worker_disk_ids.items():
                         for disk_id in disk_ids:
-                            node_sgdisk += f'sgdisk --zap-all /dev/disk/by-id/{self.__worker_disk_prefix}{disk_id}; wipefs -a /dev/disk/by-id/{self.__worker_disk_prefix}{disk_id};'
+                            node_sgdisk += f'sgdisk --zap-all /dev/disk/by-id/wwn-0x{disk_id}; wipefs -a /dev/disk/by-id/wwn-0x{disk_id};'
                         result_dict[node] = node_sgdisk
                         node_sgdisk = ''
                     self.__oc.run(cmd=f'chmod +x {os.path.join(self.__path, resource)}; {self.__path}/./{resource} "{list(result_dict.keys())[0]}" "{list(result_dict.values())[0]}" "{list(result_dict.keys())[1]}" "{list(result_dict.values())[1]}" "{list(result_dict.keys())[2]}" "{list(result_dict.values())[2]}"')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
OCP 4.14.0-rc5: ODF 4.13
Disk deletion is working only when using 'wwn-0x' and not working any more when using 'scsi-3'
```
sh-5.1# wipefs -a /dev/disk/by-id/scsi-3600062b2070785c028ae89f244909b6c
/dev/disk/by-id/scsi-3600062b2070785c028ae89f244909b6c: 22 bytes were erased at offset 0x00000000 (ceph_bluestore): 62 6c 75 65 73 74 6f 72 65 20 62 6c 6f 63 6b 20 64 65 76 69 63 65
sh-5.1# wipefs -a /dev/disk/by-id/wwn-0x600062b2070785c028ae89f244909b6c
```

## For security reasons, all pull requests need to be approved first before running any automated CI
