### PR TITLE
Hotfix: remove readonly and use root

### DIFF
--- a/jenkins/PerfCI/01_PerfCI_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/01_PerfCI_OpenShift_Deployment/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
         PROVISION_PORT = 22
         KUBEADMIN_PASSWORD_PATH = '/root/.kube/kubeadmin-password'
         KUBECONFIG_PATH = '/root/.kube/config'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         PROVISION_INSTALLER_PATH = '/root/jetlag/./run_jetlag.sh'
         PROVISION_INSTALLER_CMD = 'pushd /root/jetlag;/root/jetlag/./run_jetlag.sh 1>/dev/null 2>&1;popd'
         PROVISION_INSTALLER_LOG = 'tail -100 /root/jetlag/jetlag.log'
@@ -145,7 +144,7 @@ END
                                                         -e CONTAINER_PRIVATE_KEY_PATH="${CONTAINER_PRIVATE_KEY_PATH}" \
                                                         -e PROVISION_TIMEOUT="${PROVISION_TIMEOUT}" \
                                                         -e log_level="INFO" -v "${PRIVATE_KEY_PATH}":"${CONTAINER_PRIVATE_KEY_PATH}" \
-                                                        -v "${LOCAL_KUBECONFIG_PATH}":"${KUBECONFIG_PATH}:ro" \
+                                                        -v "${KUBECONFIG_PATH}":"${KUBECONFIG_PATH}" \
                                                         --privileged "${QUAY_BENCHMARK_RUNNER_REPOSITORY}"
                                                 """
                                             }

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
         KUBEADMIN_PASSWORD = readFile('/home/jenkins/.kube/kubeadmin-password').trim()
         KUBEADMIN_PASSWORD_PATH = '/home/jenkins/.kube/kubeadmin-password'
         KUBECONFIG_PATH = '/root/.kube/config'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         PRIVATE_KEY_PATH = '/home/jenkins/.ssh/provision_private_key'
         CONFIG_PATH = '/home/jenkins/.ssh/config'
         WORKSPACE = '/home/jenkins'
@@ -138,7 +137,7 @@ END
                                                             -e PROVISION_TIMEOUT='${PROVISION_TIMEOUT}' \
                                                             -e log_level='INFO' \
                                                             -v '${PRIVATE_KEY_PATH}:${CONTAINER_PRIVATE_KEY_PATH}' \
-                                                            -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                                            -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                                             --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}'
                                                     """
                                                 }

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -34,7 +34,6 @@ pipeline {
         CONFIG_PATH = '/home/jenkins/.ssh/config'
         WORKSPACE='/home/jenkins'
         CONTAINER_PRIVATE_KEY_PATH = '/root/.ssh/provision_private_key'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         WORKER_DISK_PREFIX = 'wwn-0x'
         ENABLE_PROMETHEUS_SNAPSHOT = 'True'
         SAVE_ARTIFACTS_LOCAL = 'False'
@@ -129,7 +128,7 @@ END
                                     // bootstorm_vm_scale: no need redis for synchronization but need SCALE and THREADS_LIMIT
                                     if (workload == "bootstorm_vm_scale") {
                                         // Warm-up: Pull the Fedora image from quay.io for each node
-                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                                         SCALE = BOOTSTORM_SCALE
                                     }
 
@@ -151,7 +150,7 @@ END
                                                 error "Unknown Windows scale workload ${workload}"
                                         }
 
-                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e WINDOWS_URL='${WINDOWS_URL}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e WINDOWS_URL='${WINDOWS_URL}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                                         SCALE = WINDOWS_SCALE
                                     }
                                   workload = WORKLOAD
@@ -192,7 +191,7 @@ END
                                         -e LSO_NODE='${LSO_NODE}'  \
                                         -e TIMEOUT='${TIMEOUT}' \
                                         -e log_level='INFO' \
-                                        -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                        -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                         --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}'
                                     """
                                     success = true
@@ -225,7 +224,7 @@ END
         }
         failure {
             script {
-                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS=''failed'' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS=''failed'' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                 msg = "Build error for ${env.JOB_NAME} ${env.BUILD_NUMBER} (${env.BUILD_URL})"
                 emailext body: """\
                     Jenkins job: ${env.BUILD_URL}\nSee the console output for more details:  ${env.BUILD_URL}consoleFull\n\n
