### PR TITLE
np.float_ was removed in the NumPy 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ azure==4.0.0
 boto3==1.33.13
 botocore==1.33.13
 cryptography==42.0.4
-elasticsearch==7.16.1
+elasticsearch==7.17.9
 elasticsearch_dsl==7.4.0
 ipywidgets==8.0.6
 jinja2==3.1.4

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'boto3==1.33.13',  # s3
         'botocore==1.33.13',  # s3
         'cryptography==42.0.4',  # for paramiko
-        'elasticsearch==7.16.1',
+        'elasticsearch==7.17.9',
         'elasticsearch_dsl==7.4.0',  # for deep search
         'ipywidgets==8.0.6',  # for jupyterlab widgets
         'jinja2==3.1.4',  # for yaml templates and df.style

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,5 +1,5 @@
 azure==4.0.0
-elasticsearch==7.16.1
+elasticsearch==7.17.9
 elasticsearch_dsl==7.4.0
 jinja2==3.1.4
 mock


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Solved the following error:
`AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.`

## For security reasons, all pull requests need to be approved first before running any automated CI
