### PR TITLE
Update Windows VM storage class

### DIFF
--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
@@ -121,7 +121,7 @@ spec:
           requests:
             storage: {{ storage }}
         volumeMode: Block
-        storageClassName: ocs-storagecluster-ceph-rbd
+        storageClassName: ocs-storagecluster-ceph-rbd-virtualization
       source:
         pvc:
           namespace: {{ namespace }}


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Windows recommended storage class: ocs-storagecluster-ceph-rbd-virtualization
CNV must deploy before ODF operator

## For security reasons, all pull requests need to be approved first before running any automated CI
