### PR TITLE
Revert back to 4.13 for summary report

### DIFF
--- a/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
@@ -56,7 +56,7 @@ jobs:
           END
       - name: ▶ OCP assisted installer
         env:
-          INSTALL_OCP_VERSION: "latest-4.14"
+          INSTALL_OCP_VERSION: "latest-4.13"
           OCP_CLIENT_VERSION: "4.14.1"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
@@ -80,7 +80,7 @@ jobs:
           echo '>>>>>>>>>>>>>>>>>>>>>>>>>> OCP end step: ${{ matrix.step }}   >>>>>>>>>>>>>>>>>>>>>>>>>>>>'
       - name: ▶ Rerun OCP assisted install after failure
         env:
-          INSTALL_OCP_VERSION: "latest-4.14"
+          INSTALL_OCP_VERSION: "latest-4.13"
           OCP_CLIENT_VERSION: "4.14.1"
           IBM_API_KEY: ${{ secrets.IBM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
@@ -77,8 +77,8 @@ jobs:
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
       - name: ☉ install ${{ matrix.resource }} Operator 
         env:
-          CNV_VERSION: "4.14"
-          ODF_VERSION: "4.13"
+          CNV_VERSION: "4.13"
+          ODF_VERSION: "4.12"
           NUM_ODF_DISK: "4"
           KATA_CSV: ""
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Revert back to 4.13 GA for creating a new baseline with latest workload changes for summary report (i.e. bootstorm: remove node selector)

## For security reasons, all pull requests need to be approved first before running any automated CI
