### PR TITLE
bootstorm VMs parallel verification

### DIFF
--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -90,6 +90,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['run_strategy'] = EnvironmentVariables.get_boolean_from_environment('RUN_STRATEGY', False)
         # Verification only, without running or deleting any resources, default False
         self._environment_variables_dict['verification_only'] = EnvironmentVariables.get_boolean_from_environment('VERIFICATION_ONLY', False)
+        # verify after test
+        self._environment_variables_dict['verify_after_test'] = EnvironmentVariables.get_env('VERIFY_AFTER_TEST', '')
 
         # default parameter - change only if needed
         # Parameters below related to 'run_workload()'

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -103,6 +103,7 @@ class WorkloadsOperations:
         self._windows_url = self._environment_variables_dict.get('windows_url', '')
         self._delete_all = self._environment_variables_dict.get('delete_all', '')
         self._verification_only = self._environment_variables_dict.get('verification_only', '')
+        self._verify_after_test = self._environment_variables_dict.get('verify_after_test', '')
         self._wait_for_upgrade_version = self._environment_variables_dict.get('wait_for_upgrade_version', '')
         if self._windows_url:
             file_name = os.path.basename(self._windows_url)


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. Added parallel verification for bootstorm VMs: Previously, the verification was done in a serial loop. By switching to parallel verification, the verification time has been significantly improved.

2.verify_after_test variable: This variable is used in the catalog to indicate when the verification has been completed.

## For security reasons, all pull requests need to be approved first before running any automated CI
