### PR TITLE
Change CI date

### DIFF
--- a/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
+++ b/.github/workflows/Weekly_Perf_Env_Installer_CI.yml
@@ -5,7 +5,7 @@ name: Deploy Assisted installer Perf Env Weekly CI
 
 on:
   schedule:
-    - cron: '0 4 * * 4' # run on Thursday at 4 AM UTC/ 0 AM EDT
+    - cron: '0 4 * * 5' # run on Friday at 4 AM UTC/ 0 AM EDT
   workflow_dispatch:
 
 # Ensures that only one deploy task per branch/environment will run at a time.


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
The CI is currently running on Thursday when a new version is still being generated, which causes failures due to the version not being available yet. To resolve this, we’re moving the CI to run on Friday instead.
The latest release.txt url:
`https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.5/release.txt`
```
Error:
# curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.5/release.txt
<html>
<body>
<p>File not found</p>
</body>
</html>
```
## For security reasons, all pull requests need to be approved first before running any automated CI
