### PR TITLE
Update GTA plugins

### DIFF
--- a/.github/workflows/Build_runner.yml
+++ b/.github/workflows/Build_runner.yml
@@ -25,9 +25,9 @@ jobs:
     name: pypi_upload
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: 🔨 Build and publish distribution 📦 to PyPI
@@ -45,9 +45,9 @@ jobs:
     needs: [pypi_upload]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Validate upload to PyPI
@@ -88,9 +88,9 @@ jobs:
     needs: [ pypi_upload, pypi_validate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: ⌛ Build and Upload 🐋 to quay.io
@@ -109,9 +109,9 @@ jobs:
     needs: [pypi_upload, pypi_validate, quay_upload]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: ⚙ Set START CI TIME

--- a/.github/workflows/Nightly_Func_Env_CI.yml
+++ b/.github/workflows/Nightly_Func_Env_CI.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       start_time_output: ${{ steps.nightly_start_step.outputs.start_time }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: nightly_start_step
       run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
@@ -112,9 +112,9 @@ jobs:
               - 'bootstorm_vm_scale'
               - 'windows_vm_scale'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install latest benchmark-runner
@@ -211,9 +211,9 @@ jobs:
     if: always()
     needs: [initialize_nightly, workload]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: ⚙ Set START CI TIME

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       start_time_output: ${{ steps.nightly_start_step.outputs.start_time }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: nightly_start_step
       run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
@@ -116,9 +116,9 @@ jobs:
               - 'windows_vm_scale_windows_server_2022'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install latest benchmark-runner
@@ -247,9 +247,9 @@ jobs:
     if: always()
     needs: [initialize_nightly, workload]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: ⚙ Set START CI TIME
@@ -350,7 +350,7 @@ jobs:
         python-version: [ '3.10' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/Nightly_Perf_Env_CI_Scale.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI_Scale.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       start_time_output: ${{ steps.nightly_start_step.outputs.start_time }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: nightly_start_step
       run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
@@ -83,9 +83,9 @@ jobs:
               - 'windows_vm_scale_windows_server_2022'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install latest benchmark-runner

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -91,9 +91,9 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -179,9 +179,9 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: 🔨 Build and publish distribution 📦 to PyPI
@@ -202,9 +202,9 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Validate upload to PyPI
@@ -248,9 +248,9 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: ⌛ Build and Upload 🐋 to quay.io
@@ -272,9 +272,9 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install latest benchmark-runner
@@ -309,9 +309,9 @@ jobs:
           workload: [ 'stressng_pod', 'vdbench_pod' ]
           python-version: [ '3.10' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install latest benchmark-runner
@@ -387,7 +387,7 @@ jobs:
         python-version: [ '3.10' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/Perf_Env_E2E_Test_CI.yml
+++ b/.github/workflows/Perf_Env_E2E_Test_CI.yml
@@ -37,9 +37,9 @@ jobs:
     outputs:
       install_resource_time_output: ${{ steps.ocp_install_resource_step.outputs.install_resource_time }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install latest benchmark-runner

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -32,11 +32,11 @@ jobs:
     # minimize potential vulnerabilities
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -102,11 +102,11 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -182,11 +182,11 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
    steps:
-   - uses: actions/checkout@v3
+   - uses: actions/checkout@v4
      with:
        ref: ${{ github.event.pull_request.head.sha }}
    - name: Set up Python ${{ matrix.python-version }}
-     uses: actions/setup-python@v4
+     uses: actions/setup-python@v5
      with:
        python-version: ${{ matrix.python-version }}
    - name: Install dependencies

--- a/.github/workflows/Release_ClusterBuster_Perf_Env_CI.yml
+++ b/.github/workflows/Release_ClusterBuster_Perf_Env_CI.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       start_time_output: ${{ steps.nightly_start_step.outputs.start_time }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: nightly_start_step
       run: echo "start_time=$(printf '%(%s)T' -1)" >> $GITHUB_OUTPUT
     - name: ⚙️ Set SSH key
@@ -80,9 +80,9 @@ jobs:
        matrix:
           workload: [ 'files', 'fio', 'uperf', 'cpusoaker']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install latest benchmark-runner
@@ -160,9 +160,9 @@ jobs:
     if: always()
     needs: [initialize_nightly, workload]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: ⚙ Set START CI TIME

--- a/.github/workflows/Weekly_Func_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Installer_CI.yml
@@ -25,9 +25,9 @@ jobs:
        matrix:
           step: [ 'run_ibm_ocp_installer', 'verify_install_complete' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install latest benchmark-runner

--- a/.github/workflows/Weekly_Func_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Func_Env_Operator_CI.yml
@@ -36,9 +36,9 @@ jobs:
     outputs:
       install_resource_time_output: ${{ steps.ocp_install_resource_step.outputs.install_resource_time }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install latest benchmark-runner

--- a/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
@@ -25,9 +25,9 @@ jobs:
        matrix:
           step: [ 'run_ibm_ocp_installer', 'verify_install_complete' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install latest benchmark-runner

--- a/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Operator_CI.yml
@@ -36,9 +36,9 @@ jobs:
     outputs:
       install_resource_time_output: ${{ steps.ocp_install_resource_step.outputs.install_resource_time }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install latest benchmark-runner


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
<!--- Describe your changes below -->
Update the GHA plugins to use the node-20, for that we need to update the current plugin versions.

ref:

[GH checkout](https://github.com/marketplace/actions/checkout)
[Python plugin](https://github.com/actions/setup-python)

Solved plugins warnings:
[Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.](https://github.com/redhat-performance/benchmark-runner/actions/runs/7752236376)
## For security reasons, all pull requests need to be approved first before running any automated CI
