### PR TITLE
Fix vdbench pod failure

### DIFF
--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -212,13 +212,13 @@ class WorkloadsOperations:
     def __is_float(value) -> bool:
         """
         This method checks if value is float
-        :param value:
-        :return:
+        :param value: The value to check
+        :return: True if the value is a float, False when cannot be converted to a float
         """
         try:
             float(value)
             return True
-        except ValueError:
+        except (ValueError, TypeError):
             return False
 
     def _create_scale_logs(self):


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
The Vdbench pod workload sometimes fails due to a float casting error:
```
ile "/usr/local/lib/python3.10/site-packages/benchmark_runner/workloads/workloads_operations.py", line 219, in __is_float
    float(value)
TypeError: float() argument must be a string or a real number, not 'list'
```
Adding list check to __is_float method to avoid the above error.

For more error details see [logs](https://github.com/redhat-performance/benchmark-runner/actions/runs/7613842210/job/20737537991)

## For security reasons, all pull requests need to be approved first before running any automated CI
