### PR TITLE
fix stressng

### DIFF
--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
@@ -36,6 +36,7 @@ spec:
       # cpu stressor options
       cpu_stressors: "{{ cpu_stressors }}"
       cpu_percentage: "{{ cpu_percentage }}"
+      cpu_method: "{{ cpu_method }}"
       # vm stressor option
       vm_stressors: "{{ vm_stressors }}"
       vm_bytes: "{{ vm_bytes }}"

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
@@ -28,6 +28,7 @@ spec:
       # cpu stressor options
       cpu_stressors: "{{ cpu_stressors }}"
       cpu_percentage: "{{ cpu_percentage }}"
+      cpu_method: "{{ cpu_method }}"
       # vm stressor option
       vm_stressors: "{{ vm_stressors }}"
       vm_bytes: "{{ vm_bytes }}"

--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -7,6 +7,7 @@ template_data:
     instances: 1
     # cpu stressor options
     cpu_percentage: 100
+    cpu_method: all
     # vm stressor option
     vm_stressors: 1
     # mem stressor options


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Missing argument in yaml:
`   "msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'cpu_method'. 'dict object' has no attribute 'cpu_method'. 'dict object' has no attribute 'cpu_method'. 'dict object' has no attribute 'cpu_method'\n\nThe error appears to be in '/opt/ansible/roles/stressng/tasks/main.yaml': line 4, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - name: template stressng config file\n    ^ here\n"`

## For security reasons, all pull requests need to be approved first before running any automated CI
