### PR TITLE
Hotfix: Add login retry mechanism

### DIFF
--- a/benchmark_runner/common/oc/oc_exceptions.py
+++ b/benchmark_runner/common/oc/oc_exceptions.py
@@ -7,8 +7,8 @@ class OCError(Exception):
 
 class LoginFailed(OCError):
     """This exception return login failed error"""
-    def __init__(self):
-        self.message = f'Login error, check credentials'
+    def __init__(self, msg):
+        self.message = msg
         super(LoginFailed, self).__init__(self.message)
 
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Add a login retry mechanism and also for the 'oc get clusterversion' command, because the API server can be down for a short period during OCP upgrading.

## For security reasons, all pull requests need to be approved first before running any automated CI
