### PR TITLE
Fix jsonnet terraform

### DIFF
--- a/benchmark_runner/grafana/perf/dashboard.tf
+++ b/benchmark_runner/grafana/perf/dashboard.tf
@@ -13,6 +13,7 @@ provider "jsonnet" {
 
 data "jsonnet_file" "dashboard" {
   source = "${path.cwd}/jsonnet/main.libsonnet"
+  jsonnet_path = "${path.cwd}/jsonnet/vendor"
 }
 
 output "dashboard" {


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Got the following error when running Terraform through [GitHub actions](https://github.com/redhat-performance/benchmark-runner/actions/runs/6772156250/job/18407159847)

```
│ Error: Failed to render test from jsonnet template
│ 
│   with data.jsonnet_file.dashboard,
│   on dashboard.tf line 14, in data "jsonnet_file" "dashboard":
│   14: data "jsonnet_file" "dashboard" {
│ 
│ RUNTIME ERROR: couldn't open import
│ "github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet": no
│ match locally or in the Jsonnet library paths
│ 	/app/jsonnet/g.libsonnet:2:1-74	$
│ 	/app/jsonnet/main.libsonnet:1:11-31	thunk <g> from <$>
│ 	/app/jsonnet/main.libsonnet:8:1-2	
│ 	During evaluation	
```

There is a recommendation to add [jsonnet_path](https://registry.terraform.io/providers/alxrem/jsonnet/latest/docs/data-sources/file#jsonnet_path)

## For security reasons, all pull requests need to be approved first before running any automated CI
