### PR TITLE
Upload PerfCi backup and report to Google Drive

### DIFF
--- a/benchmark_runner/common/google_drive/google_drive_operations.py
+++ b/benchmark_runner/common/google_drive/google_drive_operations.py
@@ -1,0 +1,148 @@
+
+import os
+import logging
+from googleapiclient.discovery import build
+from google.oauth2.credentials import Credentials
+from googleapiclient.http import MediaFileUpload
+from google.auth.transport.requests import Request
+from google_auth_oauthlib.flow import InstalledAppFlow
+from benchmark_runner.common.logger.logger_time_stamp import logger  # Added logger import
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Define the scope
+SCOPES = ['https://www.googleapis.com/auth/drive']
+
+
+class GoogleDriveOperations:
+    """
+    This class is for Google Drive operations and requires the following:
+
+    1. credentials.json - Obtain from the "Google Cloud Console" under "APIs & Services" > "Credentials" > "Create Credentials" and select "OAuth 2.0 Client ID".
+    2. token.json - This is generated automatically. If a browser is not available, copy the token from a machine with a browser.
+    """
+    def __init__(self):
+        """
+        Initializes GoogleDriveOperations with authentication.
+        """
+        self.creds = self.authenticate()
+        self.service = build('drive', 'v3', credentials=self.creds)
+
+    def authenticate(self):
+        """
+        Authenticates and returns credentials using token.json or interactive login.
+        :return: Credentials object
+        """
+        creds = None
+        if os.path.exists('token.json'):
+            creds = Credentials.from_authorized_user_file('token.json', SCOPES)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
+                creds = flow.run_local_server(port=0)
+            with open('token.json', 'w') as token_file:
+                token_file.write(creds.to_json())
+        return creds
+
+    def list_files_in_folder(self, folder_id, level=0):
+        """
+        Recursively lists files and folders in a specified Google Drive folder.
+        :param folder_id: The ID of the folder to list.
+        :param level: Current recursion level (default is 0).
+        :return: List of file and folder metadata dictionaries.
+        """
+        items = []
+        page_token = None
+        while True:
+            results = self.service.files().list(
+                q=f"'{folder_id}' in parents and trashed = false",
+                includeItemsFromAllDrives=True,
+                supportsAllDrives=True,
+                pageSize=100,
+                fields="nextPageToken, files(id, name, mimeType)",
+                pageToken=page_token
+            ).execute()
+
+            items.extend(results.get('files', []))
+            page_token = results.get('nextPageToken', None)
+            if page_token is None:
+                break
+
+        for item in items:
+            indent = '  ' * level
+            if item['mimeType'] == 'application/vnd.google-apps.folder':
+                logger.info(f"{indent}Folder: {item['name']} ({item['id']})")
+                self.list_files_in_folder(item['id'], level + 1)
+            else:
+                logger.info(f"{indent}File: {item['name']} ({item['id']})")
+
+        return items
+
+    def list_folders_and_files_in_shared_drive(self, shared_drive_id):
+        """
+        Lists all folders and files within a specified Google Drive shared drive.
+        :param shared_drive_id: The ID of the shared drive to list.
+        """
+        try:
+            logger.info(f'Folders and Files in shared drive with ID {shared_drive_id}:')
+            self.list_files_in_folder(shared_drive_id)
+            logger.info("Folder and file listing successful!")
+        except Exception as e:
+            logger.error(f"An error occurred: {e}")
+
+    def find_existing_file(self, file_name, shared_drive_id):
+        """
+        Finds an existing file in a specified Google Drive shared drive.
+        :param file_name: The name of the file to find.
+        :param shared_drive_id: The ID of the shared drive to search.
+        :return: File metadata dictionary if found, otherwise None.
+        """
+        try:
+            all_files = self.list_files_in_folder(shared_drive_id)
+            for file in all_files:
+                if file['name'] == file_name:
+                    return file
+            return None
+        except Exception as e:
+            logger.error(f"An error occurred while searching for the file: {e}")
+            return None
+
+    def upload_file(self, file_path, shared_drive_id):
+        """
+        Uploads a file to a specified Google Drive shared drive and override if exist
+        :param file_path: The local path of the file to upload.
+        :param shared_drive_id: The ID of the shared drive to upload the file to.
+        """
+        try:
+            file_name = os.path.basename(file_path)
+            existing_file = self.find_existing_file(file_name, shared_drive_id)
+            media = MediaFileUpload(file_path)
+
+            if existing_file:
+                file_id = existing_file['id']
+                file = self.service.files().update(
+                    fileId=file_id,
+                    media_body=media,
+                    supportsAllDrives=True,
+                    fields='id'
+                ).execute()
+                logger.info(f"File '{file_name}' updated successfully in shared drive with ID: {shared_drive_id}")
+            else:
+                file_metadata = {
+                    'name': file_name,
+                    'parents': [shared_drive_id]
+                }
+                file = self.service.files().create(
+                    body=file_metadata,
+                    media_body=media,
+                    supportsAllDrives=True,
+                    fields='id'
+                ).execute()
+                logger.info(f"File '{file_name}' uploaded successfully to shared drive with ID: {shared_drive_id}")
+
+        except Exception as e:
+            logger.error(f"An error occurred: {e}")

