### PR TITLE
Update benchmark-runner version manually due to build failure

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.812
+current_version = 1.0.813
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.812'  # update also .bumpversion.cfg
+__version__ = '1.0.813'  # update also .bumpversion.cfg
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Update the benchmark-runner version due to a failed [manual run](https://github.com/redhat-performance/benchmark-runner/actions/runs/15136753760) due to missing client version, fixed in [PR](https://github.com/redhat-performance/benchmark-runner/pull/1035)

## For security reasons, all pull requests need to be approved first before running any automated CI
