### PR TITLE
Add a wait for ODF health check

### DIFF
--- a/benchmark_runner/common/oc/oc_exceptions.py
+++ b/benchmark_runner/common/oc/oc_exceptions.py
@@ -157,3 +157,10 @@ class OperatorUpgradeTimeout(OCError):
     def __init__(self, operator, version, namespace):
         self.message = f"{operator} operator upgrade to: {version} in namespace: {namespace} didn't complete"
         super(OperatorUpgradeTimeout, self).__init__(self.message)
+
+
+class ODFHealthCheckTimeout(OCError):
+    """This exception return odf healthcheck timeout error"""
+    def __init__(self):
+        self.message = f"ODF health check timeout"
+        super(ODFHealthCheckTimeout, self).__init__(self.message)

--- a/jenkins/PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Operators_Deployment/Jenkinsfile
@@ -156,10 +156,6 @@ END
                 emailext body: """\
                     Jenkins job: ${env.BUILD_URL}\nSee the console output for more details:  ${env.BUILD_URL}consoleFull\n\n
                 """, subject: msg, to: "${CONTACT_EMAIL1}"
-
-                // Trigger PerfCI-Openshift-Deployment pipeline on failure
-                echo 'Triggering PerfCI-Openshift-Deployment pipeline due to failure'
-                build job: 'PerfCI-Openshift-Deployment', wait: false
             }
         }
         success {


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below --> 
ODF installation failed due to a missing wait.(ODFInstallationFailed)
Add a wait for the ODF health check and raise an ODFHealthCheckTimeout error

## For security reasons, all pull requests need to be approved first before running any automated CI
