### PR TITLE
Node-Health-Check and Self-Node-Remediation operators deployment

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_nhc_snr.py
+++ b/benchmark_runner/common/ocp_resources/create_nhc_snr.py
@@ -1,0 +1,43 @@
+
+import os
+
+from benchmark_runner.common.oc.oc import OC
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.ocp_resources.create_ocp_resource_operations import CreateOCPResourceOperations
+
+
+class CreateNHCSNR(CreateOCPResourceOperations):
+    """
+    This class is created node-health-check and self-node-remediation operators
+    """
+    def __init__(self, oc: OC, path: str, resource_list: list):
+        super().__init__(oc)
+        self.__oc = oc
+        self.__path = path
+        self.__resource_list = resource_list
+
+    @logger_time_stamp
+    def create_nhc_snr(self):
+        """
+        This method creates node-health-check and self-node-remediation operators
+        :return:
+        """
+        for resource in self.__resource_list:
+            logger.info(f'run {resource}')
+            self.__oc.create_async(yaml=os.path.join(self.__path, resource))
+
+            if '03_subscription.yaml' in resource:
+                # verify once after create all resource files
+                self.wait_for_ocp_resource_create(operator='nhc',
+                                                  verify_cmd="oc get csv -n openshift-workload-availability -o jsonpath='{.items[0].status.phase}'",
+                                                  status='Succeeded')
+                self.wait_for_ocp_resource_create(operator='snr',
+                                                  verify_cmd="oc get csv -n openshift-workload-availability -o jsonpath='{.items[1].status.phase}'",
+                                                  status='Succeeded')
+            # SNR is automatically enabled when NHC is enabled
+            if '04_nhc_snr.yaml' in resource:
+                # Verify NHC is enabled
+                self.wait_for_ocp_resource_create(operator='nhc',
+                                                  verify_cmd="oc get nhc -A -o jsonpath='{range .items[*]}{.status.phase}{\"\\n\"}{end}'",
+                                                  status='Enabled')
+        return True

--- a/benchmark_runner/common/ocp_resources/create_ocp_resource.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource.py
@@ -8,6 +8,7 @@ from benchmark_runner.common.ocp_resources.create_lso import CreateLSO
 from benchmark_runner.common.ocp_resources.create_odf import CreateODF
 from benchmark_runner.common.ocp_resources.create_kata import CreateKata
 from benchmark_runner.common.ocp_resources.create_cnv import CreateCNV
+from benchmark_runner.common.ocp_resources.create_nhc_snr import CreateNHCSNR
 from benchmark_runner.common.ocp_resources.create_custom import CreateCustom
 from benchmark_runner.common.ocp_resources.migrate_infra import MigrateInfra
 
@@ -91,6 +92,9 @@ class CreateOCPResource:
         elif 'cnv' == resource:
             create_cnv = CreateCNV(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files)
             create_cnv.create_cnv()
+        elif 'nhc_snr' == resource:
+            create_nhc_snr = CreateNHCSNR(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files)
+            create_nhc_snr.create_nhc_snr()
         elif 'infra' == resource:
             create_infra = MigrateInfra(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files)
             create_infra.migrate_infra()

--- a/benchmark_runner/common/ocp_resources/nhc_snr/template/01_namespace_template.yaml
+++ b/benchmark_runner/common/ocp_resources/nhc_snr/template/01_namespace_template.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-workload-availability

--- a/benchmark_runner/common/ocp_resources/nhc_snr/template/02_operator_group_template.yaml
+++ b/benchmark_runner/common/ocp_resources/nhc_snr/template/02_operator_group_template.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: workload-availability-operator-group
+  namespace: openshift-workload-availability

--- a/benchmark_runner/common/ocp_resources/nhc_snr/template/03_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/nhc_snr/template/03_subscription_template.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: node-health-check-operator
+  namespace: openshift-workload-availability
+spec:
+  channel: stable
+  name: node-healthcheck-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  package: node-healthcheck-operator

--- a/benchmark_runner/common/ocp_resources/nhc_snr/template/04_nhc_snr_template.yaml
+++ b/benchmark_runner/common/ocp_resources/nhc_snr/template/04_nhc_snr_template.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: remediation.medik8s.io/v1alpha1
+kind: NodeHealthCheck
+metadata:
+  name: chaos-nodehealthcheck
+spec:
+  minHealthy: 1
+  remediationTemplate:
+    apiVersion: self-node-remediation.medik8s.io/v1alpha1
+    name: self-node-remediation-automatic-strategy-template
+    namespace: openshift-workload-availability
+    kind: SelfNodeRemediationTemplate
+  selector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/worker
+        operator: Exists
+  unhealthyConditions:
+    - type: Ready
+      status: "False"
+      duration: 20s
+    - type: Ready
+      status: Unknown
+      duration: 20s
+
+---
+apiVersion: v1
+items:
+  - apiVersion: self-node-remediation.medik8s.io/v1alpha1
+    kind: SelfNodeRemediationTemplate
+    metadata:
+      annotations:
+        remediation.medik8s.io/multiple-templates-support: "true"
+      name: self-node-remediation-automatic-strategy-template
+      namespace: openshift-workload-availability
+    spec:
+      template:
+        spec:
+          remediationStrategy: OutOfServiceTaint
+kind: List
+metadata:
+  resourceVersion: ""

--- a/jenkins/PerfCI_Chaos/02_PerfCI_Chaos_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/02_PerfCI_Chaos_Operators_Deployment/Jenkinsfile
@@ -84,7 +84,7 @@ END
         steps {
             script {
                 // cnv first for “-virtualization” storage class name for Win bootstorm
-                def resources = ['cnv', 'lso', 'odf', 'infra', 'custom']
+                def resources = ['cnv', 'lso', 'odf', 'nhc_snr', 'infra', 'custom']
 
                 for (resource in resources) {
                     echo "Run Operator Deployment for ${resource}"


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [X] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Deployment of Node Health Check and Self Node Remediation Operators.
These operators are intended to assist in tracking VM migration during OCP upgrades and chaos testing

## For security reasons, all pull requests need to be approved first before running any automated CI
