### PR TITLE
add Jenkin pipelines dependency between OCP and Operators deployment

### DIFF
--- a/jenkins/PerfCI_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_OpenShift_Deployment/Jenkinsfile
@@ -37,13 +37,14 @@ pipeline {
         stage('⚙️ SET SSH key') {
             steps {
                 script {
-                    sh 'umask 77 && mkdir -p $WORKSPACE/.ssh/'
+                    sh 'mkdir -p $WORKSPACE/.ssh/'
+                    sh 'sudo chmod 700 $WORKSPACE/.ssh/'
                     withCredentials([file(credentialsId: 'perfci_provision_private_key_file', variable: 'PROVISION_PRIVATE_KEY_FILE')]) {
                         sh "sudo cp \$PROVISION_PRIVATE_KEY_FILE $WORKSPACE/.ssh/provision_private_key"
                     }
-                    sh 'chmod 600 $PRIVATE_KEY_PATH'
+                    sh 'sudo chmod 600 $PRIVATE_KEY_PATH'
                     sh '''
-                        cat > "$CONFIG_PATH" <<END
+                        sudo cat > "$CONFIG_PATH" <<END
     Host provision
         HostName ${PROVISION_IP}
         User ${PROVISION_USER}
@@ -53,7 +54,7 @@ pipeline {
         ServerAliveCountMax 5
 END
                     '''
-                    sh 'chmod 600 $CONFIG_PATH'
+                    sh 'sudo chmod 600 $CONFIG_PATH'
                 }
             }
         }
@@ -113,6 +114,10 @@ END
                     Jenkins job: ${env.BUILD_URL}\nSee the console output for more details:  ${env.BUILD_URL}consoleFull\n\n
                 """, subject: msg, to: "${CONTACT_EMAIL1}"
             }
+        }
+        success {
+            echo 'Triggering PerfCI-Operators-Deployment'
+            build job: 'PerfCI-Operators-Deployment', wait: false
         }
     }
 }

--- a/jenkins/PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Operators_Deployment/Jenkinsfile
@@ -36,13 +36,14 @@ pipeline {
         stage('⚙️ SET SSH key') {
             steps {
                 script {
-                    sh 'umask 77 && mkdir -p $WORKSPACE/.ssh/'
+                    sh 'mkdir -p $WORKSPACE/.ssh/'
+                    sh 'sudo chmod 700 $WORKSPACE/.ssh/'
                     withCredentials([file(credentialsId: 'perfci_provision_private_key_file', variable: 'PROVISION_PRIVATE_KEY_FILE')]) {
                         sh "sudo cp \$PROVISION_PRIVATE_KEY_FILE $WORKSPACE/.ssh/provision_private_key"
                     }
-                    sh 'chmod 600 $PRIVATE_KEY_PATH'
+                    sh 'sudo chmod 600 $PRIVATE_KEY_PATH'
                     sh '''
-                        cat > "$CONFIG_PATH" <<END
+                        sudo cat > "$CONFIG_PATH" <<END
     Host provision
         HostName ${PROVISION_IP}
         User ${PROVISION_USER}
@@ -52,7 +53,7 @@ pipeline {
         ServerAliveCountMax 5
 END
                     '''
-                    sh 'chmod 600 $CONFIG_PATH'
+                    sh 'sudo chmod 600 $CONFIG_PATH'
                 }
             }
         }


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies
1. Add Jenkin pipelines dependency between PerfCI-OpenShift-Deployment -> PerfCI-Operators-Deployment
Once OpenShift deployment finishes successfully, PerfCI-Operators-Deployment will start
2. Fix bash: /home/jenkins/.ssh/config: Permission denied issue by running
`sudo chmod 700 $WORKSPACE/.ssh/`

## Description
<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
