### PR TITLE
Hot fix: fix login issue while upgrade

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -33,7 +33,6 @@ class OC(SSH):
 
     def __init__(self, kubeadmin_password: str = ''):
         super().__init__()
-        self.__kubeadmin_password = kubeadmin_password
         self.__environment_variables_dict = environment_variables.environment_variables_dict
         self._run_artifacts = self.__environment_variables_dict.get('run_artifacts_path', '')
         self.__elasticsearch_url = self.__environment_variables_dict.get('elasticsearch_url', '')
@@ -43,6 +42,10 @@ class OC(SSH):
         self.__worker_disk_ids = self.__environment_variables_dict.get('worker_disk_ids', '')
         if self.__worker_disk_ids:
             self.__worker_disk_ids = ast.literal_eval(self.__worker_disk_ids)
+        if kubeadmin_password:
+            self.__kubeadmin_password = kubeadmin_password
+        else:
+            self.__kubeadmin_password = self.__environment_variables_dict.get('kubeadmin_password', '')
 
     def get_ocp_server_version(self):
         """

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -217,6 +217,7 @@ class BootstormVM(WorkloadsOperations):
             failure_vms = []  # List to store failed VM names
 
             if self._wait_for_upgrade_version:
+                logger.info(f"wait for ocp upgrade version: {self._wait_for_upgrade_version}")
                 upgrade_done = self._oc.get_cluster_status() == f'Cluster version is {self._wait_for_upgrade_version}'
                 current_wait_time = 0
 

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -391,6 +391,7 @@ class WorkloadsOperations:
         :return:
         """
         date_format = '%Y_%m_%d'
+        self._oc.login()
         metadata = {'ocp_version': self._oc.get_ocp_server_version(),
                     'previous_ocp_version': self._oc.get_previous_ocp_version() if self._upgrade_ocp_version else '',
                     'cnv_version': self._oc.get_cnv_version(),

--- a/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
@@ -169,7 +169,7 @@ END
                                                             -e PROVISION_IP="${PROVISION_IP}" \
                                                             -e PROVISION_USER="${PROVISION_USER}" \
                                                             -e PROVISION_PORT="${PROVISION_PORT}" \
-                                                            -e KUBEADMIN_PASSWORD_PATH="${KUBEADMIN_PASSWORD_PATH}" \
+                                                            -e KUBEADMIN_PASSWORD="${KUBEADMIN_PASSWORD}" \
                                                             -e KUBECONFIG_PATH="${KUBECONFIG_PATH}" \
                                                             -e PROVISION_INSTALLER_PATH="${PROVISION_INSTALLER_PATH}" \
                                                             -e PROVISION_INSTALLER_CMD="${PROVISION_INSTALLER_CMD}" \


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix login issue during upgrade, should fix the following error that happened because missing oc login:
```
File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/windows_vm.py", line 52, in run

    self._upload_to_elasticsearch(index=self._es_index, kind=self._kind, status='failed', result=self._data_dict)

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/workloads_operations.py", line 434, in _upload_to_elasticsearch

    self._es_operations.upload_to_elasticsearch(index=index, data=self.__get_metadata(kind=kind, status=status, result=result))

                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/workloads/workloads_operations.py", line 399, in __get_metadata

    'odf_version': self._oc.get_odf_version(),

                   ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/common/oc/oc.py", line 173, in get_odf_version

    if self.get_ocp_major_version() <= 4 and self.get_ocp_minor_version() <= 16:

       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/common/oc/oc.py", line 685, in get_ocp_major_version

    return int(self.get_ocp_server_version().split('.')[0])

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

ValueError: invalid literal for int() with base 10: 'E0205 14:01:41'
```

## For security reasons, all pull requests need to be approved first before running any automated CI
