### PR TITLE
Fix group by warning

### DIFF
--- a/benchmark_runner/jupyterlab/templates/summary_report/summary_report_operations.py
+++ b/benchmark_runner/jupyterlab/templates/summary_report/summary_report_operations.py
@@ -246,7 +246,7 @@ class SummaryReportOperations:
         @return:
         """
         geometric_mean_df = pd.DataFrame(geometric_mean_data)
-        self.median_indices = geometric_mean_df.groupby(['metric', 'ocp_version']).apply(self.__get_median)
+        self.median_indices = geometric_mean_df.drop(columns=['metric', 'ocp_version']).groupby([geometric_mean_df['metric'], geometric_mean_df['ocp_version']], group_keys=False).apply(self.__get_median)
         geometric_mean_df = geometric_mean_df.loc[self.median_indices['median_result']]
         return self.__calc_percentage(geometric_mean_df, complementary)
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Getting the following error:
```
/usr/local/lib/python3.11/site-packages/benchmark_runner/jupyterlab/templates/summary_report/summary_report_operations.py:249: FutureWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass include_groups=False to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
  self.median_indices = geometric_mean_df.groupby(['metric', 'ocp_version']).apply(self.__get_median)
```
Fixing it by passing include_groups=False to exclude the groupings or explicitly 

## For security reasons, all pull requests need to be approved first before running any automated CI
