### PR TITLE
Wait for the full timeout duration until the upgrade starts

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -123,16 +123,19 @@ class OC(SSH):
     @logger_time_stamp
     def wait_for_ocp_upgrade_start(self, upgrade_version: str, timeout: int = SHORT_TIMEOUT):
         """
-        This method waits for ocp upgrade to start
-        :param upgrade_version:
-        :param timeout:
-        :return:
+        This method waits for the OCP upgrade to start.
+        :param upgrade_version: The target OCP version.
+        :param timeout: Timeout in seconds (waits indefinitely if <= 0).
+        :return: True if upgrade starts within timeout, else raises UpgradeNotStartTimeout.
         """
         current_wait_time = 0
-        while timeout <= 0 or current_wait_time <= timeout and not self.upgrade_in_progress():
-            # sleep for x seconds
+        while timeout <= 0 or current_wait_time <= timeout:
+            if self.upgrade_in_progress():
+                return True
             time.sleep(OC.SLEEP_TIME)
             current_wait_time += OC.SLEEP_TIME
+
+        # Final check after timeout
         if self.upgrade_in_progress():
             return True
         else:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
This fix ensures the full timeout is honored before considering the upgrade as not started. 
Currently, it fails immediately without waiting for the timeout. 
With this fix, it will wait for the entire timeout duration before raising the UpgradeNotStartTimeout error.
## For security reasons, all pull requests need to be approved first before running any automated CI
