### PR TITLE
Hot fix: CNV version

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -161,7 +161,7 @@ class OC(SSH):
         This method returns cnv version
         :return:
         """
-        return self.run(f"{self.__cli} get csv -n openshift-cnv $({self.__cli} get csv -n openshift-cnv --no-headers | awk '{{ print $1; }}') -o jsonpath='{{.spec.version}}'")
+        return self.run(f"{self.__cli} get csv -n openshift-cnv -o json | jq -r '.items[] | select(.metadata.name | startswith(\"kubevirt-hyperconverged-operator\")) | .spec.version'")
 
     def get_odf_version(self):
         """


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Return None version when there are several versions:
```
# oc get csv -n openshift-cnv
NAME                                       DISPLAY                          VERSION   REPLACES                                   PHASE
kubevirt-hyperconverged-operator.v4.14.8   OpenShift Virtualization         4.14.8    kubevirt-hyperconverged-operator.v4.14.7   Succeeded
node-healthcheck-operator.v0.8.2           Node Health Check Operator       0.8.2     node-healthcheck-operator.v0.8.1           Succeeded
self-node-remediation.v0.9.0               Self Node Remediation Operator   0.9.0     self-node-remediation.v0.8.0               Succeeded
```
Solved it by searching hyperconverged-operator and there return the cnv version

## For security reasons, all pull requests need to be approved first before running any automated CI
