### PR TITLE
Enable/Disable must gather logs

### DIFF
--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -92,6 +92,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['run_strategy'] = EnvironmentVariables.get_boolean_from_environment('RUN_STRATEGY', False)
         # Verification only, without running or deleting any resources, default False
         self._environment_variables_dict['verification_only'] = EnvironmentVariables.get_boolean_from_environment('VERIFICATION_ONLY', False)
+        # Collect CNV/ODF must-gather logs in case of VM verification failure (default: False).
+        self._environment_variables_dict['must_gather_log'] = EnvironmentVariables.get_boolean_from_environment('MUST_GATHER_LOG', False)
         # test name
         self._environment_variables_dict['test_name'] = EnvironmentVariables.get_env('TEST_NAME', '')
 

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -302,8 +302,9 @@ class BootstormVM(WorkloadsOperations):
                 logger.info(f'Cluster is upgraded to: {self._wait_for_upgrade_version}')
 
             if failure_vms:
-                self._oc.generate_cnv_must_gather(destination_path=self._run_artifacts_path, cnv_version=self._cnv_version)
-                self._oc.generate_odf_must_gather(destination_path=self._run_artifacts_path, odf_version=self._odf_version)
+                if self._must_gather_log:
+                    self._oc.generate_cnv_must_gather(destination_path=self._run_artifacts_path, cnv_version=self._cnv_version)
+                    self._oc.generate_odf_must_gather(destination_path=self._run_artifacts_path, odf_version=self._odf_version)
                 # Error log with details of failed VM, for catching all vm errors
                 logger.error(f"Failed to verify virtctl SSH login for the following VMs: {', '.join(failure_vms)}")
             # Upload artifacts in validation

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -104,6 +104,7 @@ class WorkloadsOperations:
         self._windows_url = self._environment_variables_dict.get('windows_url', '')
         self._delete_all = self._environment_variables_dict.get('delete_all', '')
         self._verification_only = self._environment_variables_dict.get('verification_only', '')
+        self._must_gather_log = self._environment_variables_dict.get('must_gather_log', '')
         self._test_name = self._environment_variables_dict.get('test_name', '')
         self._wait_for_upgrade_version = self._environment_variables_dict.get('wait_for_upgrade_version', '')
         if self._windows_url:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
When a VM verification failure is encountered, CNV/ODF must-gather logs are collected by default, which is time-consuming (several minutes).
We are adding the ability to enable or disable must-gather log collection in case of failure to reduce overall verification time. The default setting is False.

## For security reasons, all pull requests need to be approved first before running any automated CI
