### PR TITLE
Retry checking upgrade in progress

### DIFF
--- a/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
+++ b/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
@@ -107,12 +107,13 @@ class BareMetalOperations:
         current_wait_time = 0
         logger.info(f'Waiting until the upgrade to version {self._upgrade_ocp_version} starts...')
         oc.wait_for_ocp_upgrade_start(upgrade_version=self._upgrade_ocp_version)
-        while self._timeout <= 0 or current_wait_time <= self._timeout and oc.upgrade_in_progress():
+        while (self._timeout <= 0 or current_wait_time <= self._timeout) and oc.upgrade_in_progress():
             logger.info(f'Waiting till OCP upgrade complete, waiting {int(current_wait_time / 60)} minutes')
             # sleep for x seconds
             time.sleep(sleep_time)
             current_wait_time += sleep_time
-        if f'Cluster version is {self._upgrade_ocp_version}' == oc.get_cluster_status():
+        if oc.get_upgrade_version() == self._upgrade_ocp_version:
+            logger.info(f"OCP successfully upgraded to {oc.get_upgrade_version()}")
             return True
         else:
             raise OCPUpgradeFailed(status=oc.get_cluster_status())


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
The OCP upgrade failed while checking its progress. It looks like we need to wrap the status fetch in a try/except block and add a retry mechanism.

The error I got is:
```
benchmark_runner.common.clouds.BareMetal.bare_metal_exceptions.OCPUpgradeFailed: Bare-metal OpenShift Container Platform (OCP) upgrade failed. Upgrade status: E0612 07:40:40.247092     855 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \": net/http: TLS handshake timeout"
E0612 07:40:50.248871     855 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get 
script returned exit code 1
```

## For security reasons, all pull requests need to be approved first before running any automated CI
