### PR TITLE
VM memory distribution prometheus metrics

### DIFF
--- a/benchmark_runner/common/prometheus/metrics-default.yaml
+++ b/benchmark_runner/common/prometheus/metrics-default.yaml
@@ -1,5 +1,3 @@
-
-
 # container CPU/Memory
 
 - query: (sum(irate(container_cpu_usage_seconds_total{container!="",namespace="benchmark-runner", mode!="idle"}[2m])) by (node)) > 0
@@ -17,3 +15,38 @@
 - query: container_memory_max_usage_bytes{pod=~"virt-launcher.*", container="compute"}
   metricName: VM Memory Max Usage Bytes
 
+- query: container_memory_cache{container=~"virt-handler", namespace="openshift-cnv"}
+  metricName: virt handler Cache
+
+- query: container_memory_working_set_bytes{container=~"virt-handler", namespace="openshift-cnv"}
+  metricName: virt handler working set bytes
+
+- query: container_memory_cache{container=~"virt-controller", namespace="openshift-cnv"}
+  metricName: virt controller Cache
+
+- query: container_memory_working_set_bytes{container=~"virt-controller", namespace="openshift-cnv"}
+  metricName: virt controller working set bytes
+
+- query: container_memory_cache{container=~"virt-operator", namespace="openshift-cnv"}
+  metricName: virt operator Cache
+
+- query: container_memory_working_set_bytes{container=~"virt-operator", namespace="openshift-cnv"}
+  metricName: virt operator working set bytes
+
+- query: container_memory_cache{container=~"virt-api", namespace="openshift-cnv"}
+  metricName: virt api Cache
+
+- query: container_memory_working_set_bytes{container=~"virt-api", namespace="openshift-cnv"}
+  metricName: virt api working set bytes
+
+- query: min ((kube_pod_container_resource_requests{namespace="openshift-cnv",container=~"virt-handler",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="openshift-cnv"})
+  metricName: virt handler exceeds requested memory
+
+- query: min ((kube_pod_container_resource_requests{namespace="openshift-cnv",container=~"virt-controller",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="openshift-cnv"})
+  metricName: virt controller exceeds requested memory
+
+- query: min ((kube_pod_container_resource_requests{namespace="openshift-cnv",container=~"virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="openshift-cnv"})
+  metricName: virt operator exceeds requested memory
+
+- query: min ((kube_pod_container_resource_requests{namespace="openshift-cnv",container=~"virt-api",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="openshift-cnv"})
+  metricName: virt api exceeds requested memory

--- a/benchmark_runner/common/prometheus/prometheus_metrics_operations.py
+++ b/benchmark_runner/common/prometheus/prometheus_metrics_operations.py
@@ -180,7 +180,7 @@ class PrometheusMetricsOperation:
             elif 'containerMemory-benchmark-runner' in query:
                 suffix = 'Memory'
             else:
-                suffix = ''
+                suffix = None
             total = 0
             max = 0
             for item in data_list:
@@ -188,7 +188,7 @@ class PrometheusMetricsOperation:
                     if float(val[1]) > max:
                         max = round(float(val[1]), 3)
                 total = total + max
-                if 'VM Memory' in query:
+                if not suffix:
                     result_dict[f'{query}'] = max
                 else:
                     result_dict[f"{item['metric']['node']}_{suffix}"] = max

--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -5570,7 +5570,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
             ]),
             ////////////////////////
 
-            g.panel.stateTimeline.new('120 Windows VM Memory')
+            g.panel.stateTimeline.new('111 Windows VM Memory')
             + stateTimeline.queryOptions.withDatasource('Elasticsearch-windows-results')
             + g.panel.stateTimeline.withDescription('Time till VM Login - Lower is better')
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Add Prometheus VM memory metrics capturing:

- virt-handler
- virt-operator 
- virt-controller
- virt-api

Also adding exceeds requested memory for each metric.

## For security reasons, all pull requests need to be approved first before running any automated CI
