### PR TITLE
Fix Jenkins parse dictionary

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_ocp_resource.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource.py
@@ -25,9 +25,11 @@ class CreateOCPResource:
         self.__worker_disk_prefix = self.__environment_variables_dict.get('worker_disk_prefix', '')
         self.__worker_disk_ids = self.__environment_variables_dict.get('worker_disk_ids', '')
         if self.__worker_disk_ids:
-            # Solved GitHub Actions issue that env variable detect as string instead of dict/ list
-            self.__worker_disk_ids = self.__worker_disk_ids.replace('"', '')
-            self.__worker_disk_ids = ast.literal_eval(self.__worker_disk_ids)
+            if self.__worker_disk_ids:
+                # Solved GitHub Actions issue that env variable detect as string instead of dict/ list -skip for Jenkins
+                if self.__environment_variables_dict.get('github_token', ''):
+                    self.__worker_disk_ids = self.__worker_disk_ids.replace('"', '')
+                self.__worker_disk_ids = ast.literal_eval(self.__worker_disk_ids)
 
     @staticmethod
     def __get_yaml_files(path: str, extensions: list = ['.yaml', '.sh']):


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Jenkins automatically escapes single quotes to prevent any issues with Groovy
Using double quotes instead of single quotes in jenkins, and skipping Github actions workaround.

## For security reasons, all pull requests need to be approved first before running any automated CI
