### PR TITLE
OpenShift must gather logs

### DIFF
--- a/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
+++ b/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py
@@ -42,6 +42,8 @@ class BareMetalOperations:
         self._upgrade_ocp_version = self._environment_variables_dict.get('upgrade_ocp_version', '')
         self._upgrade_channel = self._environment_variables_dict.get('upgrade_channel', '')
         self._timeout = int(self._environment_variables_dict.get('timeout', ''))
+        self._must_gather_log = self._environment_variables_dict.get('must_gather_log', '')
+        self._run_artifacts_path = self._environment_variables_dict.get('run_artifacts_path', '')
         if user:
             self._user = user
             self._provision_kubeadmin_password_path = self._environment_variables_dict.get('provision_kubeadmin_password_path', '')
@@ -116,6 +118,8 @@ class BareMetalOperations:
             logger.info(f"OCP successfully upgraded to {oc.get_upgrade_version()}")
             return True
         else:
+            if self._must_gather_log:
+                oc.generate_must_gather(destination_path=self._run_artifacts_path)
             raise OCPUpgradeFailed(status=oc.get_cluster_status())
 
     def _install_ocp_cmd(self):

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -1536,6 +1536,29 @@ class OC(SSH):
 
     @typechecked
     @logger_time_stamp
+    def generate_must_gather(self, destination_path: str = '/tmp'):
+        """
+        Generates OpenShift must-gather and stores it in the destination path.
+
+        :param destination_path: The directory where the must-gather logs will be stored. Default is '/tmp'.
+        :return: The result of the run command.
+        :raises: RuntimeError if the command fails.
+        """
+        folder_path = os.path.join(destination_path, "must-gather")
+
+        try:
+            command = f'oc adm must-gather --dest-dir={folder_path}'
+            self.run(command)
+        except Exception as e:
+            if os.path.exists(folder_path):
+                try:
+                    shutil.rmtree(folder_path)
+                except Exception as remove_error:
+                    raise RuntimeError(f"Failed to remove folder {folder_path}: {remove_error}")
+            raise RuntimeError(f"Failed to generate OCP must-gather logs for version: {e}")
+
+    @typechecked
+    @logger_time_stamp
     def generate_odf_must_gather(self, destination_path: str = '/tmp', odf_version: str = None):
         """
         Generates ODF must-gather logs based on the ODF version and stores it in the destination path.

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -304,6 +304,7 @@ class BootstormVM(WorkloadsOperations):
 
             if failure_vms:
                 if self._must_gather_log:
+                    self._oc.generate_must_gather(destination_path=self._run_artifacts_path)
                     self._oc.generate_cnv_must_gather(destination_path=self._run_artifacts_path, cnv_version=self._cnv_version)
                     self._oc.generate_odf_must_gather(destination_path=self._run_artifacts_path, odf_version=self._odf_version)
                 # Error log with details of failed VM, for catching all vm errors


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Collect OpenShift must-gather logs in case of a VM validation failure during upgrade, or if the upgrade itself fails.

## For security reasons, all pull requests need to be approved first before running any automated CI
