### PR TITLE
Add OCP client version to runner builder

### DIFF
--- a/.github/workflows/Build_runner.yml
+++ b/.github/workflows/Build_runner.yml
@@ -97,8 +97,8 @@ jobs:
         run: |
           pip install setuptools
           version=$(python3 setup.py --version)
-          sudo docker build --build-arg VERSION=$version -t ${{ secrets.QUAY_PRIVATE_BENCHMARK_RUNNER_REPOSITORY }}:v$version .
-          sudo docker build --build-arg VERSION=latest -t ${{ secrets.QUAY_PRIVATE_BENCHMARK_RUNNER_REPOSITORY }}:latest .
+          sudo docker build --build-arg OCP_CLIENT_VERSION=${{ secrets.PERF_OCP_CLIENT_VERSION }} -t ${{ secrets.QUAY_PRIVATE_BENCHMARK_RUNNER_REPOSITORY }}:v$version .
+          sudo docker build --build-arg OCP_CLIENT_VERSION=${{ secrets.PERF_OCP_CLIENT_VERSION }} -t ${{ secrets.QUAY_PRIVATE_BENCHMARK_RUNNER_REPOSITORY }}:latest .
           sudo docker login quay.io -u ${{ secrets.QUAY_ROBOT_USER }} -p ${{ secrets.QUAY_ROBOT_PASSWORD }}
           sudo docker push ${{ secrets.QUAY_PRIVATE_BENCHMARK_RUNNER_REPOSITORY }}:v$version
           sudo docker push ${{ secrets.QUAY_PRIVATE_BENCHMARK_RUNNER_REPOSITORY }}:latest
@@ -117,7 +117,7 @@ jobs:
           python-version: 3.12
       - name: ⌛ Build and Upload 🐋 to quay.io
         run: |
-          sudo docker build --build-arg VERSION=latest -t ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}:latest .
+          sudo docker build --build-arg OCP_CLIENT_VERSION=${{ secrets.PERF_OCP_CLIENT_VERSION }} -t ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}:latest .
           sudo docker login quay.io -u ${{ secrets.QUAY_ROBOT_BENCHMARK_RUNNER_USER }} -p ${{ secrets.QUAY_ROBOT_BENCHMARK_RUNNER_PASSWORD }}
           sudo docker push ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}:latest
           echo '⌛ Wait 30 sec till image will be updated in quay.io'


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Add Missing OCP client argument version into runner builder Github action

## For security reasons, all pull requests need to be approved first before running any automated CI
