### PR TITLE
Update windows virtualization storage class

### DIFF
--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_dv_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_dv_template.yaml
@@ -16,4 +16,4 @@ spec:
       requests:
         storage: {{ storage }}
     volumeMode: Block
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: ocs-storagecluster-ceph-rbd-virtualization


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Update windows virtualization storage class to:
`storageClassName:  ocs-storagecluster-ceph-rbd-virtualization`

## For security reasons, all pull requests need to be approved first before running any automated CI
