### PR TITLE
Hot Fix: ODF disk count issue

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -411,11 +411,28 @@ class OC(SSH):
 
     def get_odf_disk_count(self):
         """
-        This method returns odf disk count
-        :return:
+        This method returns the ODF disk count.
+        :return: ODF disk count or -1 if the count cannot be retrieved
         """
         if self.is_odf_installed():
-            return int(self.run(f"{self.__cli} get --no-headers pod -n openshift-storage | grep osd | grep -cv prepare"))
+            try:
+                # Run the command to get ODF disk count
+                disk_count_str = self.run(
+                    f"{self.__cli} get --no-headers pod -n openshift-storage | grep osd | grep -cv prepare")
+                disk_count = int(disk_count_str)
+                return disk_count
+            except ValueError as e:
+                # Log the error and return -1 as a fallback
+                logger.error(f"Error converting ODF disk count to integer: {e}")
+                return -1
+            except Exception as e:
+                # Handle any other unexpected errors
+                logger.error(f"Unexpected error while getting ODF disk count: {e}")
+                return -1
+        else:
+            # If ODF is not installed, return -1
+            logger.info("ODF is not installed.")
+            return -1
 
     def is_kata_installed(self):
         """


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix the following error by return -1 in case of error:
```

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/bootstorm_vm.py", line 193, in _verify_single_vm

    self._finalize_vm()

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/bootstorm_vm.py", line 126, in _finalize_vm

    self._upload_to_elasticsearch(index=self._es_index, kind=self._kind, status=self._status,

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/workloads_operations.py", line 431, in _upload_to_elasticsearch

    self._es_operations.upload_to_elasticsearch(index=index, data=self.__get_metadata(kind=kind, status=status, result=result))

                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/workloads_operations.py", line 405, in __get_metadata

    'odf_disk_count': -1 if self._oc.get_odf_disk_count() in {0, 1} else self._oc.get_odf_disk_count()

                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/common/oc/oc.py", line 418, in get_odf_disk_count

    return int(self.run(f"{self.__cli} get --no-headers pod -n openshift-storage | grep osd | grep -cv prepare"))

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

ValueError: invalid literal for int() with base 10: 'E1007 20:20:15.650261  332589 memcache.go:265] couldn\'t get current server API group list: Get "https://api.bm.perfci.com:6443/api?timeout=32s": dial tcp 198.18.10.3:6443: connect: connection refuse

script returned exit code 1

```
## For security reasons, all pull requests need to be approved first before running any automated CI
