### PR TITLE
Fix Grafana CI Status color

### DIFF
--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -242,7 +242,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
       + stateTimeline.fieldConfig.withOverrides([
         stateTimeline.fieldOverride.byName.new('Ci Status')
-              + g.panel.table.fieldOverride.byName.withProperty('color', {"mode": "continuous-RdYlGr"})
+              + g.panel.table.fieldOverride.byName.withProperty('color', {"mode": "continuous-GrYlRd"})
       ])
 
       + stateTimeline.gridPos.withH(6)


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix Grafana CI Status color

## For security reasons, all pull requests need to be approved first before running any automated CI
