### PR TITLE
Update python3.12 changes

### DIFF
--- a/.github/workflows/Build_runner.yml
+++ b/.github/workflows/Build_runner.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: 🔨 Build and publish distribution 📦 to PyPI
       env:
         TWINE_USERNAME: __token__
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Validate upload to PyPI
       env:
         TWINE_USERNAME: __token__
@@ -59,8 +59,8 @@ jobs:
         # Verify and wait till latest benchmark-runner version will be updated in Pypi (timeout 900 seconds)
         timeout=900
         sleep_time=30
+        pip --no-cache-dir install setuptools benchmark-runner --upgrade
         expected_version=$(python3 setup.py --version)
-        pip --no-cache-dir install benchmark-runner --upgrade
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         actual_version="$(cut -d'=' -f2 <<<"$build")"
         current_wait_time=0
@@ -89,12 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: ⌛ Build and Upload 🐋 to quay.io
         run: |
+          pip install setuptools
           version=$(python3 setup.py --version)
           sudo docker build --build-arg VERSION=$version -t quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:v$version .
           sudo docker build --build-arg VERSION=latest -t quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:latest .
@@ -110,10 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: ⚙ Set START CI TIME
         run: echo "START_CI=${{ needs.test.outputs.start_time_output }}" >> "$GITHUB_ENV"
       - name: Install latest benchmark-runner
@@ -130,9 +131,9 @@ jobs:
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
       - name: 🎁 Bump Version
         run: |
+          pip install setuptools bumpversion
           version=$(python3 setup.py --version)
           git checkout main
-          pip install bumpversion
           git config --global user.email ${{ secrets.EMAIL }}
           git config --global user.name  ${{ secrets.USER_NAME }}
           git config pull.rebase false  # merge (the default strategy)

--- a/.github/workflows/Perf_Env_Build_Azure_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Azure_Test_CI.yml
@@ -251,8 +251,8 @@ jobs:
         # Verify and wait till latest benchmark-runner version will be updated in Pypi (timeout 900 seconds)
         timeout=900
         sleep_time=30
+        pip --no-cache-dir install setuptools benchmark-runner --upgrade
         expected_version=$(python3 setup.py --version)
-        pip --no-cache-dir install benchmark-runner --upgrade
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         actual_version="$(cut -d'=' -f2 <<<"$build")"
         current_wait_time=0
@@ -290,6 +290,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: ⌛ Build and Upload 🐋 to quay.io
         run: |
+          pip install setuptools
           version=$(python3 setup.py --version)
           sudo docker build --build-arg VERSION=$version -t quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:v$version .
           sudo docker build --build-arg VERSION=latest -t quay.io/${{ secrets.QAUYIO_REPOSITORY }}/${{ secrets.PACKAGE_NAME }}:latest .
@@ -318,9 +319,9 @@ jobs:
           pip install benchmark-runner wheel
       - name: 🎁 Bump Version
         run: |
+          pip install setuptools bumpversion
           version=$(python3 setup.py --version)
           git checkout main
-          pip install bumpversion
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
           git config pull.rebase false  # merge

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -216,9 +216,8 @@ jobs:
         # Verify and wait till latest benchmark-runner version will be updated in Pypi (timeout 900 seconds)
         timeout=900
         sleep_time=30
-        pip install setuptools
+        pip --no-cache-dir install setuptools benchmark-runner --upgrade
         expected_version=$(python3 setup.py --version)
-        pip --no-cache-dir install benchmark-runner --upgrade
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         actual_version="$(cut -d'=' -f2 <<<"$build")"
         current_wait_time=0
@@ -285,10 +284,9 @@ jobs:
           pip install benchmark-runner wheel
       - name: 🎁 Bump Version
         run: |
-          pip install setuptools
+          pip install setuptools bumpversion
           version=$(python3 setup.py --version)
           git checkout main
-          pip install bumpversion
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name  "${{ secrets.USER_NAME }}"
           git config pull.rebase false  # merge

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf group install -y "Development Tools"
 RUN dnf install -y podman jq
 
 # Prerequisite for Python installation
