### PR TITLE
Fix ODF installation

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -212,7 +212,7 @@ jobs:
                    'windows_vm_scale_windows11') WINDOWS_URL=$WINDOWS11_URL ;;
                    'windows_vm_scale_windows_server_2019') WINDOWS_URL=$WINDOWS_SERVER_2019_URL ;;
                    'windows_vm_scale_windows_server_2022') WINDOWS_URL=$WINDOWS_SERVER_2022_URL ;;
-                    *) echo "Unknown Windows scale workload ${{ matrix.workload }}"; exit 1 ;;
+                    *) echo "Unknown Windows scale workload ${{ matrix_workload }}"; exit 1 ;;
               esac
               # Warm-up: Load DV for Windows
               ssh -t provision "podman run --rm -t -e WORKLOAD='$workload' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e SCALE='$SCALE' -e SCALE_NODES=$SCALE_NODES -e REDIS='$REDIS' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='$ENABLE_PROMETHEUS_SNAPSHOT' -e THREADS_LIMIT='$THREADS_LIMIT' -e WINDOWS_URL='$WINDOWS_URL' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -212,7 +212,7 @@ jobs:
                    'windows_vm_scale_windows11') WINDOWS_URL=$WINDOWS11_URL ;;
                    'windows_vm_scale_windows_server_2019') WINDOWS_URL=$WINDOWS_SERVER_2019_URL ;;
                    'windows_vm_scale_windows_server_2022') WINDOWS_URL=$WINDOWS_SERVER_2022_URL ;;
-                    *) echo "Unknown Windows scale workload ${{ matrix_workload }}"; exit 1 ;;
+                    *) echo "Unknown Windows scale workload ${{ matrix.workload }}"; exit 1 ;;
               esac
               # Warm-up: Load DV for Windows
               ssh -t provision "podman run --rm -t -e WORKLOAD='$workload' -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e SCALE='$SCALE' -e SCALE_NODES=$SCALE_NODES -e REDIS='$REDIS' -e RUN_ARTIFACTS_URL='$RUN_ARTIFACTS_URL' -e BUILD_VERSION='$build_version' -e RUN_TYPE='$RUN_TYPE' -e KATA_CPUOFFLINE_WORKAROUND='True' -e SAVE_ARTIFACTS_LOCAL='False' -e ENABLE_PROMETHEUS_SNAPSHOT='$ENABLE_PROMETHEUS_SNAPSHOT' -e THREADS_LIMIT='$THREADS_LIMIT' -e WINDOWS_URL='$WINDOWS_URL' -e TIMEOUT='$TIMEOUT' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged 'quay.io/ebattat/benchmark-runner:latest'"

--- a/benchmark_runner/common/ocp_resources/create_kata.py
+++ b/benchmark_runner/common/ocp_resources/create_kata.py
@@ -22,7 +22,7 @@ class CreateKata(CreateOCPResourceOperations):
 
     def __install_and_wait_for_resource_with_retry(self, yaml_file: str, resource_type: str, resource: str):
         """
-        Create a resource where the creation process itself may fail
+        This method creates a resource where the creation process itself may fail
         without indicating an error and then have to be retried.
         :param yaml_file:YAML file to create the resource
         :param resource_type:type of resource to create
@@ -44,7 +44,7 @@ class CreateKata(CreateOCPResourceOperations):
     @logger_time_stamp
     def create_kata(self):
         """
-        This method create kata resource
+        This method creates kata resource
         :return:
         """
         for resource in self.__resource_list:

--- a/benchmark_runner/common/ocp_resources/create_ocp_resource_operations.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource_operations.py
@@ -10,7 +10,7 @@ from benchmark_runner.common.ocp_resources.create_ocp_resource_exceptions import
 
 class CreateOCPResourceOperations:
     """
-    This class is create OCP resources
+    This class is created OCP resources
     """
     def __init__(self, oc: OC):
         self._environment_variables_dict = environment_variables.environment_variables_dict
@@ -20,7 +20,7 @@ class CreateOCPResourceOperations:
     @typechecked
     def _replace_in_file(file_path: str, old_value: str, new_value: str):
         """
-        This method replace string in file
+        This method replaces string in file
         :param file_path:
         :param old_value:
         :param new_value:
@@ -37,35 +37,15 @@ class CreateOCPResourceOperations:
         with open(file_path, 'w') as file:
             file.write(file_data)
 
-    def _install_and_wait_for_resource(self, yaml_file: str, resource_type: str, resource: str):
-            """
-            Create a resource where the creation process itself may fail and has to be retried
-            :param yaml_file:YAML file to create the resource
-            :param resource_type:type of resource to create
-            :param resource: name of resource to create
-            :return:
-            """
-            timeout = int(environment_variables.environment_variables_dict['timeout'])
-            current_wait_time = 0
-            while timeout <= 0 or current_wait_time < timeout:
-                self.__oc.create_async(yaml_file)
-                # We cannot wait for a condition here, because the
-                # create_async may simply not work even if it returns success.
-                time.sleep(OC.SLEEP_TIME)
-                if self.__oc.run(f'if oc get {resource_type} {resource} > /dev/null 2>&1 ; then echo succeeded; fi') == 'succeeded':
-                    return True
-                current_wait_time += OC.SLEEP_TIME
-            return False
-
     @typechecked
     @logger_time_stamp
