### PR TITLE
Wait until the nodes are ready

### DIFF
--- a/benchmark_runner/common/oc/oc_exceptions.py
+++ b/benchmark_runner/common/oc/oc_exceptions.py
@@ -167,7 +167,7 @@ class ODFHealthCheckTimeout(OCError):
 
 
 class NodeNotReady(OCError):
-    """This exception returns node not ready timeout error"""
-    def __init__(self, node_name, node_status):
-        self.message = f"Node {node_name} is not ready. Current status: {node_status}"
+    """This exception indicates a node not ready due to a timeout error"""
+    def __init__(self, nodes_status: dict):
+        self.message = f"Node not ready: {nodes_status}"
         super(NodeNotReady, self).__init__(self.message)

--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -175,7 +175,7 @@ def upgrade_ocp_bare_metal(step: str):
     elif step == 'verify_bare_metal_upgrade_complete':
         if bare_metal_operations.is_cluster_upgraded(oc, cnv_version=cnv_version, odf_version=odf_version, lso_version=lso_version):
             bare_metal_operations.verify_cluster_is_up(oc)
-            oc.verify_nodes_ready()
+            oc.wait_for_node_ready()
         else:
             error_message = f'OCP {upgrade_ocp_version} upgrade failed'
             logger.error(error_message)
@@ -200,7 +200,7 @@ def install_resources():
     logger.info(f'Start Bare-Metal OpenShift resources installation')
     oc = bare_metal_operations.oc_login()
     bare_metal_operations.verify_cluster_is_up(oc)
-    oc.verify_nodes_ready()
+    oc.wait_for_node_ready()
     bare_metal_operations.install_ocp_resources(resources=resources)
     bare_metal_operations.disconnect_from_provisioner()
     logger.info(f'End Bare-Metal OpenShift resources installation')

--- a/tests/integration/benchmark_runner/common/oc/test_oc.py
+++ b/tests/integration/benchmark_runner/common/oc/test_oc.py
@@ -234,11 +234,11 @@ def test_collect_prometheus():
         assert tarfile.is_tarfile(tarball)
 
 
-def test_verify_nodes_ready():
+def test_wait_for_nodes_ready():
     """
-    This method test nodes are ready
+    This method waits till nodes are ready
     @return:
     """
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.login()
-    assert oc.verify_nodes_ready()
+    assert oc.wait_for_node_ready()

--- a/tests/unittest/benchmark_runner/common/oc/test_oc.py
+++ b/tests/unittest/benchmark_runner/common/oc/test_oc.py
@@ -1,6 +1,8 @@
 
 import mock
 import pytest
+from unittest.mock import patch
+
 from benchmark_runner.common.oc.oc import OC
 from benchmark_runner.common.oc.oc_exceptions import YAMLNotExist, LoginFailed, NodeNotReady
 
@@ -49,15 +51,33 @@ def test_short_uuid():
         assert oc._OC__get_short_uuid(workload='stressng_pod') == 'bb2be20e'
 
 
-def test_check_node_status_ready():
+def test_check_all_nodes_status_ready():
     oc = OC()
-    result = oc.check_node_status(nodes_list=['node-0 Ready', 'node-1 Ready', 'node-2 Ready'])
-    assert result
+    with patch.object(OC, 'get_node_status', return_value=['node-0 Ready', 'node-1 Ready', 'node-2 Ready']):
+        result = oc.wait_for_node_ready()
+        assert result
 
 
-def test_check_node_status_not_ready():
+def test_check_all_nodes_status_not_ready():
     oc = OC()
     with pytest.raises(NodeNotReady) as exc_info:
-        oc.check_node_status(nodes_list=['node-0 Ready', 'node-1 NotReady', 'node-2 Ready'])
+        with patch.object(OC, 'get_node_status', return_value=['node-0 NotReady', 'node-1 NotReady', 'node-2 Ready']):
+            oc.wait_for_node_ready(wait_time=3, timeout=10)
     # Check that the exception message is as expected
-    assert str(exc_info.value) == "Node node-1 is not ready. Current status: NotReady"
+    assert str(exc_info.value) == "Node not ready: {'node-0': 'NotReady', 'node-1': 'NotReady'}"
+
+
+def test_check_not_ready_node_status_not_ready():
+    oc = OC()
+    with pytest.raises(NodeNotReady) as exc_info:
+        with patch.object(OC, 'get_node_status', return_value=['node-0 NotReady', 'node-1 NotReady', 'node-2 Ready']):
+            oc.wait_for_node_ready(node='node-1', wait_time=3, timeout=10)
+    # Check that the exception message is as expected
+    assert str(exc_info.value) == "Node not ready: {'node-1': 'NotReady'}"
+
+
+def test_check_ready_node_status_not_ready():
+    oc = OC()
+    with patch.object(OC, 'get_node_status', return_value=['node-0 NotReady', 'node-1 NotReady', 'node-2 Ready']):
+        result = oc.wait_for_node_ready(node='node-2', wait_time=3, timeout=10)
+        assert result


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Currently, there is only node verification without waiting for it to reach the ready status. 
Adding a wait for the node to be ready until timeout.
## For security reasons, all pull requests need to be approved first before running any automated CI
