### PR TITLE
HotFix: upgrade OCP client version to 4.18.0-rc.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN wget https://www.python.org/ftp/python/${python_full_version}/Python-${pytho
 # install & run benchmark-runner (--no-cache-dir for take always the latest)
 RUN python3.12 -m pip install --upgrade pip && python3.12 -m pip install --upgrade benchmark-runner
 
-# install oc/kubectl client tools for OpenShift/Kubernetes
-ARG OCP_CLIENT_VERSION="4.17.11"
+# Must update every OCP version !!!
+ARG OCP_CLIENT_VERSION="4.18.0-rc.9"
 RUN  curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_CLIENT_VERSION}/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz" -o "/tmp/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz" \
      && tar -xzvf /tmp/openshift-client-linux-${OCP_CLIENT_VERSION}.tar.gz -C /tmp/ \
      && mv /tmp/kubectl /usr/local/bin/kubectl \


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Upgrade OCP client version to 4.18 while using OCP 4.18 version

## For security reasons, all pull requests need to be approved first before running any automated CI
