### PR TITLE
add nhc and far operators version

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -199,6 +199,20 @@ class OC(SSH):
         """
         return self.run(f"{self._cli} get csv -n openshift-cnv -o json | jq -r '.items[] | select(.metadata.name | startswith(\"kubevirt-hyperconverged-operator\")) | .spec.version'")
 
+    def get_nhc_version(self):
+        """
+        This method returns Node Health Check Operator version
+        :return:
+        """
+        return self.run(f"""{self._cli} get csv -n openshift-workload-availability -o json | jq -r '.items[] | select(.metadata.name | startswith("node-healthcheck-operator")) | .spec.version'""")
+
+    def get_far_version(self):
+        """
+        This method returns Fence Agents Remediation Operator version
+        :return:
+        """
+        return self.run(f"""{self._cli} get csv -n openshift-workload-availability -o json | jq -r '.items[] | select(.metadata.name | startswith("fence-agents-remediation")) | .spec.version'""")
+
     def get_odf_version(self):
         """
         This method returns the ODF version by extracting it from the csv name.

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -413,6 +413,8 @@ class WorkloadsOperations:
         metadata = {'ocp_version': self._oc.get_ocp_server_version(),
                     'previous_ocp_version': '' if len(self._oc.get_previous_ocp_version()) > 10 else self._oc.get_previous_ocp_version(),
                     'cnv_version': self._oc.get_cnv_version(),
+                    'nhc_version': self._oc.get_nhc_version(),
+                    'far_version': self._oc.get_far_version(),
                     'kata_version': self._oc.get_kata_operator_version(),
                     'kata_rpm_version': self._oc.get_kata_rpm_version(node=self._pin_node1),
                     'odf_version': self._oc.get_odf_version(),


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Adding 2 new operator versions to upload it into ElasticSearch:
1. fence-agents-remediation
2. node-healthcheck-operator.

## For security reasons, all pull requests need to be approved first before running any automated CI
