### PR TITLE
Temporary Replace Uperf VM with Stressng VM

### DIFF
--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -306,7 +306,7 @@ jobs:
        # continue to next job if failed
        fail-fast: false
        matrix:
-          workload: [ 'stressng_pod', 'uperf_vm' ]
+          workload: [ 'stressng_pod', 'stressng_vm' ]
           python-version: [ '3.10' ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Currently, there is an issue with the benchmark-operator: uperf_vm, which is under investigation by @jtaleric. [Inconsistent failures]
Replace uperf_vm with stressng_vm until the issue is fixed.
## For security reasons, all pull requests need to be approved first before running any automated CI
