### PR TITLE
Fix ODF HealthCheck

### DIFF
--- a/benchmark_runner/common/oc/oc_exceptions.py
+++ b/benchmark_runner/common/oc/oc_exceptions.py
@@ -161,8 +161,8 @@ class OperatorUpgradeTimeout(OCError):
 
 class ODFHealthCheckTimeout(OCError):
     """This exception return odf healthcheck timeout error"""
-    def __init__(self):
-        self.message = f"ODF health check timeout"
+    def __init__(self, message: str):
+        self.message = message
         super(ODFHealthCheckTimeout, self).__init__(self.message)
 
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Moving the health check inside the while loop should solve the issue of skipping the initial wait for the first check.

## For security reasons, all pull requests need to be approved first before running any automated CI
