### PR TITLE
Paramiko > 3.4.1 cause to SSH session not active

### DIFF
--- a/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
+++ b/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
@@ -228,7 +228,6 @@ class BareMetalOperations:
         logger.info(f'Starting OCP assisted installer, Start time: {datetime.now().strftime(datetime_format)}')
         # Must add -t otherwise remote ssh of ansible will not end
         self._ssh.run(f"ssh -t provision \"{self._install_ocp_cmd()}\" ")
-        self._wait_for_install_complete()
         logger.info(f'OpenShift cluster {self._get_installation_version()} version is installed successfully, End time: {datetime.now().strftime(datetime_format)}')
 
     @logger_time_stamp

--- a/benchmark_runner/common/clouds/IBM/ibm_operations.py
+++ b/benchmark_runner/common/clouds/IBM/ibm_operations.py
@@ -92,5 +92,4 @@ class IBMOperations(BareMetalOperations):
         logger.info(f'Starting OCP assisted installer, Start time: {datetime.now().strftime(datetime_format)}')
         # Must add -t otherwise remote ssh of ansible will not end
         self._ssh.run(cmd=f"ssh -t provision \"{self.__ibm_login_cmd()};{self._install_ocp_cmd()}\" ")
-        self._wait_for_install_complete()
         logger.info(f'OpenShift cluster {self._get_installation_version()} version is installed successfully, End time: {datetime.now().strftime(datetime_format)}')

--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -4,6 +4,11 @@ from enum import Enum
 from multiprocessing import set_start_method
 import platform
 
+# @todo paramiko==3.4.1/3.5.0 cause to "RunCommandError: Cannot run shell command: SSH session not active"
+import warnings
+from cryptography.utils import CryptographyDeprecationWarning
+warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+
 from benchmark_runner.main.environment_variables import *
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.benchmark_operator.benchmark_operator_workloads import BenchmarkOperatorWorkloads


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->

Paramiko 3.4.0 causes the following warning:
`/root/benchmark-runner/venv/lib/python3.12/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.`

After upgrading to Paramiko 3.4.1/3.5.0, the following error occurs when running a remote shell:
 Got [SSH session not active](https://github.com/redhat-performance/benchmark-runner/actions/runs/11068161437/job/30753164624)

When revert back to paramiko==3.4.0 [all working properly](https://github.com/redhat-performance/benchmark-runner/actions/runs/11072629312/job/30767282287).

Currently, I am using filterwarnings to temporarily suppress the warning and adding a TODO to follow up on the Paramiko fix.

## For security reasons, all pull requests need to be approved first before running any automated CI
