### PR TITLE
WAIT FOR UPGRADE VERSION

### DIFF
--- a/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
@@ -151,8 +151,6 @@ END
                                                             --privileged "${QUAY_BENCHMARK_RUNNER_REPOSITORY}"
 
                                                     """
-                                                   // Set the flag to indicate that upgrade steps are completed
-                                                   currentBuild.description = "UpgradeStageCompleted"
                                                 }
                                             }
                                         }
@@ -172,12 +170,8 @@ END
                     def WINDOWS_URL = ''
                     def SCALE = ''
                     def workload_name = ''
-                    def retryCount = 3 // Number of retries per workload
-                    // while
-                    while (currentBuild.description != "UpgradeStageCompleted") {
                     for (workload in workloads) {
-                        boolean success = false
-                        for (int i = 0; i < retryCount && !success; i++) {
+                            boolean success = false
                             try {
                                 // workload full name
                                 workload_name = workload
@@ -264,14 +258,12 @@ END
                                 } else {
                                     echo "Reached maximum retry attempts for workload ${workload}. Moving to the next workload..."
                                 }
-                            }
                         }
                         if (!success) {
                             echo "Workload ${workload} failed after ${retryCount} retries."
                         }
                         // sleep 10 sec between each VMs validation interation
                         sleep(time: 10, unit: 'SECONDS')
-                    } // while
                  }
                 }
             }


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Currently, the stage 'WORKLOADS Verifications' runs until the stage 'OpenShift Upgrade AND Verifications' is complete. Change it to use WAIT_FOR_UPGRADE_VERSION inside the stage 'WORKLOADS Verifications', so that it runs the Windows verification in a single job loop.

## For security reasons, all pull requests need to be approved first before running any automated CI
