### PR TITLE
Increase timeout operator installation

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -148,7 +148,7 @@ class OC(SSH):
         version = self.run(f"{self._cli} get csv -n {namespace} -o jsonpath='{{.items[0].spec.version}}'")
         return '.'.join(version.split('.')[:2])
 
-    def wait_for_operator_installation(self, operator: str, version: str, namespace: str, timeout: int = SHORT_TIMEOUT):
+    def wait_for_operator_installation(self, operator: str, version: str, namespace: str, timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
         """
         This method waits till operator version is installed successfully
         @param operator:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Operator upgrade took longer than 600 seconds; increase the timeout to the default of 3600 seconds.

## For security reasons, all pull requests need to be approved first before running any automated CI