--- a/benchmark_runner/jupyterlab/templates/summary_report/update_summary_report_versions.ipynb
+++ b/benchmark_runner/jupyterlab/templates/summary_report/update_summary_report_versions.ipynb
@@ -44,15 +44,32 @@
     "import configparser\n",
     "config = configparser.ConfigParser()\n",
     "config.read('data.conf')\n",
+    "\n",
+    "# ElasticSearch\n",
     "es_host = config.get(\"data\", 'es_host') \n",
     "es_port = config.get(\"data\", 'es_port')\n",
     "es_user = config.get(\"data\", 'es_user') \n",
     "es_password = config.get(\"data\", 'es_password')\n",
-    "grafana_url = config.get(\"data\", 'grafana_url')\n",
+    "\n",
+    "# Grafana\n",
+    "os.environ['grafana_url'] = config.get(\"data\", 'grafana_url')\n",
     "os.environ['network_speed'] = config.get(\"data\", 'network_speed')\n",
     "os.environ['fetch_ocp_versions_days'] = config.get(\"data\", 'fetch_ocp_versions_days')\n",
     "os.environ['filter_kind'] = config.get(\"data\", 'filter_kind')\n",
     "\n",
+    "# AWS\n",
+    "endpoint_url = config.get(\"data\", 'service_name') \n",
+    "region_name = config.get(\"data\", 'region_name') \n",
+    "endpoint_url= config.get(\"data\", 'endpoint_url') \n",
+    "aws_access_key_id = config.get(\"data\", 'aws_access_key_id') \n",
+    "aws_secret_access_key = config.get(\"data\", 'aws_secret_access_key') \n",
+    "bucket = config.get(\"data\", 'bucket') \n",
+    "key = config.get(\"data\", 'key')\n",
+    "\n",
+    "# Google drive\n",
+    "google_folder_id = config.get(\"data\", 'google_folder_id')\n",
+    "\n",
+    "from benchmark_runner.common.google_drive.google_drive_operations import GoogleDriveOperations\n",
     "from benchmark_runner.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations\n",
     "from benchmark_runner.jupyterlab.templates.summary_report.summary_report_widgets import SummaryReportWidgets\n",
     "\n",
@@ -76,14 +93,52 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dda58b0-ddce-456e-81cb-ea6abe7d0ea1",
+   "id": "7dd25474-a859-497a-acae-e9aa96ca64a3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Get the two last major versions\n",
     "versions = summary_report_widget.get_two_last_major_versions()\n",
-    "os.rename('summary_report.html', f'summary_report_{versions[0]}_{versions[1]}.html')"
+    "\n",
+    "# Define the source and destination file paths\n",
+    "source = 'summary_report.html'\n",
+    "destination = f'summary_report_{versions[0]}_{versions[1]}.html'\n",
+    "\n",
+    "# Copy the file\n",
+    "shutil.copyfile(source, destination)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76587440-180b-426a-893f-7e18ff99fee7",
+   "metadata": {},
+   "source": [
+    "## Upload summary report to Google drive (override)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b3a7396-f990-40e1-8cb0-4159952c7f34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Performance & Scale -> CNV -> Summary Report\n",
+    "shared_drive_id = google_folder_id\n",
+    "file_path = destination\n",
+    "gdrive_operations = GoogleDriveOperations()\n",
+    "gdrive_operations.upload_file(file_path, shared_drive_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd1683f8-de61-439d-b6ce-97a757d1c82a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -102,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/jenkins/PerfCI_Backup_Report_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Backup_Report_Deployment/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
             }
         }
 
