### PR TITLE
fix pypi validate

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.603
+current_version = 1.0.604
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -230,7 +230,7 @@ jobs:
               echo 'wait' "$((current_wait_time+sleep_time))" 'seconds'
               sleep $sleep_time
               current_wait_time="$((current_wait_time+sleep_time))"
-              pip --no-cache-dir install benchmark-runner --upgrade
+              pip --no-cache-dir install setuptools benchmark-runner --upgrade
               build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
               actual_version="$(cut -d'=' -f2 <<<"$build")"
               if (( $current_wait_time == $timeout )); then

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.603'
+__version__ = '1.0.604'
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix pypi validate by installing [setuptools](https://github.com/redhat-performance/benchmark-runner/actions/runs/9354758522/job/25751483638)

```
Run echo '⌛ Wait till package will be updated in PyPI'
⌛ Wait till package will be updated in PyPI
Traceback (most recent call last):
  File "/home/runner/work/benchmark-runner/benchmark-runner/setup.py", line 4, in <module>
    from setuptools import setup, find_packages
ModuleNotFoundError: No module named 'setuptools'
```

## For security reasons, all pull requests need to be approved first before running any automated CI