@@ -234,7 +233,7 @@ END
         }
         success {
             script {
-                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS='pass' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS='pass' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                 echo '04-PerfCI-Grafana-Deployment pipeline'
                 build job: '04-PerfCI-Grafana-Deployment', wait: false
             }

--- a/jenkins/PerfCI_Chaos/01_PerfCI_Chaos_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/01_PerfCI_Chaos_OpenShift_Deployment/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
         PROVISION_PORT = 22
         KUBEADMIN_PASSWORD_PATH = '/root/.kube/kubeadmin-password'
         KUBECONFIG_PATH = '/root/.kube/config'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         PROVISION_INSTALLER_PATH = '/root/jetlag/./run_jetlag.sh'
         PROVISION_INSTALLER_CMD = 'pushd /root/jetlag;/root/jetlag/./run_jetlag.sh 1>/dev/null 2>&1;popd'
         PROVISION_INSTALLER_LOG = 'tail -100 /root/jetlag/jetlag.log'
@@ -148,7 +147,7 @@ END
                                                         -e CONTAINER_PRIVATE_KEY_PATH="${CONTAINER_PRIVATE_KEY_PATH}" \
                                                         -e PROVISION_TIMEOUT="${PROVISION_TIMEOUT}" \
                                                         -e log_level="INFO" -v "${PRIVATE_KEY_PATH}":"${CONTAINER_PRIVATE_KEY_PATH}" \
-                                                        -v "${LOCAL_KUBECONFIG_PATH}":"${KUBECONFIG_PATH}:ro" \
+                                                        -v "${KUBECONFIG_PATH}":"${KUBECONFIG_PATH}" \
                                                         --privileged "${QUAY_BENCHMARK_RUNNER_REPOSITORY}"
                                                 """
                                             }

--- a/jenkins/PerfCI_Chaos/02_PerfCI_Chaos_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/02_PerfCI_Chaos_Operators_Deployment/Jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
         KUBEADMIN_PASSWORD = readFile('/home/jenkins/.kube/kubeadmin-password').trim()
         KUBEADMIN_PASSWORD_PATH = '/home/jenkins/.kube/kubeadmin-password'
         KUBECONFIG_PATH = '/root/.kube/config'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         PRIVATE_KEY_PATH = '/home/jenkins/.ssh/provision_private_key'
         CONFIG_PATH = '/home/jenkins/.ssh/config'
         WORKSPACE = '/home/jenkins'
@@ -122,7 +121,7 @@ END
                                                             -e PROVISION_TIMEOUT='${PROVISION_TIMEOUT}' \
                                                             -e log_level='INFO' \
                                                             -v '${PRIVATE_KEY_PATH}:${CONTAINER_PRIVATE_KEY_PATH}' \
-                                                            -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                                            -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                                             --privileged ${QUAY_BENCHMARK_RUNNER_REPOSITORY}
                                                     """
                                                 }

--- a/jenkins/PerfCI_Chaos/03_PerfCI_Choas_Windows_VMs_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/03_PerfCI_Choas_Windows_VMs_Deployment/Jenkinsfile
@@ -41,7 +41,6 @@ pipeline {
         CONFIG_PATH = '/home/jenkins/.ssh/config'
         WORKSPACE='/home/jenkins'
         CONTAINER_PRIVATE_KEY_PATH = '/root/.ssh/provision_private_key'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         WORKER_DISK_PREFIX = 'wwn-0x'
         SAVE_ARTIFACTS_LOCAL = 'False'
         ENABLE_PROMETHEUS_SNAPSHOT = 'True'
@@ -163,7 +162,7 @@ END
                                     // bootstorm_vm_scale: no need redis for synchronization but need SCALE and THREADS_LIMIT
                                     if (workload == "bootstorm_vm_scale") {
                                         // Warm-up: Pull the Fedora image from quay.io for each node
-                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                                         SCALE = BOOTSTORM_SCALE
                                     }
 
@@ -196,7 +195,7 @@ END
                                             -e WINDOWS_URL='${WINDOWS_URL}' \
                                             -e TIMEOUT='${TIMEOUT}' \
                                             -e log_level='INFO' \
-                                            -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                            -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                             --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}'
                                         """
                                         SCALE = WINDOWS_SCALE
@@ -246,7 +245,7 @@ END
                                         -e LSO_NODE='${LSO_NODE}'  \
                                         -e TIMEOUT='${TIMEOUT}' \
                                         -e log_level='INFO' \
-                                        -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                        -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                         -v '${TEMP_DIR}:${GOOGLE_DESTINATION_PATH}' \
                                         --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}'
                                     """