-    def wait_for_ocp_resource_create(self, resource: str, verify_cmd: str, status: str = '', count_local_storage: bool = False, count_openshift_storage: bool = False, kata_worker_machine_count: bool = False, timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
+    def wait_for_ocp_resource_create(self, resource: str, verify_cmd: str, status: str = '', count_disk_maker: bool = False, count_openshift_storage: bool = False, kata_worker_machine_count: bool = False, timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
         """
-        This method is wait till operator is created or throw exception after timeout
+        This method waits till operator is created or throw exception after timeout
         :param resource: The resource cnv, local storage, odf, kata
         :param verify_cmd: Verify command that resource was created successfully
         :param status: The final success status
-        :param count_local_storage: count local storage disks
+        :param count_disk_maker: count disk maker
         :param count_openshift_storage: count openshift storage disks
         :param kata_worker_machine_count: count kata worker machine
         :return: True if met the result
@@ -76,16 +56,14 @@ class CreateOCPResourceOperations:
             if count_openshift_storage:
                 if int(self.__oc.run(verify_cmd)) == self.__oc.get_num_active_nodes() * int(environment_variables.environment_variables_dict['num_odf_disk']):
                     return True
-                # Count local storage disks (worker/master * (discovery+manager)
-            elif count_local_storage:
-                if int(self.__oc.run(verify_cmd)) == self.__oc.get_num_active_nodes() * 2:
+                # Count disk maker (worker/master number * disk maker)
+            elif count_disk_maker:
+                if int(self.__oc.run(verify_cmd)) == int(self.__oc.get_num_active_nodes()) * 2:
                     return True
                 # Count worker machines
             elif kata_worker_machine_count:
                 if int(self.__oc.run(verify_cmd)) > 0:
                     return True
-                else:
-                    return False
             # verify query return positive result
             if status:
                 # catch equal or contains
@@ -101,7 +79,7 @@ class CreateOCPResourceOperations:
 
     def apply_non_approved_patch(self, approved_values_list: list, namespace: str, resource: str):
         """
-        This method return the index of not approved InstallPlan
+        This method returns the index of not approved InstallPlan
         :param approved_values_list:
         :param namespace:
         :param resource:
@@ -132,7 +110,7 @@ class CreateOCPResourceOperations:
 
     def apply_patch(self, namespace: str, resource: str):
         """
-        This method return the index of not approved InstallPlan
+        This method applies not approved InstallPlan
         :param namespace:
         :param resource:
         :return:

--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -1,5 +1,6 @@
 
 import os
+import time
 
 from benchmark_runner.common.oc.oc import OC
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
@@ -47,7 +48,8 @@ class CreateODF(CreateOCPResourceOperations):
                     self.wait_for_ocp_resource_create(resource='odf',
                                                       verify_cmd=r"""oc get pod -n openshift-local-storage -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" | grep diskmaker""")
                     self.wait_for_ocp_resource_create(resource='odf',
-                                                      verify_cmd=r"""oc get pod -n openshift-local-storage -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" | grep diskmaker | wc -l""", count_local_storage=True)
+                                                      verify_cmd=r"""oc get pod -n openshift-local-storage -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" | grep diskmaker | wc -l""",
+                                                      count_disk_maker=True)
                     # openshift persistence volume (pv)
                     self.wait_for_ocp_resource_create(resource='odf',
                                                       verify_cmd=r"""oc get pv -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" | grep local""")
@@ -69,4 +71,7 @@ class CreateODF(CreateOCPResourceOperations):
                     self.wait_for_ocp_resource_create(resource='odf',
                                                       verify_cmd='oc get pod -n openshift-storage | grep osd | grep -v prepare | wc -l',
                                                       count_openshift_storage=True)
+            # sleep between each resource run for avoiding installation failure
+            logger.info(f"sleep {self._environment_variables_dict.get('bulk_sleep_time', '')} seconds")
+            time.sleep(int(self._environment_variables_dict.get('bulk_sleep_time', '')))
         return True

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -358,7 +358,9 @@ class WorkloadsOperations:
                     'uuid': self._uuid,
                     'pin_node1': self._pin_node1,
                     'pin_node2': self._pin_node2,
-                    'odf_disk_count': self._oc.get_odf_disk_count()}
+                    # display -1 when 0,1 for avoiding conflict with 0/1 status code
+                    'odf_disk_count': -1 if self._oc.get_odf_disk_count() in {0, 1} else self._oc.get_odf_disk_count()
+}
         if kind:
             metadata.update({'kind': kind})
         if status:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix ODF installation:
1. Add sleep 30 sec between each ODF yaml for avoiding ODF installation failure
2. odf_disk_count: display -1 when 0,1 for avoiding conflict with 0/1 status code
3. Remove unused/ duplicated method: _install_and_wait_for_resource [duplicated: [__install_and_wait_for_resource_with_retry](https://github.com/redhat-performance/benchmark-runner/blob/3e85b76f3dbaab87ff529da685927e6bcd91e8c4/benchmark_runner/common/ocp_resources/create_kata.py#L23C4-L42)]
## For security reasons, all pull requests need to be approved first before running any automated CI