-ARG python_full_version=3.10.8
+ARG python_full_version=3.12.3
 RUN dnf install openssl-devel bzip2-devel wget libffi-devel -y
 
 # Install Python
@@ -22,14 +22,14 @@ RUN wget https://www.python.org/ftp/python/${python_full_version}/Python-${pytho
     && cd Python-${python_full_version} \
     && ./configure --enable-optimizations \
     && make altinstall \
-    && echo alias python=python3.10 >> ~/.bashrc \
+    && echo alias python=python3.12 >> ~/.bashrc \
     && rm -rf Python-${python_full_version}.tgz
 
 # install & run benchmark-runner (--no-cache-dir for take always the latest)
-RUN python3.10 -m pip install --upgrade pip && pip install --upgrade benchmark-runner
+RUN python3.12 -m pip install --upgrade pip && python3.12 -m pip install --upgrade benchmark-runner
 
 # install oc/kubectl client tools for OpenShift/Kubernetes
-ARG OCP_CLIENT_VERSION="4.15.0"
+ARG OCP_CLIENT_VERSION="4.16.0-rc.3"
 RUN  curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_CLIENT_VERSION}/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz" -o "/tmp/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz" \
      && tar -xzvf /tmp/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz -C /tmp/ \
      && mv /tmp/kubectl /usr/local/bin/kubectl \
@@ -37,7 +37,7 @@ RUN  curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_CL
      && rm -rf /tmp/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz /tmp/kubectl /tmp/oc
 
 # Install virtctl for VNC
-ARG virtctl_version="1.0.0"
+ARG virtctl_version="1.2.0"
 RUN curl -L "https://github.com/kubevirt/kubevirt/releases/download/v${virtctl_version}/virtctl-v${virtctl_version}-linux-amd64" -o /usr/local/bin/virtctl \
     && chmod +x /usr/local/bin/virtctl
 
@@ -63,7 +63,7 @@ RUN git clone -b v1.2.2-kata-ci https://github.com/RobertKrawitz/OpenShift4-tool
 # Add main
 COPY benchmark_runner/main/main.py /benchmark_runner/main/main.py
 
-CMD [ "python3.10", "/benchmark_runner/main/main.py"]
+CMD [ "python3.12", "/benchmark_runner/main/main.py"]
 
 # oc: https://www.ibm.com/docs/en/fci/6.5.1?topic=steps-setting-up-installation-server
 # sudo podman build -t quay.io/ebattat/benchmark-runner:latest . --no-cache

--- a/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
+++ b/benchmark_runner/common/elasticsearch/elasticsearch_operations.py
@@ -6,7 +6,7 @@ from typeguard import typechecked
 from elasticsearch import Elasticsearch
 from elasticsearch.connection import create_ssl_context
 from elasticsearch_dsl import Search
-from datetime import datetime
+from datetime import datetime, timezone
 
 from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
@@ -169,7 +169,7 @@ class ElasticSearchOperations:
                 data.update(es_add_items)
 
             # utcnow - solve timestamp issue
-            data['timestamp'] = datetime.utcnow()  # datetime.now()
+            data['timestamp'] = datetime.now(timezone.utc)  # datetime.utcnow() or datetime.now()
 
             # Uploads data to elasticsearch server
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs==21.4.0
 azure==4.0.0
-boto3==1.26.1
-botocore==1.29.1
+boto3==1.34.119
+botocore==1.34.119
 cryptography==42.0.4
 elasticsearch==7.16.1
 elasticsearch_dsl==7.4.0


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Update python 3.12 changes:
1. pip install setuptools before running: python3 setup.py --version
2. Update Dockerfile with python3.12
3. Update Dockerfile with latest virtctl/oc client versions
 
This PR must merged after [PR](https://github.com/redhat-performance/benchmark-runner/pull/823 ) because it used python3.12 packages dependencies inside Dockerfile

## For security reasons, all pull requests need to be approved first before running any automated CI
