### PR TITLE
Upgrading the base image in the Dockerfile to CentOS Stream 9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.600
+current_version = 1.0.601
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 # benchmark-runner latest version
 ARG VERSION
@@ -7,12 +7,10 @@ ARG VERSION
 RUN dnf update -y --nobest
 
 # install make
-Run dnf group install -y "Development Tools"
+RUN dnf group install -y "Development Tools"
 
 # install podman and jq
-Run dnf config-manager --set-enabled powertools \
-    && dnf install -y @container-tools \
-    && dnf install -y jq
+RUN dnf install -y podman jq
 
 # Prerequisite for Python installation
 ARG python_full_version=3.10.8
@@ -28,7 +26,7 @@ RUN wget https://www.python.org/ftp/python/${python_full_version}/Python-${pytho
     && rm -rf Python-${python_full_version}.tgz
 
 # install & run benchmark-runner (--no-cache-dir for take always the latest)
-RUN python3.10 -m pip --no-cache-dir install --upgrade pip && pip --no-cache-dir install benchmark-runner --upgrade
+RUN python3.10 -m pip install --upgrade pip && pip install --upgrade benchmark-runner
 
 # install oc/kubectl client tools for OpenShift/Kubernetes
 ARG OCP_CLIENT_VERSION="4.15.0"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.600'
+__version__ = '1.0.601'
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
CentOS Stream 8 has reached its [**End of Life**](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/). Upgrade the base image in the Dockerfile to CentOS Stream 9.

[CentOS Stream 8 Build failure](https://github.com/redhat-performance/benchmark-runner/actions/runs/9346156486/job/25721614545)

## For security reasons, all pull requests need to be approved first before running any automated CI
