### PR TITLE
Fetch dynamic CNV/ODF versions for must gather

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -1387,7 +1387,9 @@ class OC(SSH):
         :raises: RuntimeError if the command fails.
         """
         if not odf_version:
-            raise ValueError("ODF version must be provided")
+            odf_version = ".".join(self.get_odf_version().split(".")[:2])
+            if not odf_version:
+                raise ValueError("ODF version must be provided")
 
         folder_path = os.path.join(destination_path, f"odf-must-gather-rhel9-v{odf_version}")
 
@@ -1415,7 +1417,9 @@ class OC(SSH):
         :raises: RuntimeError if the command fails.
         """
         if not cnv_version:
-            raise ValueError("CNV version must be provided")
+            cnv_version = ".".join(self.get_cnv_version().split(".")[:2])
+            if not cnv_version:
+                raise ValueError("CNV version must be provided")
 
         folder_path = os.path.join(destination_path, f"cnv-must-gather-rhel9-v{cnv_version}")
 

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -207,8 +207,8 @@ class BootstormVM(WorkloadsOperations):
             if self._wait_for_upgrade_version:
                 logger.info(f'Cluster is upgraded to: {self._wait_for_upgrade_version}')
             if failure:
-                self._oc.generate_cnv_must_gather(destination_path=self._run_artifacts_path, cnv_version=self._cnv_version)
-                self._oc.generate_odf_must_gather(destination_path=self._run_artifacts_path, odf_version=self._odf_version)
+                self._oc.generate_cnv_must_gather(destination_path=self._run_artifacts_path)
+                self._oc.generate_odf_must_gather(destination_path=self._run_artifacts_path)
                 # google drive
                 if self._google_drive_shared_drive_id:
                     self.upload_run_artifacts_to_google_drive()

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -60,8 +60,6 @@ class WorkloadsOperations:
         self._redis = self._environment_variables_dict.get('redis', '')
         self._threads_limit = self._environment_variables_dict.get('threads_limit', '')
         self._kata_thread_pool_size = self._environment_variables_dict.get('kata_thread_pool_size', '')
-        self._cnv_version = self._environment_variables_dict.get('cnv_version', '')
-        self._odf_version = self._environment_variables_dict.get('odf_version', '')
         if self._scale:
             self._scale = int(self._scale)
             self._scale_nodes = self._environment_variables_dict.get('scale_nodes', '')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
An OpenShift cluster upgrade can fail due to fetching dynamic CNV/ODF versions for must-gather

## For security reasons, all pull requests need to be approved first before running any automated CI
