### PR TITLE
Update benchmark-operator to 1.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir -p ~/.ssh/
 RUN mkdir -p /tmp/run_artifacts
 
 # download benchmark-operator to /tmp default path
-RUN git clone -b v1.0.2 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
+RUN git clone -b v1.0.3 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 # download clusterbuster to /tmp default path && install cluster-buster dependency
 RUN git clone -b v1.2.2-kata-ci https://github.com/RobertKrawitz/OpenShift4-tools /tmp/OpenShift4-tools \


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Benchmark-operator workloads [uperf, vdbench] failed in OCP/CNV 4.15
Based on benchmark-operator [PR](https://github.com/cloud-bulldozer/benchmark-operator/pull/823)

Root cause:
```
  File "/usr/local/lib/python3.8/site-packages/openshift/dynamic/discovery.py", line 193, in get_resources_for_api_version
    resource, name = subresource['name'].split('/')
ValueError: too many values to unpack (expected 2)
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/opt/ansible/.ansible/tmp/ansible-tmp-1709981190.321196-648-
```

This looks like the same issue: https://giters.com/openshift/openshift-restclient-python/issues/437
and there is a PR, but I am not sure how to get the update, does it maybe mean this needs to be bumped? https://github.com/redhat-performance/benchmark-runner/blob/main/requirements.txt#L11
GitersGiters
[get_resources_for_api_version() expects sub-resource names to be of the format a/b](https://giters.com/openshift/openshift-restclient-python/issues/437)
get_resources_for_api_version() in https://github.com/openshift/openshift-restclient-python/blob/master/openshift/dynamic/discovery.py#L133, currently expects sub-resource names to be of the format a/b.

## For security reasons, all pull requests need to be approved first before running any automated CI
