### PR TITLE
add run strategy to bootstorm vm

### DIFF
--- a/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/bootstorm/internal_data/bootstorm_vm_template.yaml
@@ -18,6 +18,11 @@ metadata:
     benchmark-uuid: {{uuid }}
     benchmark-runner-workload: bootstorm
 spec:
+  {% if run_strategy -%}
+  runStrategy: Always
+  {%- else -%}
+  running: false
+  {%- endif %}
   running: false
   template:
     metadata:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Add run strategy to bootstorm vm for chaos testing, already exist in [windows vm](https://github.com/redhat-performance/benchmark-runner/blob/bcb885c4652d3da2e931f7278dcde65f9f0a943d/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml#L15-L19)


## For security reasons, all pull requests need to be approved first before running any automated CI
