### PR TITLE
Enable Google Drive  & Disable Prometheus during VM validation

### DIFF
--- a/jenkins/PerfCI_Chaos/03_PerfCI_Choas_Windows_VMs_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/03_PerfCI_Choas_Windows_VMs_Deployment/Jenkinsfile
@@ -18,6 +18,10 @@ pipeline {
         IBM_SECRET_ACCESS_KEY = credentials('perfci_ibm_secret_access_key')
         IBM_BUCKET = credentials('perfci_ibm_bucket')
         IBM_KEY = credentials('perfci_ibm_key')
+        GOOGLE_DRIVE_PATH = credentials('perfci_google_drive_path')
+        GOOGLE_DRIVE_CREDENTIALS = credentials('perfci_google_drive_credentials')
+        GOOGLE_DRIVE_TOKEN = credentials('perfci_google_drive_token')
+        GOOGLE_DRIVE_SHARED_DRIVE_ID = credentials('perfci_google_drive_shared_drive_id')
         RUN_ARTIFACTS_URL = credentials('perfci_run_artifacts_url')
         REDIS = credentials('perfci_redis')
         WORKER_DISK_IDS = credentials('perfci_worker_disk_ids')
@@ -191,6 +195,10 @@ END
                                         -e IBM_SECRET_ACCESS_KEY='${IBM_SECRET_ACCESS_KEY}' \
                                         -e IBM_BUCKET='${IBM_BUCKET}' \
                                         -e IBM_KEY='${IBM_KEY}' \
+                                        -e GOOGLE_DRIVE_PATH='${GOOGLE_DRIVE_PATH}' \
+                                        -e GOOGLE_DRIVE_CREDENTIALS='${GOOGLE_DRIVE_CREDENTIALS}' \
+                                        -e GOOGLE_DRIVE_TOKEN='${GOOGLE_DRIVE_TOKEN}' \
+                                        -e GOOGLE_DRIVE_SHARED_DRIVE_ID='${GOOGLE_DRIVE_SHARED_DRIVE_ID}' \
                                         -e RUN_ARTIFACTS_URL='${RUN_ARTIFACTS_URL}' \
                                         -e BUILD_VERSION='${build_version}' \
                                         -e RUN_TYPE='${RUN_TYPE}' \

--- a/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
         CONTAINER_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         WORKER_DISK_PREFIX = 'wwn-0x'
         SAVE_ARTIFACTS_LOCAL = 'False'
-        ENABLE_PROMETHEUS_SNAPSHOT = 'True'
+        ENABLE_PROMETHEUS_SNAPSHOT = 'False'
         DELETE_ALL = 'False' // Not delete the running Windows11 VMs
         VERIFICATION_ONLY = 'True'
         RUN_TYPE = 'perf_ci'

--- a/jenkins/PerfCI_Chaos/05_PerfCI_Chaos_Verify_Windows_VMs_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/05_PerfCI_Chaos_Verify_Windows_VMs_Deployment/Jenkinsfile
@@ -18,6 +18,10 @@ pipeline {
         IBM_SECRET_ACCESS_KEY = credentials('perfci_ibm_secret_access_key')
         IBM_BUCKET = credentials('perfci_ibm_bucket')
         IBM_KEY = credentials('perfci_ibm_key')
+        GOOGLE_DRIVE_PATH = credentials('perfci_google_drive_path')
+        GOOGLE_DRIVE_CREDENTIALS = credentials('perfci_google_drive_credentials')
+        GOOGLE_DRIVE_TOKEN = credentials('perfci_google_drive_token')
+        GOOGLE_DRIVE_SHARED_DRIVE_ID = credentials('perfci_google_drive_shared_drive_id')
         RUN_ARTIFACTS_URL = credentials('perfci_run_artifacts_url')
         REDIS = credentials('perfci_redis')
         WORKER_DISK_IDS = credentials('perfci_worker_disk_ids')
@@ -38,7 +42,7 @@ pipeline {
         CONTAINER_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         WORKER_DISK_PREFIX = 'wwn-0x'
         SAVE_ARTIFACTS_LOCAL = 'False'
-        ENABLE_PROMETHEUS_SNAPSHOT = 'True'
+        ENABLE_PROMETHEUS_SNAPSHOT = 'False'
         DELETE_ALL = 'False' // Not delete the running Windows11 VMs
         VERIFICATION_ONLY = 'True'
         RUN_TYPE = 'test_ci'
@@ -167,6 +171,10 @@ END
                                         -e IBM_SECRET_ACCESS_KEY='${IBM_SECRET_ACCESS_KEY}' \
                                         -e IBM_BUCKET='${IBM_BUCKET}' \
                                         -e IBM_KEY='${IBM_KEY}' \
+                                        -e GOOGLE_DRIVE_PATH='${GOOGLE_DRIVE_PATH}' \
+                                        -e GOOGLE_DRIVE_CREDENTIALS='${GOOGLE_DRIVE_CREDENTIALS}' \
+                                        -e GOOGLE_DRIVE_TOKEN='${GOOGLE_DRIVE_TOKEN}' \
+                                        -e GOOGLE_DRIVE_SHARED_DRIVE_ID='${GOOGLE_DRIVE_SHARED_DRIVE_ID}' \
                                         -e RUN_ARTIFACTS_URL='${RUN_ARTIFACTS_URL}' \
                                         -e BUILD_VERSION='${build_version}' \
                                         -e RUN_TYPE='${RUN_TYPE}' \


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. Disable Prometheus during VM verifications - no need to collects prometheus logs during VM verifications.
We already collect each VM Prometheus when creating it.
3. Enable Google drive for storing logs in case of errors

## For security reasons, all pull requests need to be approved first before running any automated CI
