### PR TITLE
Remove Jenkins job dependency

### DIFF
--- a/jenkins/PerfCI_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_OpenShift_Deployment/Jenkinsfile
@@ -142,7 +142,7 @@ END
         }
         success {
             echo 'Triggering PerfCI-Operators-Deployment pipeline'
-            build job: 'PerfCI-Operators-Deployment', wait: true
+            build job: 'PerfCI-Operators-Deployment', wait: false
         }
     }
 }


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. build job: 'PerfCI-Operators-Deployment', wait: false
No need dependency between OpenShift and Operator deployment jobs


## For security reasons, all pull requests need to be approved first before running any automated CI
