### PR TITLE
Fix CNV installation verification

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -161,14 +161,11 @@ class OC(SSH):
         @param operator_name: str - The name of the operator to search for.
         @return: major version
         """
-        cmd = (
-            f"""{self._cli} get csv -n {namespace} -o json | """
-            f"""jq -r '.items[] | select(.metadata.name | startswith("{operator_name}")) | .spec.version'"""
-        )
+        cmd = f"""{self._cli} get csv -n {namespace} -o json | jq -r '.items[] | select(.metadata.name | startswith("{operator_name}")) | .spec.version'"""
         version = self.run(cmd)
         return '.'.join(version.split('.')[:2])
 
-    def wait_for_operator_installation(self, operator_name: str, version: str, namespace: str, timeout: int =  SHORT_TIMEOUT):
+    def wait_for_operator_installation(self, operator_name: str, version: str, namespace: str, timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
         """
         This method waits till operator version is installed successfully
         @param operator_name:

--- a/benchmark_runner/common/ocp_resources/create_cnv.py
+++ b/benchmark_runner/common/ocp_resources/create_cnv.py
@@ -42,18 +42,18 @@ class CreateCNV(CreateOCPResourceOperations):
                     if cnv_nightly_channel:
                         # wait till get the patch
                         self.wait_for_ocp_resource_create(operator=resource,
-                                                          verify_cmd="oc get InstallPlan -n openshift-cnv -o jsonpath={.items[0].metadata.name}",
+                                                          verify_cmd = """oc get installplan -n openshift-cnv -o json | jq -r '.items[] | select(.spec.clusterServiceVersionNames[] | startswith("kubevirt-hyperconverged-operator")) | select(.status.phase=="Complete") | .metadata.name' | tail -n1""",
                                                           status="install-")
                         self.apply_patch(namespace='openshift-cnv', operator='cnv')
                     # stable channel
                     else:
                         self.wait_for_ocp_resource_create(operator='cnv',
-                                                          verify_cmd="oc get csv -n openshift-cnv -o jsonpath='{.items[0].status.phase}'",
+                                                          verify_cmd="""oc get csv -n openshift-cnv -o json | jq -r '.items[] | select(.metadata.name | startswith("kubevirt-hyperconverged-operator")) | .status.phase'""",
                                                           status='Succeeded')
                 # for second script wait for refresh status
                 if '02_hyperconverge.yaml' in resource:
                     # Wait that till succeeded
                     self.wait_for_ocp_resource_create(operator='cnv',
-                                                      verify_cmd="oc get csv -n openshift-cnv -o jsonpath='{.items[0].status.phase}'",
+                                                      verify_cmd = """oc get csv -n openshift-cnv -o json | jq -r '.items[] | select(.metadata.name | startswith("kubevirt-hyperconverged-operator")) | .status.phase'""",
                                                       status='Succeeded')
         return True


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
1. Use operator name verification instead of index number
2. Increase the wait time for operator upgrade from 600 to 3600 seconds, because after the upgrade it took more than 600 seconds to upgrade the CNV operator.
For more details see error:
```

  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/common/clouds/BareMetal/bare_metal_operations.py", line 313, in is_cluster_upgraded
    oc.wait_for_operator_installation(operator_name=operator_name, version=ver, namespace=ns)
  File "/usr/local/lib/python3.12/site-packages/benchmark_runner/common/oc/oc.py", line 189, in wait_for_operator_installation
    raise OperatorInstallationTimeout(operator=operator_name, version=version, namespace=namespace)
benchmark_runner.common.oc.oc_exceptions.OperatorInstallationTimeout: kubevirt-hyperconverged-operator operator installation to: **** in namespace: openshift-cnv didn't complete
script returned exit code 1
```

## For security reasons, all pull requests need to be approved first before running any automated CI
