### PR TITLE
VM run_strategy support

### DIFF
--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
@@ -12,7 +12,11 @@ metadata:
   {%- endif %}
   namespace: {{ namespace }}
 spec:
+  {% if run_strategy -%}
+  runStrategy: Always
+  {%- else -%}
   running: false
+  {%- endif %}
   template:
     metadata:
       labels:

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -86,6 +86,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['windows_url'] = EnvironmentVariables.get_env('WINDOWS_URL', '')
         # Delete all resources before and after the run, default True
         self._environment_variables_dict['delete_all'] = EnvironmentVariables.get_boolean_from_environment('DELETE_ALL', True)
+        # Run RunStrategy: Always can be set to True or False (default: False). Set it to True for VMs that need to start in a running state
+        self._environment_variables_dict['run_strategy'] = EnvironmentVariables.get_boolean_from_environment('RUN_STRATEGY', False)
         # Verification only, without running or deleting any resources, default False
         self._environment_variables_dict['verification_only'] = EnvironmentVariables.get_boolean_from_environment('VERIFICATION_ONLY', False)
         # Verification while upgrade, e.g. 4.15.23

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -101,7 +101,9 @@ class BootstormVM(WorkloadsOperations):
         """
         try:
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self._name}_{vm_num}.yaml'))
-            self._oc.wait_for_vm_status(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}', status=VMStatus.Stopped)
+            # run_strategy run immediately the vm
+            if not self._run_strategy:
+                self._oc.wait_for_vm_status(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}', status=VMStatus.Stopped)
         except Exception as err:
             # save run artifacts logs
             self.save_error_logs()
@@ -260,7 +262,9 @@ class BootstormVM(WorkloadsOperations):
         try:
             vm_name = f'{self._workload_name}-{self._trunc_uuid}-{vm_num}'
             self._set_bootstorm_vm_start_time(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}')
-            self._virtctl.start_vm_async(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}')
+            # run_strategy run immediately the vm
+            if not self._run_strategy:
+                self._virtctl.start_vm_async(vm_name=f'{self._workload_name}-{self._trunc_uuid}-{vm_num}')
             self._virtctl.wait_for_vm_status(vm_name=vm_name, status=VMStatus.Running)
             vm_node = self._wait_ssh_vm(vm_name)
             self._data_dict = self._get_bootstorm_vm_elapsed_time(vm_name=vm_name, vm_node=vm_node)

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -119,6 +119,7 @@ class WorkloadsOperations:
                                                                  google_drive_token=self._google_drive_token,
                                                                  google_drive_shared_drive_id=self._google_drive_shared_drive_id)
         self._upgrade_ocp_version = self._environment_variables_dict.get('upgrade_ocp_version', '')
+        self._run_strategy = self._environment_variables_dict.get('run_strategy', '')
 
     def _get_workload_file_name(self, workload):
         """

--- a/jenkins/PerfCI_Chaos/03_PerfCI_Choas_Windows_VMs_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/03_PerfCI_Choas_Windows_VMs_Deployment/Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
         SAVE_ARTIFACTS_LOCAL = 'False'
         ENABLE_PROMETHEUS_SNAPSHOT = 'True'
         DELETE_ALL = 'False' // Not delete the running Windows11 VMs
+        RUN_STRATEGY = 'True' // runStrategy: Always for NHC/ SNR operators
         RUN_TYPE = 'perf_ci'
         PROVISION_PORT = 22
         NUM_ODF_DISK = 6
@@ -212,6 +213,7 @@ END
                                         -e THREADS_LIMIT='${THREADS_LIMIT}' \
                                         -e WINDOWS_URL='${WINDOWS_URL}'  \
                                         -e DELETE_ALL=${DELETE_ALL} \
+                                        -e RUN_STRATEGY=${RUN_STRATEGY} \
                                         -e LSO_NODE='${LSO_NODE}'  \
                                         -e TIMEOUT='${TIMEOUT}' \
                                         -e log_level='INFO' \


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Add VM Run Strategy Support:
1. NodeHealthCheck (NHC Operator): Deploy node health checks using the Node Health Check Operator. This requires a run_strategy set to always, which is essential for the OCP upgrade process.

3. Fast VM Loading: Accelerate VM loading without transitioning through all the states (e.g., create -> stop -> start). Start VMs immediately to reduce loading time from 30 minutes to **10 minutes for 150 VMs**.

## For security reasons, all pull requests need to be approved first before running any automated CI
