### PR TITLE
Add sleep after disk deletion

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_ocp_resource_exceptions.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource_exceptions.py
@@ -1,33 +1,25 @@
 
-class OCError(Exception):
-    """ Base class for all OC error classes.
-        All exceptions raised by the benchmark runner library should inherit from this class. """
+class OCPResourceError(Exception):
+    """ Base class for all OCP resource error classes. """
     pass
 
 
-class OCPResourceNotCreateTimeout(OCError):
-    """This exception return resource create timeout error"""
+class OCPResourceCreationTimeout(OCPResourceError):
+    """This exception returns resource creation timeout error"""
     def __init__(self, resource):
         self.message = f'The {resource} resource was not created'
-        super(OCPResourceNotCreateTimeout, self).__init__(self.message)
+        super(OCPResourceCreationTimeout, self).__init__(self.message)
 
 
-class KataInstallationFailed(OCError):
+class ODFInstallationFailed(OCPResourceError):
+    """This exception returns failure to install ODF"""
+    def __init__(self, disk_num):
+        self.message = f'Incorrect ODF Ceph disk number: {disk_num}'
+        super(ODFInstallationFailed, self).__init__(self.message)
+
+
+class KataInstallationFailed(OCPResourceError):
     """This exception returns failure to install sandboxed containers"""
     def __init__(self, reason):
         self.message = f'Installation of sandboxed containers failed: {reason}'
         super(KataInstallationFailed, self).__init__(self.message)
-
-
-class ExecFailed(OCError):
-    """exec command on pod failed"""
-    def __init__(self, pod, command, reason):
-        self.message = f'exec {command} on {pod} failed: {reason}'
-        super(ExecFailed, self).__init__(self.message)
-
-
-class PodFailed(OCError):
-    """exec command on pod failed"""
-    def __init__(self, pod):
-        self.message = f'pod {pod} failed'
-        super(PodFailed, self).__init__(self.message)


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. Add sleep after Ceph disk deletion - for avoiding installation failure
2. ODF installation verification and raise an error if it fails

## For security reasons, all pull requests need to be approved first before running any automated CI
