### PR TITLE
Update fedora 37 instead of 34

### DIFF
--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
@@ -53,7 +53,7 @@ spec:
        sockets: {{ sockets }}
        cores: {{ cores }}
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: {{ limits_memory }}
        requests:
@@ -71,7 +71,7 @@ spec:
        sockets: {{ sockets }}
        cores: {{ cores }}
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: {{ limits_memory }}
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -45,7 +45,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:
@@ -63,7 +63,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -45,7 +45,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:
@@ -63,7 +63,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -49,7 +49,7 @@ spec:
        sockets: 8
        cores: 1
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 8Gi
        requests:
@@ -67,7 +67,7 @@ spec:
        sockets: 8
        cores: 1
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 8Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -49,7 +49,7 @@ spec:
        sockets: 8
        cores: 1
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 8Gi
        requests:
@@ -67,7 +67,7 @@ spec:
        sockets: 8
        cores: 1
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 8Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -45,7 +45,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:
@@ -63,7 +63,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -45,7 +45,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:
@@ -63,7 +63,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -45,7 +45,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:
@@ -63,7 +63,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -45,7 +45,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:
@@ -63,7 +63,7 @@ spec:
        sockets: 1
        cores: 2
        threads: 1
-       image: quay.io/kubevirt/fedora-container-disk-images:34
+       image: quay.io/ebattat/fedora37-container-disk:latest
        limits:
          memory: 1Gi
        requests:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Update Fedora 37 instead of 34 for virtio-net performance improvement

## For security reasons, all pull requests need to be approved first before running any automated CI