-        stage('CI Pod Deployment') {
+        stage('CI Pod Deployment & Report') {
             steps {
                 script {
                        withCredentials([string(credentialsId: 'perfci_ci_pod_deployment', variable: 'CI_POD_DEPLOYMENT')]) {
@@ -40,7 +40,7 @@ pipeline {
             }
         }
 
-        stage('Backup to S3') {
+        stage('Backup to Google Drive') {
             steps {
                 script {
                        withCredentials([string(credentialsId: 'perfci_ci_backup', variable: 'CI_BACKUP')]) {

--- a/jenkins/PerfCI_Grafana_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Grafana_Deployment/Jenkinsfile
@@ -194,7 +194,7 @@ pipeline {
             }
         }
         success {
-            echo 'TBD'
+            echo 'Triggering PerfCI-Backup-Report-Deployment pipeline'
             build job: 'PerfCI-Backup-Report-Deployment', wait: false
         }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ botocore==1.33.13
 cryptography==42.0.4
 elasticsearch==7.16.1
 elasticsearch_dsl==7.4.0
+google-api-python-client==2.135.0
+google-auth==2.30.0
+google-auth-httplib2==0.2.0
+google-auth-oauthlib==1.2.0
 ipywidgets==8.0.6
 jinja2==3.1.4
 myst-parser==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,10 @@ setup(
         'cryptography==42.0.4',  # for paramiko
         'elasticsearch==7.16.1',
         'elasticsearch_dsl==7.4.0',  # for deep search
+        'google-auth==2.30.0',  # for Google Drive
+        'google-auth-httplib2==0.2.0',  # for Google Drive
+        'google-auth-oauthlib==1.2.0',  # for Google Drive
+        'google-api-python-client==2.135.0'  # for Google Drive
         'ipywidgets==8.0.6',  # for jupyterlab widgets
         'jinja2==3.1.4',  # for yaml templates and df.style
         'myst-parser==1.0.0',  # readthedocs

--- a/tests/unittest/benchmark_runner/common/google_drive/mock_google_drive.py
+++ b/tests/unittest/benchmark_runner/common/google_drive/mock_google_drive.py
@@ -1,0 +1,29 @@
+import pytest
+import tempfile
+from unittest.mock import MagicMock, patch
+from benchmark_runner.common.google_drive.google_drive_operations import GoogleDriveOperations
+
+
+def mock_google_drive(func):
+    def decorated(*args, **kwargs):
+        # Set up the mock Google Drive service
+        mock_service = MagicMock()
+        mock_files = mock_service.files.return_value
+        mock_files.list.return_value.execute.return_value = {
+            'files': [
+                {'id': '1CcVZmoN4qjEaMrJrYSpzcUIZA5_JmFnM', 'name': 'summary_report_4.15.13_4.16.13.html',
+                 'mimeType': 'text/html'},
+                {'id': '1dHTHrAHdJljXE_6itAG7FYPqtu07ZyIJ', 'name': 'summary_report_4.15.13_4.16.0-rc.8.html',
+                 'mimeType': 'text/html'}
+            ]
+        }
+
+        # Patch the GoogleDriveOperations to use the mock service
+        with patch('benchmark_runner.common.google_drive.google_drive_operations.GoogleDriveOperations.authenticate', return_value=None):
+            with patch('benchmark_runner.common.google_drive.google_drive_operations.build', return_value=mock_service):
+                google_drive_operations = GoogleDriveOperations()
+                google_drive_operations.service = mock_service
+
+                return func(google_drive_operations, mock_service, *args, **kwargs)
+
+    return decorated

--- a/tests/unittest/benchmark_runner/common/google_drive/test_google_drive_operations.py
+++ b/tests/unittest/benchmark_runner/common/google_drive/test_google_drive_operations.py
@@ -1,0 +1,76 @@
+
+import tempfile
+from unittest.mock import MagicMock, patch
+from tests.unittest.benchmark_runner.common.google_drive.mock_google_drive import mock_google_drive
+
+
+@mock_google_drive
+def test_list_files_in_folder(google_drive_operations, mock_google_drive_service):
+    """
+    Tests listing files in a Google Drive folder.
+
+    @param google_drive_operations: Instance of GoogleDriveOperations.
+    """
+    # Now call the method to test
+    result = google_drive_operations.list_files_in_folder('root_folder_id')
+
+    # Assert the expected results based on the mocked data
+    assert len(result) == 2
+    assert result[0]['id'] == '1CcVZmoN4qjEaMrJrYSpzcUIZA5_JmFnM'
+    assert result[0]['name'] == 'summary_report_4.15.13_4.16.13.html'
+    assert result[0]['mimeType'] == 'text/html'
+    assert result[1]['id'] == '1dHTHrAHdJljXE_6itAG7FYPqtu07ZyIJ'
+    assert result[1]['name'] == 'summary_report_4.15.13_4.16.0-rc.8.html'
+    assert result[1]['mimeType'] == 'text/html'
+
+
+@mock_google_drive
+def test_find_existing_file(google_drive_operations, mock_google_drive_service):
+    """
+    Tests finding an existing file in a Google Drive shared drive.
+
+    @param google_drive_operations: Instance of GoogleDriveOperations.
+    @param mock_google_drive_service: Mocked Google Drive service.
+    """
+    # Now call the method to test
+    result = google_drive_operations.find_existing_file('summary_report_4.15.13_4.16.0-rc.8.html', 'shared_drive_id')
+
+    # Assert the expected result
+    assert result is not None
+    assert result['id'] == '1dHTHrAHdJljXE_6itAG7FYPqtu07ZyIJ'
+    assert result['name'] == 'summary_report_4.15.13_4.16.0-rc.8.html'
+    assert result['mimeType'] == 'text/html'
+
+
+@mock_google_drive
+def test_upload_file_with_mock(google_drive_operations, mock_google_drive_service):
+    """
+    Tests uploading a new file to a Google Drive shared drive using a mock for upload_file.
+
+    @param google_drive_operations: Instance of GoogleDriveOperations.
+    @param mock_google_drive_service: Mocked Google Drive service.
+    """
+    # Prepare a temporary file to upload
+    with tempfile.NamedTemporaryFile(suffix='.html') as temp_file:
+        temp_file_name = temp_file.name.split('/')[-1]  # Extract only the file name
+
+        # Mock the upload_file method to update the mock_service
+        def mock_upload_file(file_path, shared_drive_id):
+            # Simulate updating the mock_service with the new file entry
+            mock_service = google_drive_operations.service
+            updated_entry = {'id': 'new_file_id', 'name': temp_file_name, 'mimeType': 'text/html'}
+            mock_service.files.return_value.list.return_value.execute.return_value['files'].append(updated_entry)
+            return mock_service.files.return_value.list.return_value.execute.return_value['files']
+
+        # Patch the upload_file method with the mock implementation
+        google_drive_operations.upload_file = MagicMock(side_effect=mock_upload_file)
+
+        # Call the upload_file method
+        returned_files_list = google_drive_operations.upload_file(temp_file.name, 'shared_drive_id')
+
+        # Verify the returned files list
+        assert returned_files_list is not None
+        assert len(returned_files_list) == 3  # Assuming three files are now in the list after upload
+
+        # Verify that the new file entry exists in the returned files list
+        assert any(file['name'] == temp_file_name for file in returned_files_list)


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Upload PerfCi backup and report to Google Shared Drive instead of S3.

1. Backup the following:

- ElasticSearch data
- Grafana metadata
- PerfCi bastion files

2. Upload the latest CNV workloads summary report.
3. Update Jenkinsfile to upload to Google Shared Drive instead of S3.
4. Update Jupyterlab notebook o upload to Google Shared Drive instead of S3.
5. Adding unittest for [google_drive_operations.py](https://github.com/redhat-performance/benchmark-runner/compare/main...ebattat:google_drive?expand=1#diff-766194074614eb5489ce1bafe1739a391b4a04d6fe11bfd05601b76684244805) using internal mock_google_drive
6. Update google dependency packages.

** Upload and override if the file already exists.

## For security reasons, all pull requests need to be approved first before running any automated CI
