### PR TITLE
Fix format issue

### DIFF
--- a/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
+++ b/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
@@ -177,7 +177,7 @@ class BareMetalOperations:
         self._remote_ssh.replace_parameter(remote_path='/root/jetlag/ansible/vars',
                                             file_name=file_name,
                                             parameter='ocp_release_image:',
-                                            value=f'quay.io\/openshift-release-dev\/ocp-release:{self._install_ocp_version}-x86_64')
+                                            value=fr'quay.io\/openshift-release-dev\/ocp-release:{self._install_ocp_version}-x86_64')
         self._remote_ssh.replace_parameter(remote_path='/root/jetlag/ansible/vars',
                                             file_name=file_name,
                                             parameter='openshift_version:',


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix the following SyntaxWarning:
```
/Users/ebattat/PycharmProjects/benchmark-runner/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py:180: SyntaxWarning: invalid escape sequence '/'
value=f'quay.io/openshift-release-dev/ocp-release:{self._install_ocp_version}-x86_64')
```

## For security reasons, all pull requests need to be approved first before running any automated CI
