### PR TITLE
Hot fix: Remove grafana from configmap

### DIFF
--- a/benchmark_runner/common/ocp_resources/infra/template/01_cluster-monitoring-configmap-template.yaml
+++ b/benchmark_runner/common/ocp_resources/infra/template/01_cluster-monitoring-configmap-template.yaml
@@ -26,13 +26,6 @@ data:
         effect: "NoSchedule"
       nodeSelector:
         node-role.kubernetes.io/infra: ""
-    grafana:
-      tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
     k8sPrometheusAdapter:
       tolerations:
       - key: "node-role.kubernetes.io/master"


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Remove Grafana from the ConfigMap, as it no longer exists in the latest OCP.
This fixes the following error:
`configuration in the "openshift-monitoring/cluster-monitoring-config" ConfigMap is invalid and should be fixed: error unmarshaling JSON: while decoding JSON: json: unknown field "grafana"`

## For security reasons, all pull requests need to be approved first before running any automated CI
