### PR TITLE
Hot Fix: Update LSO operator installation

### DIFF
--- a/benchmark_runner/common/ocp_resources/lso/template/03_catalogsource_template.yaml
+++ b/benchmark_runner/common/ocp_resources/lso/template/03_catalogsource_template.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: redhat-operators-v{{ lso_version | replace('.', '') }}
+  namespace: openshift-marketplace
+spec:
+  displayName: Red Hat Operators v{{ lso_version | replace('.', '') }}
+  image: registry.redhat.io/redhat/redhat-operator-index:v{{ lso_version }}
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m0s

--- a/benchmark_runner/common/ocp_resources/lso/template/04_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/lso/template/04_subscription_template.yaml
@@ -7,5 +7,6 @@ spec:
   channel: "stable"
   installPlanApproval: Automatic
   name: local-storage-operator
-  source: redhat-operators
+  source: redhat-operators-v{{ lso_version | replace('.', '') }}   # <-- Modify the name of the redhat-operators catalogsource if not default
   sourceNamespace: openshift-marketplace
+


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
It seems that the official LSO version does not work with the OCP release candidate version.
Update LSO operator installation for using CatalogSource 
## For security reasons, all pull requests need to be approved first before running any automated CI