@@ -289,7 +288,7 @@ END
         }
         failure {
             script {
-                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS=''failed'' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS=''failed'' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                 msg = "Build error for ${env.JOB_NAME} ${env.BUILD_NUMBER} (${env.BUILD_URL})"
                 emailext body: """\
                     Jenkins job: ${env.BUILD_URL}\nSee the console output for more details:  ${env.BUILD_URL}consoleFull\n\n

--- a/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/04_PerfCI_Chaos_Upgrade_OpenShift_Deployment/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
         WORKSPACE = '/home/jenkins'
         KUBEADMIN_PASSWORD_PATH = '/home/jenkins/.kube/kubeadmin-password'
         KUBECONFIG_PATH = '/root/.kube/config'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         PRIVATE_KEY_PATH = '/home/jenkins/.ssh/provision_private_key'
         CONFIG_PATH = '/home/jenkins/.ssh/config'
         CONTAINER_CONFIG_PATH = '/root/.ssh/config'
@@ -160,7 +159,7 @@ END
                                                             -e KUBEADMIN_PASSWORD="${KUBEADMIN_PASSWORD}" \
                                                             -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' \
                                                             -e TIMEOUT="${TIMEOUT}" \
-                                                            -v "${LOCAL_KUBECONFIG_PATH}":"${KUBECONFIG_PATH}:ro" \
+                                                            -v "${KUBECONFIG_PATH}":"${KUBECONFIG_PATH}" \
                                                             --privileged "${QUAY_BENCHMARK_RUNNER_REPOSITORY}"
 
                                                     """
@@ -258,7 +257,7 @@ END
                                         -e LSO_NODE='${LSO_NODE}'  \
                                         -e TIMEOUT='${TIMEOUT}' \
                                         -e log_level='INFO' \
-                                        -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                        -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                         -v '${TEMP_DIR}:${GOOGLE_DESTINATION_PATH}' \
                                         --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}'
                                     """

--- a/jenkins/PerfCI_Chaos/05_PerfCI_Chaos_Verify_Windows_VMs_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI_Chaos/05_PerfCI_Chaos_Verify_Windows_VMs_Deployment/Jenkinsfile
@@ -42,7 +42,6 @@ pipeline {
         WORKSPACE='/home/jenkins'
         CONTAINER_PRIVATE_KEY_PATH = '/root/.ssh/provision_private_key'
         CONTAINER_CONFIG_PATH = '/root/.ssh/config'
-        LOCAL_KUBECONFIG_PATH = '/home/jenkins/.kube/config'
         WORKER_DISK_PREFIX = 'wwn-0x'
         SAVE_ARTIFACTS_LOCAL = 'False'
         ENABLE_PROMETHEUS_SNAPSHOT = 'False'
@@ -221,7 +220,7 @@ END
                                         -e LSO_NODE='${LSO_NODE}'  \
                                         -e TIMEOUT='${TIMEOUT}' \
                                         -e log_level='INFO' \
-                                        -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' \
+                                        -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' \
                                         -v '${TEMP_DIR}:${GOOGLE_DESTINATION_PATH}' \
                                         --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}'
                                     """
@@ -264,7 +263,7 @@ END
         }
         failure {
             script {
-                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS=''failed'' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${LOCAL_KUBECONFIG_PATH}:${KUBECONFIG_PATH}:ro' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                sh """ sudo podman run --rm -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e KUBECONFIG_PATH='${KUBECONFIG_PATH}' -e ELASTICSEARCH='${ELASTICSEARCH}' -e ELASTICSEARCH_PORT='${ELASTICSEARCH_PORT}' -e CI_STATUS=''failed'' -e RUN_TYPE='${RUN_TYPE}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                 msg = "Build error for ${env.JOB_NAME} ${env.BUILD_NUMBER} (${env.BUILD_URL})"
                 emailext body: """\
                     Jenkins job: ${env.BUILD_URL}\nSee the console output for more details:  ${env.BUILD_URL}consoleFull\n\n


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Remove the read-only config file and use the root config instead of the Jenkins config, as the script runs with sudo.
read-only cause to the following error: 
`subprocess Status : FAIL: 1 b'Login successful.\n\nYou have access to 71 projects, the list has been suppressed. You can list all projects with \'oc projects\'\n\nUsing project "default".\nerror: open /****/.kube/config: read-only file system\n'`

## For security reasons, all pull requests need to be approved first before running any automated CI
