### PR TITLE
Migrate stressng and uperf workloads from benchmark-operator/snafu to native resource creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Choose one from the following list:
 
 Not mandatory:
 
-**auto:** NAMESPACE=benchmark-operator [ The default namespace is benchmark-operator ]
+**auto:** NAMESPACE=benchmark-runner [ The default namespace is benchmark-runner ]
 
 **auto:** ODF_PVC=True [ True=ODF PVC storage, False=Ephemeral storage, default True ]
 
@@ -83,8 +83,6 @@ Not mandatory:
 **auto:** SYSTEM_METRICS=False [ True=collect metric, False=not collect metrics, default False ]
 
 **auto:** RUNNER_PATH=/tmp [ The default work space is /tmp ]
-
-**optional:** PIN_NODE_BENCHMARK_OPERATOR=$PIN_NODE_BENCHMARK_OPERATOR [node selector for benchmark operator pod]
 
 **optional:** PIN_NODE1=$PIN_NODE1 [node1 selector for running the workload]
 
@@ -111,17 +109,16 @@ Not mandatory:
 For example:
 
 ```sh
-podman run --rm -e WORKLOAD="hammerdb_pod_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE_BENCHMARK_OPERATOR="node_name-0" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
+podman run --rm -e WORKLOAD="hammerdb_pod_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
 ```
 or
 ```sh
-docker run --rm -e WORKLOAD="hammerdb_vm_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE_BENCHMARK_OPERATOR="node_name-0" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
+docker run --rm -e WORKLOAD="hammerdb_vm_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
 ```
 
 SAVE RUN ARTIFACTS LOCAL:
 1. add `-e SAVE_ARTIFACTS_LOCAL='True'` or `--save-artifacts-local=true`
 2. add `-v /tmp/benchmark-runner-run-artifacts:/tmp/benchmark-runner-run-artifacts`
-3. git clone -b v1.0.3 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 
 ### Run vdbench workload in Pod using OpenShift
 ![](media/benchmark-runner-demo.gif)

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -802,18 +802,27 @@ class OC(SSH):
 
     @typechecked
     @logger_time_stamp
-    def get_pod(self, label: str, database: str = '', namespace: str = environment_variables.environment_variables_dict['namespace']):
+    def get_pod(self, label: str = '', database: str = '', namespace: str = environment_variables.environment_variables_dict['namespace'], label_selector: str = ''):
         """
-        This method gets pods according to label
-        :param label:
+        This method gets pod name by name pattern or label selector
+        :param label: pod name pattern (grep match)
         :param database:
         :param namespace:
-        :return:
+        :param label_selector: Kubernetes label selector (e.g. 'app=stressng_workload-<uuid>')
+        :return: pod name
         """
         if database:
             return self.run(
                 f"{self._cli} get pods -n '{database}-db'" + " --no-headers | awk '{ print $1; }' | grep " + database,
                 is_check=True).rstrip().decode('ascii')
+        elif label_selector:
+            namespace_opt = f'-n {namespace}' if namespace else ''
+            result = self.run(
+                f"{self._cli} get pods {namespace_opt} -l '{label_selector}' -o jsonpath='{{.items[0].metadata.name}}'",
+                is_check=True)
+            if isinstance(result, bytes):
+                return result.decode('utf-8').strip().strip("'")
+            return str(result).strip().strip("'") if result else ''
         else:
             namespace = f'-n {namespace}' if namespace else ''
             return self.run(f"{self._cli} get pods {namespace} --no-headers | awk '{{ print $1; }}' | grep -w '{label}'", is_check=True).rstrip().decode('ascii')
@@ -862,26 +871,27 @@ class OC(SSH):
 
     @typechecked
     @logger_time_stamp
-    def wait_for_pod_create(self, pod_name: str,
+    def wait_for_pod_create(self, pod_name: str = '', label: str = '',
                             namespace: str = environment_variables.environment_variables_dict['namespace'],
                             timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
         """
-        This method waits till pod name is creating or throw exception after timeout
+        This method waits till pod is created or throws exception after timeout.
+        Can match by pod_name or label selector (for Job pods with random suffixes).
+        :param pod_name: Pod name to match
+        :param label: Label selector to match (e.g. 'app=stressng_workload-<uuid>')
         :param namespace:
-        :param pod_name:
         :param timeout:
-        :return: True if getting pod name or raise PodNameError
+        :return: True if pod found or raise PodNotCreateTimeout
         """
         current_wait_time = 0
         while timeout <= 0 or current_wait_time <= timeout:
-            if self.pod_exists(pod_name=pod_name, namespace=namespace):
-                self.describe_pod(pod_name=pod_name, namespace=namespace)
+            if label and self.pod_label_exists(label_name=label, namespace=namespace):
                 return True
-            # sleep for x seconds
+            elif pod_name and self.pod_exists(pod_name=pod_name, namespace=namespace):
+                return True
             time.sleep(OC.SLEEP_TIME)
             current_wait_time += OC.SLEEP_TIME
-        self.describe_pod(pod_name=pod_name, namespace=namespace)
-        raise PodNotCreateTimeout(pod_name)
+        raise PodNotCreateTimeout(pod_name or label)
 
     @typechecked
     @logger_time_stamp
@@ -1163,13 +1173,23 @@ class OC(SSH):
                         f"{self._cli} {namespace} wait --for=condition=failed -l {label}-{self.__get_short_uuid(workload=workload)} jobs --timeout={OC.SLEEP_TIME}s")
                     if 'met' in result:
                         return False
-                if not job:
+                elif job:
+                    # Handle job=True with label_uuid=False (direct pod workloads)
+                    result = self.run(
+                        f"{self._cli} {namespace} wait --for=condition=complete -l {label} jobs --timeout={OC.SHORT_TIMEOUT}s")
+                    if 'met' in result:
+                        return True
+                    result = self.run(
+                        f"{self._cli} {namespace} wait --for=condition=failed -l {label} jobs --timeout={OC.SLEEP_TIME}s")
+                    if 'met' in result:
+                        return False
+                elif not job:
                     result = self.run(f"{self._cli} get pod -l {label}" + " -n benchmark-runner --no-headers | awk '{ print $3; }'")
                     if 'Completed' in result:
                         return True
-            # sleep for x seconds
-            time.sleep(OC.SLEEP_TIME)
-            current_wait_time += OC.SLEEP_TIME
+                # sleep for x seconds
+                time.sleep(OC.SLEEP_TIME)
+                current_wait_time += OC.SLEEP_TIME
         except Exception as err:
             raise PodNotCompletedTimeout(workload=workload)
 
@@ -1244,6 +1264,55 @@ class OC(SSH):
                 cmd=f"{self._cli} get vmi {namespace} --no-headers | awk '{{ print $1; }}' | grep -w '{label}'", is_check=True).rstrip().decode('ascii')
         else:
             return self.run(f'{self._cli} get vmi', is_check=True)
+
+    def _get_pod_field(self, field: str, label: str = '', pod_name: str = '', namespace: str = '') -> str:
+        """
+        Get a pod field via jsonpath, by label selector or pod name
+        """
+        namespace = namespace or environment_variables.environment_variables_dict.get('namespace', '')
+        try:
+            if label:
+                result = self.run(
+                    cmd=f"{self._cli} get pods -n {namespace} -l {label} -o jsonpath='{{.items[0].{field}}}'")
+            else:
+                result = self.run(
+                    cmd=f"{self._cli} get pod -n {namespace} {pod_name} -o jsonpath='{{.{field}}}'")
+            return result.strip().strip(b"'").decode('ascii') if isinstance(result, bytes) else str(result).strip().strip("'")
+        except Exception:
+            return ''
+
+    def get_pod_ip(self, label: str = '', pod_name: str = '', namespace: str = '') -> str:
+        return self._get_pod_field('status.podIP', label=label, pod_name=pod_name, namespace=namespace)
+
+    def get_pod_node(self, label: str = '', pod_name: str = '', namespace: str = '') -> str:
+        return self._get_pod_field('spec.nodeName', label=label, pod_name=pod_name, namespace=namespace)
+
+    def get_vmi_ip(self, namespace: str, vm_name: str, retries: int = 30) -> str:
+        """
+        Get the IP address of a VirtualMachineInstance, retrying until available
+        """
+        for attempt in range(retries):
+            try:
+                result = self.run(
+                    cmd=f"{self._cli} get vmi -n {namespace} {vm_name} -o jsonpath='{{.status.interfaces[0].ipAddress}}'")
+                ip = result.strip().strip(b"'").decode('ascii') if isinstance(result, bytes) else str(result).strip().strip("'")
+                if ip and ip != '<none>':
+                    return ip
+            except Exception:
+                pass
+            time.sleep(2)
+        return ''
+
+    def get_cluster_name(self) -> str:
+        """
+        Get the cluster name/ID
+        """
+        try:
+            result = self.run(cmd=f"{self._cli} get infrastructure cluster -o jsonpath='{{.status.infrastructureName}}'")
+            return result.strip().strip(b"'").decode('ascii') if isinstance(result, bytes) else str(result).strip().strip("'")
+        except Exception:
+            return ''
+
 
     @logger_time_stamp
     def __verify_vm_log_complete(self, vm_name: str, timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
@@ -1452,19 +1521,26 @@ class OC(SSH):
 
     @typechecked
     @logger_time_stamp
-    def delete_vm_sync(self, yaml: str, vm_name: str,
+    def delete_vm_sync(self, yaml: str = '', vm_name: str = '',
                        namespace: str = environment_variables.environment_variables_dict['namespace'],
                        timeout: int = int(environment_variables.environment_variables_dict['timeout'])):
         """
-        This method deletes specified VM synchronously; return False if it does not exist
+        This method deletes specified VM synchronously; return False if it does not exist.
+        Can delete by YAML file or by VM name directly.
+        :param yaml: YAML file to delete (deletes all resources in YAML)
+        :param vm_name: VM name to delete (used when no YAML, or to delete specific VM)
         :param namespace:
         :param timeout:
-        :param vm_name:
-        :param yaml:
         :return: return False if vm does not exist
         """
         if self.vm_exists(vm_name=vm_name, namespace=namespace):
-            self.delete_async(yaml)
+            if yaml:
+                self.delete_async(yaml)
+            else:
+                try:
+                    self.run(f"{self._cli} delete vm {vm_name} -n {namespace} --ignore-not-found")
+                except Exception:
+                    pass
             return self.wait_for_vm_delete(vm_name=vm_name, namespace=namespace, timeout=timeout)
         else:
             return False
@@ -1492,9 +1568,19 @@ class OC(SSH):
         current_wait_time = 0
         namespace = f'-n {namespace}' if namespace else ''
         while timeout <= 0 or current_wait_time <= timeout:
-            if self.run(
-                    f"{self._cli} {namespace} get benchmark {workload} -o jsonpath={{.status.complete}}") == 'true':
-                return True
+            # Check VMI phase for direct VM workloads
+            if vm_name:
+                vmi_phase = self.run(
+                    f"{self._cli} {namespace} get vmi {vm_name} -o jsonpath={{.status.phase}}")
+                if vmi_phase == 'Succeeded':
+                    return True
+                elif vmi_phase == 'Failed':
+                    return False
+            else:
+                # Fallback to benchmark CR for operator-based workloads
+                if self.run(
+                        f"{self._cli} {namespace} get benchmark {workload} -o jsonpath={{.status.complete}}") == 'true':
+                    return True
             # sleep for x seconds
             time.sleep(OC.SLEEP_TIME)
             current_wait_time += OC.SLEEP_TIME

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_job_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_job_template.yaml
@@ -1,0 +1,152 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+data:
+  jobfile: |
+    run {{ runtype }}
+    verbose
+    metrics-brief
+    timeout {{ stressng_timeout }}
+
+    # cpu stressor
+    {%- if cpu_stressors is defined %}
+    cpu {{ cpu_stressors }}
+    cpu-load {{ cpu_percentage }}
+    cpu-method {{ cpu_method }}
+    {%- endif %}
+
+    # vm stressor
+    {%- if vm_stressors is defined %}
+    vm {{ vm_stressors }}
+    vm-bytes {{ vm_bytes }}
+    vm-keep
+    vm-populate
+    {%- endif %}
+
+    # memcpy stressor
+    {%- if mem_stressors is defined %}
+    memcpy {{ mem_stressors }}
+    {%- endif %}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-{{ kind }}-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+spec:
+  parallelism: {{ instances }}
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ job_timeout|default(3600) }}
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-{{ trunc_uuid }}
+        type: stressng-bench-workload-{{ trunc_uuid }}
+        benchmark-uuid: {{ uuid }}
+        benchmark-runner-workload: stressng
+    spec:
+      {%- if pin == 'true' or pin == true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ pin_node }}'
+      {%- endif %}
+      {%- if kind == 'kata' %}
+      runtimeClassName: kata
+      {%- endif %}
+      containers:
+      - name: stressng
+        {%- if resources == 'true' or resources == true %}
+        resources:
+          requests:
+            cpu: {{ requests_cpu }}
+            memory: {{ requests_memory }}
+          limits:
+            cpu: {{ limits_cpu }}
+            memory: {{ limits_memory }}
+        {%- endif %}
+        image: {{ image | default('quay.io/benchmark-runner/stressng:latest') }}
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user | default('user') }}"
+          - name: clustername
+            value: "{{ clustername | default('') }}"
+          - name: runtype
+            value: "{{ runtype }}"
+          - name: timeout
+            value: "{{ stressng_timeout }}"
+          {%- if cpu_stressors is defined %}
+          - name: cpu_stressors
+            value: "{{ cpu_stressors }}"
+          {%- endif %}
+          {%- if cpu_percentage is defined %}
+          - name: cpu_percentage
+            value: "{{ cpu_percentage }}"
+          {%- endif %}
+          {%- if cpu_method is defined %}
+          - name: cpu_method
+            value: "{{ cpu_method }}"
+          {%- endif %}
+          {%- if vm_stressors is defined %}
+          - name: vm_stressors
+            value: "{{ vm_stressors }}"
+          {%- endif %}
+          {%- if vm_bytes is defined %}
+          - name: vm_bytes
+            value: "{{ vm_bytes }}"
+          {%- endif %}
+          {%- if mem_stressors is defined %}
+          - name: mem_stressors
+            value: "{{ mem_stressors }}"
+          {%- endif %}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-{{ trunc_uuid }}
+          defaultMode: 0660
+      restartPolicy: Never

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_direct_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_direct_template.yaml
@@ -1,0 +1,71 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+  labels:
+    app: stressng-vm-{{ trunc_uuid }}
+    type: stressng-vm-{{ trunc_uuid }}
+    benchmark-uuid: {{ uuid }}
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-{{ trunc_uuid }}
+    spec:
+      {%- if pin == 'true' or pin == true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ pin_node }}'
+      {%- endif %}
+      domain:
+        cpu:
+          sockets: {{ sockets }}
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: {{ requests_cpu }}
+            memory: {{ requests_memory }}
+          limits:
+            cpu: {{ limits_cpu }}
+            memory: {{ limits_memory }}
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: {{ fedora_container_disk }}
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              {%- if ssh_public_key is defined and ssh_public_key %}
+              ssh_authorized_keys:
+                - {{ ssh_public_key }}
+              {%- endif %}
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu {{ cpu_stressors }} --cpu-load {{ cpu_percentage }} --vm {{ vm_stressors }} --vm-bytes {{ vm_bytes }} --memcpy {{ mem_stressors }} --verbose --metrics-brief --timeout {{ stressng_timeout }} 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -1,10 +1,18 @@
 metadata:
   name: stressng
+files:
+  - name: stressng_pod.yaml
+    template: stressng_pod_job_template.yaml
+  - name: stressng_vm.yaml
+    template: stressng_vm_direct_template.yaml
 template_data:
   shared:
     pin_node: {{ pin_node1 }}
+    test_user: user
+    run_id: NA
     runtype: sequential
     instances: 1
+    image: quay.io/benchmark-runner/stressng:latest
     # cpu stressor options
     cpu_percentage: 100
     cpu_method: all
@@ -16,6 +24,7 @@ template_data:
   run_type:
     perf_ci:
       timeout: 120
+      stressng_timeout: 120
       cpu_stressors: 60
       vm_bytes: 60G
       limits_cpu: 60
@@ -24,6 +33,7 @@ template_data:
       requests_memory: 75Gi
     default:
       timeout: 30
+      stressng_timeout: 30
       cpu_stressors: 1
       vm_bytes: 128M
       limits_cpu: 2

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
@@ -1,0 +1,130 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: {{ uuid }}
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-{{ trunc_uuid }}
+    spec:
+      {%- if kind == 'kata' %}
+      runtimeClassName: kata
+      {%- endif %}
+      {%- if hostnetwork == 'true' or hostnetwork == true %}
+      hostNetwork: true
+      {%- endif %}
+      containers:
+      - name: benchmark
+        image: {{ image | default('quay.io/benchmark-runner/uperf:latest') }}
+        env:
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user | default('user') }}"
+          - name: clustername
+            value: "{{ clustername | default('') }}"
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "{{ pin_server | default('unknown') }}"
+          - name: server_ip
+            value: "{{ server_ip | default('') }}"
+          - name: run_id
+            value: "{{ run_id | default('NA') }}"
+          - name: client_ips
+            value: "{{ client_ips | default('') }}"
+          - name: service_ip
+            value: "{{ service_ip | default('False') }}"
+          - name: service_type
+            value: "{{ service_type | default('') }}"
+          - name: port
+            value: "{{ port | default('30000') }}"
+          - name: num_pairs
+            value: "{{ num_pairs | default('') }}"
+          - name: multus_client
+            value: "{{ multus_client | default('') }}"
+          - name: networkpolicy
+            value: "{{ networkpolicy | default('') }}"
+          - name: density
+            value: "{{ density | default('') }}"
+          - name: nodes_in_iter
+            value: "{{ nodes_in_iter | default('') }}"
+          - name: step_size
+            value: "{{ step_size | default('') }}"
+          - name: colocate
+            value: "{{ colocate | default('') }}"
+          - name: density_range
+            value: "{{ density_range | default('') }}"
+          - name: node_range
+            value: "{{ node_range | default('') }}"
+          - name: hostnetwork
+            value: "{{ hostnetwork | default('False') }}"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        {%- if client_resources is defined and client_resources %}
+        resources:
+          requests:
+            cpu: {{ requests_cpu }}
+            memory: {{ requests_memory }}
+          limits:
+            cpu: {{ limits_cpu }}
+            memory: {{ limits_memory }}
+        {%- endif %}
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h="{{ server_ip }}"
+            export port=30000
+            export hostnet={{ hostnetwork | default('false') }}
+            export num_pairs={{ pair | default('1') }}
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP="{{ server_ip }}"
+
+            # Run each test combination and upload metrics to ES
+            {%- for test_type in test_types %}
+            {%- for proto in protos %}
+            {%- for size in sizes %}
+            {%- for nthr in nthrs %}
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }} > /tmp/uperf-workdir/uperf-{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }}
+            cat /tmp/uperf-workdir/uperf-{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }}
+            OUTFILE="/tmp/uperf-out-{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }}.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }} -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            {%- endfor %}
+            {%- endfor %}
+            {%- endfor %}
+            {%- endfor %}
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-{{ trunc_uuid }}
+      restartPolicy: Never
+      {%- if pin == 'true' or pin == true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ pin_client }}'
+      {%- endif %}

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
@@ -1,0 +1,200 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+data:
+{%- for test_type in test_types %}
+{%- for proto in protos %}
+{%- for size in sizes %}
+{%- for nthr in nthrs %}
+  uperf-{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }}: |
+    <?xml version=1.0?>
+    <profile name="{{ test_type }}-{{ proto }}-{{ size }}-{{ size }}-{{ nthr }}">
+    {%- if test_type == 'rr' %}
+      <group nthreads="{{ nthr }}">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol={{ proto }} port=30001"/>
+          </transaction>
+          <transaction duration="{{ runtime }}">
+            <flowop type=write options="size={{ size }}"/>
+            <flowop type=read  options="size={{ size }}"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    {%- endif %}
+    {%- if test_type == 'stream' or test_type == 'bidirec' %}
+      <group nthreads="{{ nthr }}">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol={{ proto }} port=30001"/>
+          </transaction>
+          <transaction duration="{{ runtime }}">
+            <flowop type=write options="count=16 size={{ size }}"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    {%- endif %}
+    {%- if test_type == 'maerts' or test_type == 'bidirec' %}
+      <group nthreads="{{ nthr }}">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol={{ proto }} port=30002"/>
+          </transaction>
+          <transaction duration="{{ runtime }}">
+            <flowop type=read options="count=16 size={{ size }}"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    {%- endif %}
+    </profile>
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}
+{%- endfor %}
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: {{ uuid }}
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-{{ trunc_uuid }}
+        index: "0"
+        type: uperf-bench-server-{{ trunc_uuid }}
+    spec:
+      {%- if kind == 'kata' %}
+      runtimeClassName: kata
+      {%- endif %}
+      {%- if hostnetwork == 'true' or hostnetwork == true %}
+      hostNetwork: true
+      {%- endif %}
+      containers:
+      - name: benchmark
+        image: {{ image | default('quay.io/benchmark-runner/uperf:latest') }}
+        {%- if server_resources is defined and server_resources %}
+        resources:
+          requests:
+            cpu: {{ requests_cpu }}
+            memory: {{ requests_memory }}
+          limits:
+            cpu: {{ limits_cpu }}
+            memory: {{ limits_memory }}
+        {%- endif %}
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      {%- if pin == 'true' or pin == true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ pin_server }}'
+      {%- endif %}

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_direct_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_direct_template.yaml
@@ -1,0 +1,247 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    {%- if ssh_public_key is defined and ssh_public_key %}
+    ssh_authorized_keys:
+      - "{{ ssh_public_key }}"
+    {%- endif %}
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER="{{ server_ip }}"
+        RT="{{ runtime }}"
+        for tt in {{ test_types | join(' ') }}; do
+          for sz in {{ sizes | join(' ') }}; do
+            for nt in {{ nthrs | join(' ') }}; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+  labels:
+    app: uperf-server-{{ trunc_uuid }}
+    type: uperf-server-{{ trunc_uuid }}
+    benchmark-uuid: {{ uuid }}
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-{{ trunc_uuid }}
+    spec:
+      {%- if pin == 'true' or pin == true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ pin_server }}'
+      {%- endif %}
+      domain:
+        cpu:
+          sockets: {{ sockets }}
+          cores: {{ cores }}
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: {{ requests_cpu }}
+            memory: {{ requests_memory }}
+          limits:
+            cpu: {{ limits_cpu }}
+            memory: {{ limits_memory }}
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: {{ fedora_container_disk }}
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              {%- if ssh_public_key is defined and ssh_public_key %}
+              ssh_authorized_keys:
+                - {{ ssh_public_key }}
+              {%- endif %}
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-{{ trunc_uuid }}
+  namespace: {{ namespace }}
+  labels:
+    app: uperf-client-{{ trunc_uuid }}
+    type: uperf-client-{{ trunc_uuid }}
+    benchmark-uuid: {{ uuid }}
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-{{ trunc_uuid }}
+    spec:
+      {%- if pin == 'true' or pin == true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ pin_client }}'
+      {%- endif %}
+      domain:
+        cpu:
+          sockets: {{ sockets }}
+          cores: {{ cores }}
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: {{ requests_cpu }}
+            memory: {{ requests_memory }}
+          limits:
+            cpu: {{ limits_cpu }}
+            memory: {{ limits_memory }}
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: {{ fedora_container_disk }}
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-{{ trunc_uuid }}

--- a/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
@@ -1,15 +1,27 @@
 metadata:
   name: uperf
+files:
+  - name: uperf_pod_server.yaml
+    template: uperf_pod_server_template.yaml
+  - name: uperf_pod_client.yaml
+    template: uperf_pod_client_template.yaml
+  - name: uperf_vm.yaml
+    template: uperf_vm_direct_template.yaml
 template_data:
   shared:
     pin_server: {{ pin_node1 }}
     pin_client: {{ pin_node2 }}
+    test_user: user
+    run_id: NA
+    port: 30000
+    service_ip: 'False'
     serviceip: false
     hostnetwork: false
     networkpolicy: false
     multus: false
     samples: 1
     pair: 1
+    image: quay.io/benchmark-runner/uperf:latest
     protos:
       - tcp
   run_type:
@@ -39,13 +51,17 @@ template_data:
         perf_ci:
           sockets: 8
           cores: 1
+          limits_cpu: 8
           limits_memory: 8Gi
+          requests_cpu: 8
           requests_memory: 8Gi
           net_queues: 8
         default:
           sockets: 1
           cores: 2
+          limits_cpu: 2
           limits_memory: 1Gi
+          requests_cpu: 10m
           requests_memory: 1Gi
           net_queues: 4
     default:

--- a/benchmark_runner/common/virtctl/virtctl.py
+++ b/benchmark_runner/common/virtctl/virtctl.py
@@ -1,5 +1,9 @@
 
 import os
+import subprocess
+import tempfile
+import time
+from typing import Optional
 from typeguard import typechecked
 
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
@@ -14,6 +18,130 @@ class Virtctl(OC):
 
     def __init__(self):
         super().__init__()
+
+    @typechecked
+    def generate_ssh_key(self, key_path: str = '') -> str:
+        """Generate a temporary SSH keypair for virtctl ssh access to VMs. Returns the path to the private key."""
+        if not key_path:
+            key_path = os.path.join(tempfile.mkdtemp(), 'vm_key')
+        if not os.path.exists(key_path):
+            subprocess.run(['ssh-keygen', '-t', 'rsa', '-b', '4096', '-f', key_path, '-N', ''],
+                           check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            logger.debug(f'Generated SSH keypair at {key_path}')
+        return key_path
+
+    @typechecked
+    def get_ssh_public_key(self, key_path: str) -> str:
+        """Read and return the SSH public key content."""
+        with open(f'{key_path}.pub') as f:
+            return f.read().strip()
+
+    @typechecked
+    def virtctl_ssh(self, vm_name: str, command: str, namespace: str = '', key_path: str = '', username: str = '') -> Optional[str]:
+        """Execute a command inside a VM via virtctl ssh. Returns stdout string, or None on failure."""
+        namespace = namespace or environment_variables.environment_variables_dict.get('namespace', '')
+        username = username or environment_variables.environment_variables_dict.get('vm_user', 'fedora')
+        try:
+            if self.is_virtctl_ge(min_version='1.6.0'):
+                target = f'vmi/{vm_name}'
+            else:
+                target = vm_name
+            result = subprocess.run(
+                ['virtctl', '-n', namespace, 'ssh', f'--username={username}', f'--identity-file={key_path}',
+                 '--known-hosts=',
+                 '-t', '-o StrictHostKeyChecking=no', '-t', '-o UserKnownHostsFile=/dev/null',
+                 f'--command={command}', target],
+                capture_output=True, text=True, timeout=self.SHORT_TIMEOUT)
+            if result.returncode == 0:
+                return result.stdout
+            stderr = result.stderr.strip()
+            if 'connection refused' in stderr or 'no route to host' in stderr:
+                pass
+            elif 'Permanently added' in stderr and not result.stdout.strip():
+                pass
+            else:
+                if result.stdout.strip():
+                    return result.stdout
+                logger.warning(f'virtctl ssh failed: {stderr[:200]}')
+            return None
+        except Exception as e:
+            logger.warning(f'virtctl ssh error: {e}')
+            return None
+
+    @typechecked
+    def _ssh_ready(self, vm_name: str, namespace: str = '', key_path: str = '', username: str = '') -> bool:
+        """Check if SSH is accessible on a VM."""
+        result = self.virtctl_ssh(vm_name=vm_name, command='echo ready', namespace=namespace, key_path=key_path, username=username)
+        return result is not None and 'ready' in result
+
+    @typechecked
+    def _wait_for_virtctl_ssh(self, vm_name: str, namespace: str = '', key_path: str = '', username: str = '', timeout: int = OC.SHORT_TIMEOUT) -> bool:
+        """Wait for SSH to be accessible on a VM via virtctl."""
+        for i in range(0, timeout, self.SLEEP_TIME):
+            if self._ssh_ready(vm_name=vm_name, namespace=namespace, key_path=key_path, username=username):
+                logger.debug(f'SSH ready on {vm_name} after {i}s')
+                return True
+            if i > 0 and i % OC.DELAY == 0:
+                logger.debug(f'Waiting for SSH on {vm_name}... ({i}s)')
+            time.sleep(self.SLEEP_TIME)
+        logger.warning(f'SSH on {vm_name} not ready within {timeout}s')
+        return False
+
+    @typechecked
+    def _wait_for_file_created(self, vm_name: str, file_path: str, namespace: str = '', key_path: str = '', username: str = '',
+                              timeout: int = int(environment_variables.environment_variables_dict.get('timeout', 3600))) -> bool:
+        """Poll until a file exists inside the VM via SSH."""
+        for elapsed in range(0, timeout, self.SLEEP_TIME):
+            check_result = self.virtctl_ssh(vm_name=vm_name, command=f'test -f {file_path} && echo done',
+                                            namespace=namespace, key_path=key_path, username=username)
+            if check_result is not None and 'done' in check_result:
+                logger.debug(f'File {file_path} found on {vm_name} after {elapsed}s')
+                return True
+            if elapsed > 0 and elapsed % OC.DELAY == 0:
+                logger.debug(f'Waiting for {file_path} on {vm_name}... ({elapsed}s)')
+            time.sleep(self.SLEEP_TIME)
+        logger.warning(f'File {file_path} not found on {vm_name} within {timeout}s')
+        return False
+
+    @typechecked
+    def _scp_file(self, vm_name: str, remote_path: str, local_path: str, namespace: str = '', key_path: str = '', username: str = '') -> bool:
+        """Copy a file from VM to local using virtctl scp."""
+        namespace = namespace or environment_variables.environment_variables_dict.get('namespace', '')
+        username = username or environment_variables.environment_variables_dict.get('vm_user', 'fedora')
+        try:
+            if self.is_virtctl_ge(min_version='1.6.0'):
+                source = f'{username}@vmi/{vm_name}:{remote_path}'
+            else:
+                source = f'{username}@{vm_name}:{remote_path}'
+            result = subprocess.run(
+                ['virtctl', '-n', namespace, 'scp', f'--identity-file={key_path}',
+                 '--known-hosts=',
+                 '-t', '-o StrictHostKeyChecking=no', '-t', '-o UserKnownHostsFile=/dev/null',
+                 source, local_path],
+                capture_output=True, text=True, timeout=self.SHORT_TIMEOUT)
+            if result.returncode == 0:
+                logger.debug(f'SCP {remote_path} from {vm_name} to {local_path}')
+                return True
+            logger.warning(f'virtctl scp failed: {result.stderr.strip()[:200]}')
+            return False
+        except Exception as e:
+            logger.warning(f'virtctl scp error: {e}')
+            return False
+
+    @typechecked
+    @logger_time_stamp
+    def wait_for_vm_workload_completed(self, vm_name: str, file_path: str, local_path: str, namespace: str = '',
+                                       key_path: str = '', username: str = '',
+                                       timeout: int = int(environment_variables.environment_variables_dict.get('timeout', 3600))) -> bool:
+        """Wait for workload completion (file exists) then SCP result file to local."""
+        if not self._wait_for_virtctl_ssh(vm_name=vm_name, namespace=namespace, key_path=key_path, username=username):
+            logger.warning(f'SSH never became ready on {vm_name}')
+            return False
+        if not self._wait_for_file_created(vm_name=vm_name, file_path=file_path, namespace=namespace,
+                                            key_path=key_path, username=username, timeout=timeout):
+            return False
+        return self._scp_file(vm_name=vm_name, remote_path=file_path, local_path=local_path,
+                              namespace=namespace, key_path=key_path, username=username)
 
     @typechecked
     @logger_time_stamp

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -58,6 +58,9 @@ class EnvironmentVariables:
         self._environment_variables_dict['pin_node1'] = EnvironmentVariables.get_env('PIN_NODE1', '')
         self._environment_variables_dict['pin_node2'] = EnvironmentVariables.get_env('PIN_NODE2', '')
 
+        # VM SSH user (default: fedora, configurable for different VM images)
+        self._environment_variables_dict['vm_user'] = EnvironmentVariables.get_env('VM_USER', 'fedora')
+
         # ElasticSearch
         self._environment_variables_dict['elasticsearch'] = EnvironmentVariables.get_env('ELASTICSEARCH', '')
         self._environment_variables_dict['elasticsearch_port'] = EnvironmentVariables.get_env('ELASTICSEARCH_PORT', '')
@@ -115,9 +118,9 @@ class EnvironmentVariables:
                                                          'clusterbuster', 'bootstorm_vm', 'windows_vm', 'winmssql_vm', 'krknhub']
         # Workloads namespaces
         self._environment_variables_dict['workload_namespaces'] = {
-            'stressng': 'benchmark-operator',
+            'stressng': 'benchmark-runner',
             'hammerdb': 'benchmark-operator',
-            'uperf': 'benchmark-operator',
+            'uperf': 'benchmark-runner',
             'vdbench': 'benchmark-runner',
             'clusterbuster': 'clusterbuster',
             'bootstorm': 'benchmark-runner',
@@ -343,10 +346,6 @@ class EnvironmentVariables:
         self._environment_variables_dict['ocp_resource_install_minutes_time'] = EnvironmentVariables.get_env('OCP_RESOURCE_INSTALL_MINUTES_TIME', 0)
         # benchmark-runner last commit id
         self._environment_variables_dict['benchmark_runner_id'] = EnvironmentVariables.get_env('BENCHMARK_RUNNER_ID', '')
-        # benchmark-operator last commit id
-        self._environment_variables_dict['benchmark_operator_id'] = EnvironmentVariables.get_env('BENCHMARK_OPERATOR_ID', '')
-        # benchmark-wrapper last commit id
-        self._environment_variables_dict['benchmark_wrapper_id'] = EnvironmentVariables.get_env('BENCHMARK_WRAPPER_ID', '')
 
         # Node Selector functionality
         self._environment_variables_dict['pin'] = bool(self._environment_variables_dict['pin_node1'])

--- a/benchmark_runner/workloads/stressng_pod.py
+++ b/benchmark_runner/workloads/stressng_pod.py
@@ -1,0 +1,169 @@
+
+import json
+import os
+from datetime import datetime, timezone
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
+from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
+
+
+class StressngPod(WorkloadsOperations):
+    """
+    This class runs stressng workload using direct Job creation (no operator)
+    """
+    def __init__(self):
+        super().__init__()
+        self.__name = ''
+        self.__workload_name = ''
+        self.__es_index = ''
+        self.__kind = ''
+        self.__status = ''
+
+    def _extract_json_from_pod_logs(self, pod_logs: str) -> dict:
+        """
+        Extract parsed JSON result from pod logs.
+        """
+        for line in reversed(pod_logs.strip().splitlines()):
+            line = line.strip()
+            if line.startswith('{') and line.endswith('}'):
+                try:
+                    return json.loads(line)
+                except json.JSONDecodeError:
+                    pass
+        logger.warning("No JSON result found in pod logs")
+        return {}
+
+    def save_error_logs(self):
+        if self._es_host:
+            data_dict = {
+                'run_artifacts_url': os.path.join(
+                    self._run_artifacts_url,
+                    f'{self._get_run_artifacts_hierarchy(workload_name=self._get_workload_file_name(self.__workload_name), is_file=True)}.tar.gz'
+                )
+            }
+            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=data_dict)
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+    @logger_time_stamp
+    def run(self):
+        try:
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.init_prometheus()
+
+            if 'kata' in self._workload:
+                self.__kind = 'kata'
+                self.__name = self._workload.replace('kata', 'pod')
+            else:
+                self.__kind = 'pod'
+                self.__name = self._workload
+
+            self.__workload_name = self._workload.replace('_', '-')
+
+            if self._run_type == 'test_ci':
+                self.__es_index = 'stressng-test-ci-results'
+            else:
+                self.__es_index = 'stressng-results'
+
+            self._environment_variables_dict['kind'] = self.__kind
+
+            self._oc.apply_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+            self._oc.create_async(
+                yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),
+                is_check=True,
+            )
+
+            self._oc.wait_for_pod_create(label=f'app=stressng_workload-{self._trunc_uuid}')
+            self._oc.wait_for_initialized(label=f'app=stressng_workload-{self._trunc_uuid}', label_uuid=False)
+            self._oc.wait_for_ready(label=f'app=stressng_workload-{self._trunc_uuid}', label_uuid=False)
+
+            self.__status = self._oc.wait_for_pod_completed(label=f'app=stressng_workload-{self._trunc_uuid}', label_uuid=False, job=True)
+            self.__status = 'complete' if self.__status else 'failed'
+
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.finalize_prometheus()
+                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+                self._prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
+
+            # Save run artifacts (also saves pod logs to file)
+            run_artifacts_url = self._create_run_artifacts(workload=self.__workload_name)
+
+            # Read pod logs from saved file (already saved by _create_run_artifacts)
+            stressng_pod = self._oc.get_pod(label=f'stressng-pod')
+            log_file = os.path.join(self._run_artifacts_path, stressng_pod)
+            with open(log_file, 'r') as f:
+                pod_logs = f.read()
+
+            if self._es_host:
+                logger.info("Extracting stressng JSON results from pod logs")
+                parsed = self._extract_json_from_pod_logs(pod_logs)
+
+                if parsed:
+                    # Add metadata from benchmark-runner
+                    parsed['uuid'] = self._uuid
+                    parsed['timestamp'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+                    logger.info(f"Uploading stressng results: cpu_bogomips={parsed.get('cpu_bogomips')}, vm_bogomips={parsed.get('vm_bogomips')}")
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=parsed)
+
+                    ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=60)
+                    if ids:
+                        for doc_id in ids:
+                            self._update_elasticsearch_index(
+                                index=self.__es_index,
+                                id=doc_id,
+                                kind=self.__kind,
+                                status=self.__status,
+                                run_artifacts_url=run_artifacts_url,
+                                prometheus_result=self._prometheus_result
+                            )
+                else:
+                    logger.warning("No stressng JSON found in pod logs, uploading minimal metadata")
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status,
+                                                  result={'uuid': self._uuid, 'workload': 'stressng', 'kind': self.__kind, 'run_artifacts_url': run_artifacts_url})
+
+            # Cleanup
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'))
+
+            if self._delete_all:
+                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+        except ElasticSearchDataNotUploaded as err:
+            self.save_error_logs()
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'))
+            raise err
+
+        except Exception as err:
+            stressng_label = f'app=stressng_workload-{self._trunc_uuid}'
+            if self._oc.pod_label_exists(label_name=stressng_label):
+                pod_name = self._oc.get_pod(label_selector=stressng_label)
+                if pod_name:
+                    self._oc.save_pod_log(pod_name=pod_name)
+
+            run_artifacts_url = os.path.join(
+                self._environment_variables_dict.get('run_artifacts_url', ''),
+                f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz'
+            )
+
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=3)
+                if ids:
+                    for doc_id in ids:
+                        self._update_elasticsearch_index(
+                            index=self.__es_index,
+                            id=doc_id,
+                            kind=self.__kind,
+                            status='failed',
+                            run_artifacts_url=run_artifacts_url
+                        )
+                else:
+                    self._upload_to_elasticsearch(
+                        index=self.__es_index,
+                        kind=self.__kind,
+                        status='failed',
+                        result={'run_artifacts_url': run_artifacts_url}
+                    )
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'))
+            raise err

--- a/benchmark_runner/workloads/stressng_vm.py
+++ b/benchmark_runner/workloads/stressng_vm.py
@@ -1,0 +1,207 @@
+
+import json
+import os
+from datetime import datetime, timezone
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
+from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
+
+
+class StressngVM(WorkloadsOperations):
+    """
+    This class runs stressng VM workload using direct VirtualMachine creation (no operator).
+    Cloud-init installs and runs stress-ng inside the VM guest OS.
+    Results are extracted via virtctl ssh/scp.
+    """
+    def __init__(self):
+        super().__init__()
+        self.__name = self._workload
+        self.__workload_name = self._workload.replace('_', '-')
+        self.__es_index = ''
+        self.__kind = 'vm'
+        self.__status = ''
+        self.__vm_name = f'{self.__workload_name}-{self._trunc_uuid}'
+        self.__namespace = self._environment_variables_dict['namespace']
+
+    def save_error_logs(self):
+        if self._es_host:
+            data_dict = {
+                'run_artifacts_url': os.path.join(
+                    self._run_artifacts_url,
+                    f'{self._get_run_artifacts_hierarchy(workload_name=self._get_workload_file_name(self.__workload_name), is_file=True)}.tar.gz'
+                )
+            }
+            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=data_dict)
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+    @logger_time_stamp
+    def run(self):
+        """
+        This method runs the stressng VM workload.
+        Cloud-init handles installing and running stress-ng inside the VM.
+        Results are extracted via virtctl scp.
+        """
+        try:
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.init_prometheus()
+
+            # Set ElasticSearch index
+            if self._run_type == 'test_ci':
+                self.__es_index = 'stressng-test-ci-results'
+            else:
+                self.__es_index = 'stressng-results'
+
+            self._environment_variables_dict['kind'] = self.__kind
+
+            # Create namespace
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+            # Create VirtualMachine (cloud-init will install and run stress-ng)
+            logger.info("Creating stressng VirtualMachine")
+            self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
+
+            # Wait for VM to be ready
+            self._oc.wait_for_vm_create(vm_name=self.__vm_name)
+            self._oc.wait_for_initialized(label=f'app=stressng-vm-{self._trunc_uuid}', workload=self.__workload_name, label_uuid=False)
+            self._oc.wait_for_ready(label=f'app=stressng-vm-{self._trunc_uuid}', workload=self.__workload_name, label_uuid=False)
+
+            logger.info("VirtualMachine is ready, cloud-init will install and run stress-ng inside the VM...")
+
+            # Get cluster name
+            cluster_name = self._oc.get_cluster_name()
+            self._environment_variables_dict['clustername'] = cluster_name
+
+            # Wait for JSON result file (parser runs inside VM after stress-ng completes)
+            local_json_path = os.path.join(self._run_artifacts_path, f'{self.__vm_name}_stressng.json')
+            workload_complete = self._virtctl.wait_for_vm_workload_completed(
+                vm_name=self.__vm_name,
+                file_path='/tmp/stressng.json',
+                local_path=local_json_path,
+                namespace=self.__namespace,
+                key_path=self._ssh_key_path,
+                timeout=self._timeout
+            )
+
+            self.__status = 'complete' if workload_complete else 'failed'
+
+            # Read parsed JSON
+            parsed_metrics = None
+            if workload_complete and os.path.exists(local_json_path):
+                with open(local_json_path, 'r') as f:
+                    parsed_metrics = json.load(f)
+                logger.info(f"Parsed metrics from VM: {parsed_metrics}")
+            else:
+                logger.warning("Failed to extract stress-ng JSON from VM")
+
+            # Create vm logs
+            logger.info("Creating VM logs")
+            vm_name = self._create_vm_log(labels=[self.__vm_name])
+
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.finalize_prometheus()
+                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+                self._prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
+
+            # Save run artifacts logs
+            run_artifacts_url = self._create_run_artifacts(labels=[self.__vm_name])
+
+            if self._es_host:
+                if parsed_metrics:
+                    # Build full metrics dict with metadata + parsed values from VM
+                    metrics = {
+                        'uuid': self._uuid,
+                        'workload': 'stressng',
+                        'kind': 'vm',
+                        'user': self._environment_variables_dict.get('test_user', 'user'),
+                        'run_id': self._environment_variables_dict.get('run_id', 'NA'),
+                        'cluster_name': self._environment_variables_dict.get('clustername', ''),
+                        'runtype': self._environment_variables_dict.get('runtype', 'all'),
+                        'timeout': self._environment_variables_dict.get('timeout', 5),
+                        'cpu_stressors': self._environment_variables_dict.get('cpu_stressors', 1),
+                        'cpu_percentage': self._environment_variables_dict.get('cpu_percentage', 100),
+                        'vm_stressors': self._environment_variables_dict.get('vm_stressors', 1),
+                        'vm_bytes': self._environment_variables_dict.get('vm_bytes', '256M'),
+                        'mem_stressors': self._environment_variables_dict.get('mem_stressors', 1),
+                        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+                        'cpu': parsed_metrics.get('cpu', 0.0),
+                        'cpu_bogomips': parsed_metrics.get('cpu_bogomips', 0.0),
+                        'vm': parsed_metrics.get('vm', 0.0),
+                        'vm_bogomips': parsed_metrics.get('vm_bogomips', 0.0),
+                        'memcpy': parsed_metrics.get('memcpy', 0.0),
+                        'bogo_ops': parsed_metrics.get('bogo_ops', 0.0),
+                    }
+
+                    logger.info(f"Uploading stress-ng results: cpu_bogomips={metrics['cpu_bogomips']}, vm_bogomips={metrics['vm_bogomips']}")
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=metrics)
+
+                    ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=60)
+
+                    if ids:
+                        for doc_id in ids:
+                            self._update_elasticsearch_index(
+                                index=self.__es_index,
+                                id=doc_id,
+                                kind=self.__kind,
+                                status=self.__status,
+                                run_artifacts_url=run_artifacts_url,
+                                prometheus_result=self._prometheus_result
+                            )
+                else:
+                    logger.warning("No stress-ng JSON captured, uploading minimal metadata")
+                    minimal_data = {
+                        'uuid': self._uuid,
+                        'workload': 'stressng',
+                        'kind': self.__kind,
+                        'run_artifacts_url': run_artifacts_url
+                    }
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=minimal_data)
+
+            # Cleanup: delete VirtualMachine
+            self._oc.delete_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
+
+            # Delete namespace
+            if self._delete_all:
+                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+        except ElasticSearchDataNotUploaded as err:
+            self.save_error_logs()
+            self._oc.delete_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
+            raise err
+
+        except Exception as err:
+            # Save run artifacts logs
+            if self._oc.vm_exists(vm_name=self.__vm_name):
+                vm_name = self._create_vm_log(labels=[self.__vm_name])
+
+            run_artifacts_url = os.path.join(
+                self._environment_variables_dict.get('run_artifacts_url', ''),
+                f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz'
+            )
+
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=3)
+                if ids:
+                    for doc_id in ids:
+                        self._update_elasticsearch_index(
+                            index=self.__es_index,
+                            id=doc_id,
+                            kind=self.__kind,
+                            status='failed',
+                            run_artifacts_url=run_artifacts_url
+                        )
+                else:
+                    data_dict = {
+                        'run_artifacts_url': run_artifacts_url
+                    }
+                    self._upload_to_elasticsearch(
+                        index=self.__es_index,
+                        kind=self.__kind,
+                        status='failed',
+                        result=data_dict
+                    )
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+            # Cleanup on error
+            self._oc.delete_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__vm_name)
+            raise err

--- a/benchmark_runner/workloads/uperf_pod.py
+++ b/benchmark_runner/workloads/uperf_pod.py
@@ -1,0 +1,219 @@
+
+import json
+import os
+import re
+import time
+from datetime import datetime, timezone
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
+from benchmark_runner.common.template_operations.template_operations import TemplateOperations
+from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
+
+
+class UperfPod(WorkloadsOperations):
+    """
+    This class runs uperf workload using direct Job creation (no operator)
+    """
+    def __init__(self):
+        super().__init__()
+        self.__name = ''
+        self.__workload_name = self._workload.replace('_', '-')
+        self.__es_index = ''
+        self.__kind = ''
+        self.__status = ''
+        self.__template_ops = TemplateOperations(workload=self._workload)
+
+    def _extract_json_from_pod_logs(self, pod_logs: str) -> list:
+        """
+        Extract parsed JSON results from pod logs.
+        """
+        results = []
+        for line in pod_logs.strip().splitlines():
+            line = line.strip()
+            if line.startswith('{') and line.endswith('}'):
+                try:
+                    results.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        if not results:
+            logger.warning("No JSON results found in pod logs")
+        return results
+
+    def save_error_logs(self):
+        if self._es_host:
+            data_dict = {
+                'run_artifacts_url': os.path.join(
+                    self._run_artifacts_url,
+                    f'{self._get_run_artifacts_hierarchy(workload_name=self._get_workload_file_name(self.__workload_name), is_file=True)}.tar.gz'
+                )
+            }
+            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=data_dict)
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+    @logger_time_stamp
+    def run(self):
+        try:
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.init_prometheus()
+
+            if 'kata' in self._workload:
+                self.__kind = 'kata'
+                self.__name = self._workload.replace('kata', 'pod')
+            else:
+                self.__kind = 'pod'
+                self.__name = self._workload
+
+            if self._run_type == 'test_ci':
+                self.__es_index = 'uperf-test-ci-results'
+            else:
+                self.__es_index = 'uperf-results'
+
+            self._environment_variables_dict['kind'] = self.__kind
+
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+            logger.info("Creating uperf server job")
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_server.yaml'))
+
+            self._oc.wait_for_pod_create(pod_name='uperf-server')
+
+            server_name = self._environment_variables_dict.get('pin_node1', '')
+            if server_name:
+                label = f'app=uperf-bench-server-0-{self._trunc_uuid}'
+            else:
+                label = f'role=server'
+            self._oc.wait_for_initialized(label=label, workload=self.__workload_name, label_uuid=False)
+            self._oc.wait_for_ready(label=label, workload=self.__workload_name, label_uuid=False)
+
+            logger.info("Uperf server is ready, getting server IP")
+
+            namespace = self._environment_variables_dict['namespace']
+            server_label = f'app=uperf-bench-server-0-{self._trunc_uuid}'
+            server_ip = self._oc.get_pod_ip(label=server_label, namespace=namespace)
+            logger.info(f"Server IP: {server_ip}")
+
+            server_node = self._oc.get_pod_node(label=server_label, namespace=namespace)
+            logger.info(f"Server Node: {server_node}")
+
+            cluster_name = self._oc.get_cluster_name()
+
+            self._environment_variables_dict['server_ip'] = server_ip
+            self._environment_variables_dict['server_node'] = server_node
+            self._environment_variables_dict['clustername'] = cluster_name
+
+            time.sleep(5)
+
+            self.__template_ops.set_environment_variables(self._environment_variables_dict)
+            self.__template_ops.generate_yamls()
+
+            logger.info(f"Creating client job with server IP {server_ip}")
+
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_client.yaml'))
+
+            self._oc.wait_for_pod_create(pod_name='uperf-client')
+            self._oc.wait_for_initialized(label='app=uperf-bench-client', workload=self.__workload_name, label_uuid=False)
+            self._oc.wait_for_ready(label='app=uperf-bench-client', workload=self.__workload_name, label_uuid=False)
+
+            self.__status = self._oc.wait_for_pod_completed(label='app=uperf-bench-client', workload=self.__workload_name, label_uuid=False, job=True)
+            self.__status = 'complete' if self.__status else 'failed'
+
+            # Get client pod info
+            logger.info("Extracting uperf results from client pod logs")
+            client_pod = self._oc.get_pod(label='uperf-client')
+            client_node = self._oc.get_pod_node(pod_name=client_pod, namespace=namespace)
+            client_ip = self._oc.get_pod_ip(pod_name=client_pod, namespace=namespace)
+            logger.info(f"Client Node: {client_node}, Client IP: {client_ip}")
+
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.finalize_prometheus()
+                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+                self._prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
+
+            # Save run artifacts (also saves pod logs to file)
+            run_artifacts_url = self._create_run_artifacts(workload=self.__workload_name, labels=['uperf-client', 'uperf-server'])
+
+            # Read pod logs from saved file (already saved by _create_run_artifacts)
+            log_file = os.path.join(self._run_artifacts_path, client_pod)
+            with open(log_file, 'r') as f:
+                pod_logs = f.read()
+
+            if self._es_host:
+                logger.info("Extracting uperf JSON results from pod logs")
+                parsed_results = self._extract_json_from_pod_logs(pod_logs)
+
+                if parsed_results:
+                    logger.info(f"Uploading {len(parsed_results)} uperf results to ElasticSearch")
+                    for parsed in parsed_results:
+                        # Add metadata from benchmark-runner
+                        parsed['uuid'] = self._uuid
+                        parsed['timestamp'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+                        parsed['uperf_ts'] = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
+                        throughput_gbps = round((parsed.get('norm_byte', 0) * 8) / (1024**3), 4) if parsed.get('norm_byte', 0) > 0 else 0
+                        logger.info(f"  {parsed.get('test_type')}-{parsed.get('protocol')}-{parsed.get('message_size')}-{parsed.get('num_threads')}: "
+                                    f"throughput={throughput_gbps}Gbps, latency={parsed.get('norm_ltcy')}ms")
+                        self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=parsed)
+
+                    ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=60)
+                    if ids:
+                        for doc_id in ids:
+                            self._update_elasticsearch_index(
+                                index=self.__es_index,
+                                id=doc_id,
+                                kind=self.__kind,
+                                status=self.__status,
+                                run_artifacts_url=run_artifacts_url,
+                                prometheus_result=self._prometheus_result
+                            )
+                else:
+                    logger.warning("No uperf JSON found in pod logs, uploading minimal metadata")
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status,
+                                                  result={'uuid': self._uuid, 'workload': 'uperf', 'kind': self.__kind, 'run_artifacts_url': run_artifacts_url})
+
+            # Cleanup
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_client.yaml'))
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_server.yaml'))
+
+            if self._delete_all:
+                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+        except ElasticSearchDataNotUploaded as err:
+            self.save_error_logs()
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_client.yaml'))
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_server.yaml'))
+            raise err
+
+        except Exception as err:
+            if self._oc.pod_exists(pod_name='uperf-server'):
+                self._create_pod_log(pod='uperf-server')
+            if self._oc.pod_exists(pod_name='uperf-client'):
+                self._create_pod_log(pod='uperf-client')
+
+            run_artifacts_url = os.path.join(
+                self._environment_variables_dict.get('run_artifacts_url', ''),
+                f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz'
+            )
+
+            if self._es_host:
+                ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=3)
+                if ids:
+                    for doc_id in ids:
+                        self._update_elasticsearch_index(
+                            index=self.__es_index,
+                            id=doc_id,
+                            kind=self.__kind,
+                            status='failed',
+                            run_artifacts_url=run_artifacts_url
+                        )
+                else:
+                    self._upload_to_elasticsearch(
+                        index=self.__es_index,
+                        kind=self.__kind,
+                        status='failed',
+                        result={'run_artifacts_url': run_artifacts_url}
+                    )
+                    self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_client.yaml'))
+            self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_server.yaml'))
+            raise err

--- a/benchmark_runner/workloads/uperf_vm.py
+++ b/benchmark_runner/workloads/uperf_vm.py
@@ -1,0 +1,269 @@
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+
+from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
+from benchmark_runner.common.template_operations.template_operations import TemplateOperations
+from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
+
+
+class UperfVM(WorkloadsOperations):
+    """
+    This class runs uperf VM workload using direct VirtualMachine creation (no operator).
+    Cloud-init installs and runs uperf inside the VM guest OS.
+    Results are extracted via virtctl scp.
+    """
+    def __init__(self):
+        super().__init__()
+        self.__name = self._workload
+        self.__workload_name = self._workload.replace('_', '-')
+        self.__es_index = ''
+        self.__kind = 'vm'
+        self.__status = ''
+        self.__server_vm_name = f'uperf-server-{self._trunc_uuid}'
+        self.__client_vm_name = f'uperf-client-{self._trunc_uuid}'
+        self.__template_ops = TemplateOperations(workload=self._workload)
+        self.__namespace = self._environment_variables_dict['namespace']
+
+    def save_error_logs(self):
+        if self._es_host:
+            data_dict = {
+                'run_artifacts_url': os.path.join(
+                    self._run_artifacts_url,
+                    f'{self._get_run_artifacts_hierarchy(workload_name=self._get_workload_file_name(self.__workload_name), is_file=True)}.tar.gz'
+                )
+            }
+            self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status='failed', result=data_dict)
+            self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid)
+
+    @logger_time_stamp
+    def run(self):
+        """
+        This method runs the uperf VM workload.
+        Cloud-init handles installing and running uperf inside the VMs.
+        Results are extracted via virtctl scp.
+        """
+        try:
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.init_prometheus()
+
+            # Set ElasticSearch index
+            if self._run_type == 'test_ci':
+                self.__es_index = 'uperf-test-ci-results'
+            else:
+                self.__es_index = 'uperf-results'
+
+            self._environment_variables_dict['kind'] = self.__kind
+
+            # Create namespace
+            self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+            # Create VirtualMachines (server + client in one YAML)
+            logger.info("Creating uperf server and client VirtualMachines")
+            self._oc.create_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__server_vm_name)
+
+            # Wait for server VM to be ready
+            logger.info("Waiting for uperf server VM")
+            self._oc.wait_for_vm_create(vm_name=self.__server_vm_name)
+            self._oc.wait_for_initialized(label=f'app=uperf-server-{self._trunc_uuid}', workload=self.__workload_name, label_uuid=False)
+            self._oc.wait_for_ready(label=f'app=uperf-server-{self._trunc_uuid}', workload=self.__workload_name, label_uuid=False)
+
+            logger.info("Server VM is ready, getting server IP")
+
+            # Get server VMI IP
+            server_ip = self._oc.get_vmi_ip(namespace=self.__namespace, vm_name=self.__server_vm_name)
+            if not server_ip:
+                raise RuntimeError(f"Failed to get server VMI IP")
+            logger.info(f"Server VMI IP: {server_ip}")
+
+            # Get server VMI node
+            server_node = self._oc.get_vm_node(namespace=self.__namespace, vm_name=self.__server_vm_name)
+            logger.info(f"Server VMI Node: {server_node}")
+
+            # Get cluster name
+            cluster_name = self._oc.get_cluster_name()
+
+            # Update environment variables with server info for client template
+            self._environment_variables_dict['server_ip'] = server_ip
+            self._environment_variables_dict['server_node'] = server_node
+            self._environment_variables_dict['clustername'] = cluster_name
+
+            # Give server a moment to fully start uperf listener
+            time.sleep(5)
+
+            # Re-generate YAML with server IP
+            self.__template_ops.set_environment_variables(self._environment_variables_dict)
+            self.__template_ops.generate_yamls()
+            logger.info(f"Regenerated client VM YAML with server IP: {server_ip}")
+
+            # Delete the client VM by name (not by YAML, which would delete server too)
+            logger.info("Deleting client VM (created with empty server_ip) before recreating...")
+            self._oc.delete_vm_sync(vm_name=self.__client_vm_name, namespace=self.__namespace)
+            self._oc.wait_for_vm_delete(vm_name=self.__client_vm_name, namespace=self.__namespace)
+
+            # Apply combined YAML (Secret + Server VM + Client VM)
+            logger.info(f"Creating client VM with server IP: {server_ip}")
+            yaml_path = os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml')
+            self._oc.apply_async(yaml=yaml_path)
+
+            # Wait for client VM to be ready
+            logger.info("Waiting for uperf client VM")
+            self._oc.wait_for_vm_create(vm_name=self.__client_vm_name)
+            self._oc.wait_for_initialized(label=f'app=uperf-client-{self._trunc_uuid}', workload=self.__workload_name, label_uuid=False)
+            self._oc.wait_for_ready(label=f'app=uperf-client-{self._trunc_uuid}', workload=self.__workload_name, label_uuid=False)
+
+            # Get client VMI IP and node
+            client_ip = self._oc.get_vmi_ip(namespace=self.__namespace, vm_name=self.__client_vm_name)
+            client_node = self._oc.get_vm_node(namespace=self.__namespace, vm_name=self.__client_vm_name)
+            logger.info(f"Client VMI IP: {client_ip}, Client VMI Node: {client_node}")
+            self._environment_variables_dict['client_ips'] = client_ip + ' ' if client_ip else ''
+            self._environment_variables_dict['client_node'] = client_node
+
+            # Wait for JSON result file (parser runs inside VM after uperf completes)
+            local_json_path = os.path.join(self._run_artifacts_path, f'{self.__client_vm_name}_uperf.json')
+            workload_complete = self._virtctl.wait_for_vm_workload_completed(
+                vm_name=self.__client_vm_name,
+                file_path='/tmp/uperf.json',
+                local_path=local_json_path,
+                namespace=self.__namespace,
+                key_path=self._ssh_key_path,
+                timeout=self._timeout
+            )
+
+            self.__status = 'complete' if workload_complete else 'failed'
+
+            # Read parsed JSON (array of test results)
+            parsed_results = None
+            if workload_complete and os.path.exists(local_json_path):
+                with open(local_json_path, 'r') as f:
+                    parsed_results = json.load(f)
+                logger.info(f"Parsed {len(parsed_results)} uperf test results from VM")
+            else:
+                logger.warning("Failed to extract uperf JSON from VM")
+
+            # Create vm logs
+            logger.info("Creating VM logs")
+            vm_name = self._create_vm_log(labels=[self.__server_vm_name, self.__client_vm_name])
+
+            if self._enable_prometheus_snapshot:
+                self._prometheus_metrics_operation.finalize_prometheus()
+                metric_results = self._prometheus_metrics_operation.run_prometheus_queries()
+                self._prometheus_result = self._prometheus_metrics_operation.parse_prometheus_metrics(data=metric_results)
+
+            # Save run artifacts logs
+            run_artifacts_url = self._create_run_artifacts(labels=[self.__server_vm_name, self.__client_vm_name])
+
+            # Upload results to ElasticSearch
+            if self._es_host:
+                if parsed_results:
+                    logger.info(f"Uploading {len(parsed_results)} uperf results to ElasticSearch")
+                    for parsed in parsed_results:
+                        # Build full metrics dict: metadata + parsed values from VM
+                        metrics = {
+                            'uuid': self._uuid,
+                            'workload': 'uperf',
+                            'kind': 'vm',
+                            'test_type': parsed.get('test_type', 'stream'),
+                            'protocol': parsed.get('protocol', 'tcp'),
+                            'message_size': parsed.get('message_size', 64),
+                            'read_message_size': parsed.get('message_size', 64),
+                            'num_threads': parsed.get('num_threads', 1),
+                            'bytes': parsed.get('bytes', 0),
+                            'ops': parsed.get('ops', 0),
+                            'norm_byte': parsed.get('norm_byte', 0),
+                            'norm_ops': parsed.get('norm_ops', 0),
+                            'norm_ltcy': parsed.get('norm_ltcy', 0.0),
+                            'duration': parsed.get('duration', 0),
+                            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+                            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+                            'user': self._environment_variables_dict.get('test_user', 'user'),
+                            'run_id': self._environment_variables_dict.get('run_id', 'NA'),
+                            'cluster_name': self._environment_variables_dict.get('clustername', ''),
+                            'iteration': 0,
+                            'client_ips': self._environment_variables_dict.get('client_ips', ''),
+                            'remote_ip': server_ip,
+                            'service_ip': self._environment_variables_dict.get('service_ip', 'False'),
+                            'service_type': self._environment_variables_dict.get('service_type', ''),
+                            'port': self._environment_variables_dict.get('port', '30000'),
+                            'client_node': self._environment_variables_dict.get('client_node', ''),
+                            'server_node': server_node,
+                            'num_pairs': self._environment_variables_dict.get('num_pairs', ''),
+                            'multus_client': self._environment_variables_dict.get('multus_client', ''),
+                            'networkpolicy': self._environment_variables_dict.get('networkpolicy', ''),
+                            'density': self._environment_variables_dict.get('density', ''),
+                            'nodes_in_iter': self._environment_variables_dict.get('nodes_in_iter', ''),
+                            'step_size': self._environment_variables_dict.get('step_size', ''),
+                            'colocate': self._environment_variables_dict.get('colocate', ''),
+                            'density_range': self._environment_variables_dict.get('density_range', ''),
+                            'node_range': self._environment_variables_dict.get('node_range', ''),
+                            'pod_id': '',
+                            'hostnetwork': self._environment_variables_dict.get('hostnetwork', 'False')
+                        }
+                        throughput_gbps = round((metrics['norm_byte'] * 8) / (1024**3), 4) if metrics['norm_byte'] > 0 else 0
+                        logger.info(f"  {metrics['test_type']}-{metrics['protocol']}-{metrics['message_size']}-{metrics['num_threads']}: "
+                                    f"throughput={throughput_gbps}Gbps, latency={metrics['norm_ltcy']}ms")
+                        self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=metrics)
+
+                    ids = self._verify_elasticsearch_data_uploaded(index=self.__es_index, uuid=self._uuid, timeout=60)
+
+                    if ids:
+                        for doc_id in ids:
+                            self._update_elasticsearch_index(
+                                index=self.__es_index,
+                                id=doc_id,
+                                kind=self.__kind,
+                                status=self.__status,
+                                run_artifacts_url=run_artifacts_url,
+                                prometheus_result=self._prometheus_result
+                            )
+                else:
+                    logger.warning("Failed to extract uperf JSON from client VM, uploading minimal metadata")
+                    minimal_data = {
+                        'uuid': self._uuid,
+                        'workload': 'uperf',
+                        'kind': self.__kind,
+                        'run_artifacts_url': run_artifacts_url
+                    }
+                    self._upload_to_elasticsearch(index=self.__es_index, kind=self.__kind, status=self.__status, result=minimal_data)
+
+            # Cleanup: delete VirtualMachines
+            self._oc.delete_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__server_vm_name)
+
+            # Delete namespace
+            if self._delete_all:
+                self._oc.delete_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+
+        except ElasticSearchDataNotUploaded as err:
+            # Cleanup on ES upload failure
+            self._oc.delete_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__server_vm_name)
+            raise err
+        except Exception as err:
+            # Save run artifacts logs
+            if self._oc.vm_exists(vm_name=self.__server_vm_name) or self._oc.vm_exists(vm_name=self.__client_vm_name):
+                vm_name = self._create_vm_log(labels=[self.__server_vm_name, self.__client_vm_name])
+
+            run_artifacts_url = os.path.join(
+                self._environment_variables_dict.get('run_artifacts_url', ''),
+                f'{self._get_run_artifacts_hierarchy(workload_name=self.__workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz'
+            )
+
+            if self._es_host:
+                data_dict = {
+                    'uuid': self._uuid,
+                    'workload': 'uperf',
+                    'kind': self.__kind,
+                    'run_artifacts_url': run_artifacts_url
+                }
+                self._upload_to_elasticsearch(
+                    index=self.__es_index,
+                    kind=self.__kind,
+                    status='failed',
+                    result=data_dict
+                )
+
+            # Cleanup on error
+            self._oc.delete_vm_sync(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'), vm_name=self.__server_vm_name)
+            raise err

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -51,6 +51,7 @@ class WorkloadsOperations:
         self._run_artifacts_url = self._environment_variables_dict.get('run_artifacts_url', '')
         self._pin_node1 = self._environment_variables_dict.get('pin_node1', '')
         self._pin_node2 = self._environment_variables_dict.get('pin_node2', '')
+        self._pin_node_benchmark_operator = self._environment_variables_dict.get('pin_node_benchmark_operator', '')
         self._es_host = self._environment_variables_dict.get('elasticsearch', '')
         self._es_port = self._environment_variables_dict.get('elasticsearch_port', '')
         self._es_user = self._environment_variables_dict.get('elasticsearch_user', '')
@@ -87,13 +88,21 @@ class WorkloadsOperations:
                                                            es_password=self._es_password,
                                                            es_url_protocol=self._es_url_protocol,
                                                            timeout=self._timeout)
-        # Generate templates class
-        self._template = TemplateOperations(workload=self._workload)
-
+        # Generate templates class - need Virtctl first for SSH key generation
         # get oc instance
         if WorkloadsOperations.oc is None:
             self._oc = self.get_oc(kubeadmin_password=self._kubeadmin_password)
         self._virtctl = Virtctl()
+
+        # Generate SSH key for VM workloads (needed before template generation)
+        if '_vm' in self._workload:
+            ssh_key_dir = os.path.join(self._run_artifacts_path, 'ssh')
+            os.makedirs(ssh_key_dir, exist_ok=True)
+            self._ssh_key_path = self._virtctl.generate_ssh_key(key_path=os.path.join(ssh_key_dir, 'vm_key'))
+            self._environment_variables_dict['ssh_public_key'] = self._virtctl.get_ssh_public_key(self._ssh_key_path)
+            self._environment_variables_dict['ssh_key_path'] = self._ssh_key_path
+
+        self._template = TemplateOperations(workload=self._workload)
 
         # Prometheus Snapshot
         self._prometheus_result = {}
@@ -316,6 +325,22 @@ class WorkloadsOperations:
             result_list.append(dict(line_dict))
         return result_list
 
+    def _create_run_artifacts(self, workload: str = '', labels: list = None):
+        """
+        This method creates pod logs for direct pod workloads (no operator)
+        :param workload: workload name
+        :param labels: list of pod labels - use when pod labels differ from workload name
+        :return: run artifacts url
+        """
+        # Create pod logs for workload pods
+        if labels:
+            for pod_label in labels:
+                self._create_pod_log(pod=pod_label)
+        elif workload:
+            self._create_pod_log(pod=workload)
+        workload_name = self._workload.replace('_', '-')
+        return os.path.join(self._environment_variables_dict.get('run_artifacts_url', ''), f'{self._get_run_artifacts_hierarchy(workload_name=workload_name, is_file=True)}-{self._time_stamp_format}.tar.gz')
+
     def __make_run_artifacts_tarfile(self, workload: str):
         """
         This method compresses the run artifacts directory and returns the compressed file path.
@@ -425,8 +450,11 @@ class WorkloadsOperations:
                     'vm_os_version':  self._product_versions.get('db_vm_os_version', 'centos-stream9'),
                     'ci_date': datetime.now().strftime(date_format),
                     'uuid': self._uuid,
+                    'run_id': 'NA',
                     'pin_node1': self._pin_node1,
                     'pin_node2': self._pin_node2,
+                    'pin_node_benchmark_operator': self._pin_node_benchmark_operator,
+                    'storage_type': self._storage_type,
                     # display -1 when 0,1 for avoiding conflict with 0/1 status code
                     'odf_disk_count': -1 if self._oc.get_odf_disk_count() in {0, 1} else self._oc.get_odf_disk_count()
 }
@@ -445,8 +473,10 @@ class WorkloadsOperations:
         if 'win' in self._workload:
             metadata.update({'vm_os_version': self._windows_os})
         # for hammerdb
+        if database:
+            metadata.update({'hammerdb_version': self._product_versions.get('hammerdb', 4.0)})
         if database == 'mssql':
-            metadata.update({'db_type': 'mssql', 'db_version': self._product_versions.get('mssql', 2022), 'storage_type':self._storage_type})
+            metadata.update({'db_type': 'mssql', 'db_version': self._product_versions.get('mssql', 2022)})
         if self._test_name:
             metadata.update({'test_name': self._test_name})
         if result:
@@ -485,7 +515,7 @@ class WorkloadsOperations:
         self._es_operations.upload_to_elasticsearch(index=index, data=self.__get_metadata(kind=kind, status=status, result=result))
 
     @logger_time_stamp
-    def _update_elasticsearch_index(self, index: str, id: str, kind: str, status: str, run_artifacts_url: str, database: str = '', vm_name: str = '', data_updated: bool = False):
+    def _update_elasticsearch_index(self, index: str, id: str, kind: str, status: str, run_artifacts_url: str, database: str = '', vm_name: str = '', data_updated: bool = False, prometheus_result: dict = None):
         """
         This method updates elasticsearch id
         :param index:
@@ -495,22 +525,24 @@ class WorkloadsOperations:
         :param status:
         :param run_artifacts_url:
         :param data_updated: check if data was updated
+        :param prometheus_result:
         :return:
         """
-        metadata = self.__get_metadata(kind=kind, database=database, status=status, run_artifacts_url=run_artifacts_url)
+        metadata = self.__get_metadata(kind=kind, database=database, status=status, run_artifacts_url=run_artifacts_url, prometheus_result=prometheus_result)
         if vm_name:
             metadata.update({'vm_name': vm_name})
             metadata.update({'data_updated': data_updated})
         self._es_operations.update_elasticsearch_index(index=index, id=id, metadata=metadata)
 
-    def _verify_elasticsearch_data_uploaded(self, index: str, uuid: str):
+    def _verify_elasticsearch_data_uploaded(self, index: str, uuid: str, timeout: int = None):
         """
         This method verifies that elasticsearch data was uploaded
         :param index:
         :param uuid:
+        :param timeout:
         :return:
         """
-        self._es_operations.verify_elasticsearch_data_uploaded(index=index, uuid=uuid)
+        return self._es_operations.verify_elasticsearch_data_uploaded(index=index, uuid=uuid, timeout=timeout)
 
     def __parse_duration(self, value):
         try:
@@ -519,14 +551,12 @@ class WorkloadsOperations:
             return None
 
     @logger_time_stamp
-    def update_ci_status(self, status: str, ci_minutes_time: int, benchmark_runner_id: str, benchmark_operator_id: str, benchmark_wrapper_id: str, ocp_install_minutes_time: int = 0, ocp_resource_install_minutes_time: int = 0):
+    def update_ci_status(self, status: str, ci_minutes_time: int, benchmark_runner_id: str, ocp_install_minutes_time: int = 0, ocp_resource_install_minutes_time: int = 0):
         """
         This method updates ci status Pass/Failed
         :param status: Pass/Failed
         :param ci_minutes_time: ci time in minutes
         :param benchmark_runner_id: benchmark_runner last repository commit id
-        :param benchmark_operator_id: benchmark_operator last repository commit id
-        :param benchmark_wrapper_id: benchmark_wrapper last repository commit id
         :param ocp_install_minutes_time: ocp install minutes time, default 0 because ocp install run once a week
         :param ocp_resource_install_minutes_time: ocp install minutes time, default 0 because ocp install run once a week
         :return:
@@ -542,7 +572,7 @@ class WorkloadsOperations:
         if ocp_resource_install_minutes_time != 0:
             bm_operations = BareMetalOperations(user=self._environment_variables_dict.get('provision_user', ''))
             ocp_install_minutes_time = bm_operations.get_ocp_install_time()
-        metadata.update({'status': status, 'status#': status_dict[status], 'ci_minutes_time': ci_minutes_time, 'benchmark_runner_id': benchmark_runner_id, 'benchmark_operator_id': benchmark_operator_id, 'benchmark_wrapper_id': benchmark_wrapper_id, 'ocp_install_minutes_time': ocp_install_minutes_time, 'ocp_resource_install_minutes_time': ocp_resource_install_minutes_time, 'upgrade_masters_duration_seconds': self.__parse_duration(self._upgrade_masters_duration_seconds), 'upgrade_workers_duration_seconds': self.__parse_duration(self._upgrade_workers_duration_seconds)})
+        metadata.update({'status': status, 'status#': status_dict[status], 'ci_minutes_time': ci_minutes_time, 'benchmark_runner_id': benchmark_runner_id, 'ocp_install_minutes_time': ocp_install_minutes_time, 'ocp_resource_install_minutes_time': ocp_resource_install_minutes_time, 'upgrade_masters_duration_seconds': self.__parse_duration(self._upgrade_masters_duration_seconds), 'upgrade_workers_duration_seconds': self.__parse_duration(self._upgrade_workers_duration_seconds)})
         self._es_operations.upload_to_elasticsearch(index=es_index, data=metadata)
 
     @logger_time_stamp

--- a/docs/source/podman.md
+++ b/docs/source/podman.md
@@ -20,7 +20,7 @@ Choose one from the following list:
 
 Not mandatory:
 
-**auto:** NAMESPACE=benchmark-operator [ The default namespace is benchmark-operator ]
+**auto:** NAMESPACE=benchmark-runner [ The default namespace is benchmark-runner ]
 
 **auto:** ODF_PVC=True [ True=ODF PVC storage, False=Ephemeral storage, default True ]
 
@@ -31,8 +31,6 @@ Not mandatory:
 **auto:** RUNNER_PATH=/tmp [ The default work space is /tmp ]
 
 **optional:** KUBEADMIN_PASSWORD=$KUBEADMIN_PASSWORD
-
-**optional:** PIN_NODE_BENCHMARK_OPERATOR=$PIN_NODE_BENCHMARK_OPERATOR [node selector for benchmark operator pod]
 
 **optional:** PIN_NODE1=$PIN_NODE1 [node1 selector for running the workload]
 
@@ -57,13 +55,12 @@ Not mandatory:
 For example:
 
 ```sh
-podman run --rm -e WORKLOAD="hammerdb_pod_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE_BENCHMARK_OPERATOR="node_name-0" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
+podman run --rm -e WORKLOAD="hammerdb_pod_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
 ```
 or
 ```sh
-docker run --rm -e WORKLOAD="hammerdb_vm_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE_BENCHMARK_OPERATOR="node_name-0" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
+docker run --rm -e WORKLOAD="hammerdb_vm_mariadb" -e KUBEADMIN_PASSWORD="1234" -e PIN_NODE1="node_name-1" -e PIN_NODE2="node_name-2" -e log_level=INFO -v /root/.kube/config:/root/.kube/config --privileged quay.io/benchmark-runner/benchmark-runner:latest
 ```
 SAVE RUN ARTIFACTS LOCAL:
 1. add `-e SAVE_ARTIFACTS_LOCAL='True'` or `--save-artifacts-local=true`
 2. add `-v /tmp/benchmark-runner-run-artifacts:/tmp/benchmark-runner-run-artifacts`
-3. git clone -b v1.0.3 https://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator

--- a/tests/integration/benchmark_runner/common/virtctl/test_virtctl_benchmark_runner.py
+++ b/tests/integration/benchmark_runner/common/virtctl/test_virtctl_benchmark_runner.py
@@ -1,6 +1,7 @@
 
 # Tests that run benchmark-runner workloads
 
+import tempfile
 import pytest
 from benchmark_runner.common.oc.oc import OC
 from benchmark_runner.common.virtctl.virtctl import Virtctl
@@ -48,9 +49,11 @@ def before_after_each_test_fixture():
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
     oc.delete_namespace(namespace=test_environment_variable['namespace'])
     __generate_yamls(workload='vdbench')
+    __generate_yamls(workload='stressng', kind='vm_direct')
     yield
     # After all tests
     __delete_test_objects(workload='vdbench')
+    __delete_test_objects(workload='stressng', kind='vm_direct')
     oc.delete_namespace(namespace=test_environment_variable['namespace'])
     # revert to defaults namespace
     test_environment_variable['namespace'] = 'benchmark-operator'
@@ -77,3 +80,74 @@ def test_benchmark_runner_vm_create_ready_stop_start_expose_delete():
     assert oc.get_nodes_addresses()[vm_node]
     assert oc.get_exposed_vm_port(vm_name=vm_name, namespace=test_environment_variable['namespace'])
     assert oc.delete_vm_sync(yaml=os.path.join(f'{templates_path}', 'vdbench_vm.yaml'), vm_name=vm_name, namespace=test_environment_variable['namespace'], timeout=600)
+
+
+def test_virtctl_generate_ssh_key():
+    """
+    This method tests generate_ssh_key and get_ssh_public_key
+    """
+    virtctl = Virtctl()
+    key_path = os.path.join(tempfile.mkdtemp(), 'test_key')
+    result = virtctl.generate_ssh_key(key_path=key_path)
+    assert result == key_path
+    assert os.path.exists(key_path)
+    assert os.path.exists(f'{key_path}.pub')
+    pub_key = virtctl.get_ssh_public_key(key_path=key_path)
+    assert pub_key.startswith('ssh-rsa ')
+
+
+def test_virtctl_ssh_ready_and_wait():
+    """
+    This method tests virtctl_ssh and wait_for_vm_workload_completed
+    on a stressng VM with SSH key injected via cloud-init
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    virtctl = Virtctl()
+    vm_name = 'stressng-vm-test123'
+    namespace = test_environment_variable['namespace']
+
+    # Generate SSH key
+    key_path = os.path.join(tempfile.mkdtemp(), 'vm_key')
+    virtctl.generate_ssh_key(key_path=key_path)
+    pub_key = virtctl.get_ssh_public_key(key_path=key_path)
+
+    # Read template source and inject SSH key, write as rendered YAML
+    template_file = os.path.join(f'{templates_path}', 'stressng_vm_direct_template.yaml')
+    vm_yaml = os.path.join(f'{templates_path}', 'stressng_vm_direct_ssh.yaml')
+    with open(template_file, 'r') as f:
+        content = f.read()
+    content = content.replace('ssh_pwauth: true', f'ssh_pwauth: true\n              ssh_authorized_keys:\n                - {pub_key}')
+    with open(vm_yaml, 'w') as f:
+        f.write(content)
+
+    # Create VM
+    assert oc.create_vm_sync(yaml=vm_yaml, vm_name=vm_name, namespace=namespace)
+    assert oc.wait_for_ready(label='app=stressng-vm-test123', label_uuid=False, namespace=namespace)
+
+    # Test get_vmi_ip and get_vm_node
+    vmi_ip = oc.get_vmi_ip(namespace=namespace, vm_name=vm_name)
+    assert vmi_ip
+    vm_node = oc.get_vm_node(vm_name=vm_name, namespace=namespace)
+    assert vm_node
+
+    # Wait for SSH to be ready (cloud-init needs time to install packages + setup SSH)
+    import time
+    for i in range(0, 180, 5):
+        result = virtctl.virtctl_ssh(vm_name=vm_name, command='echo hello', namespace=namespace, key_path=key_path)
+        if result is not None and 'hello' in result:
+            break
+        time.sleep(5)
+    assert result is not None
+    assert 'hello' in result
+
+    # Test wait_for_vm_workload_completed (public method that combines SSH wait + file wait + SCP)
+    local_path = os.path.join(tempfile.mkdtemp(), 'stressng.json')
+    assert virtctl.wait_for_vm_workload_completed(vm_name=vm_name, file_path='/tmp/stressng.json',
+                                                   local_path=local_path, namespace=namespace,
+                                                   key_path=key_path, timeout=300)
+    assert os.path.exists(local_path)
+
+    # Cleanup
+    assert oc.delete_vm_sync(vm_name=vm_name, namespace=namespace)
+    if os.path.exists(vm_yaml):
+        os.remove(vm_yaml)

--- a/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-test123
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 10
+    cpu 1
+    cpu-load 100
+    cpu-method all
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-test123
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-test123
+        type: stressng-bench-workload-test123
+        benchmark-uuid: test-uuid-123
+        benchmark-runner-workload: stressng
+    spec:
+      containers:
+      - name: stressng
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "test-uuid-123"
+          - name: test_user
+            value: "user"
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "10"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-test123
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/integration/benchmark_runner/templates/stressng_vm_direct_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_vm_direct_template.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-test123
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-test123
+    type: stressng-vm-test123
+    benchmark-uuid: test-uuid-123
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-test123
+    spec:
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 10 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - sleep infinity

--- a/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
@@ -1,0 +1,72 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-test123
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: test-uuid-123
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-test123
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "test-uuid-123"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "unknown"
+          - name: server_ip
+            value: "SERVER_IP_PLACEHOLDER"
+          - name: run_id
+            value: "NA"
+          - name: port
+            value: "30000"
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            export h="SERVER_IP_PLACEHOLDER"
+            export port=30000
+            # Simple stream test
+            cat > /tmp/uperf-test.xml << 'XMLEOF'
+            <?xml version="1.0"?>
+            <profile name="stream-tcp-64-64-1">
+              <group nthreads="1">
+                <transaction iterations="1">
+                  <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+                </transaction>
+                <transaction duration="2">
+                  <flowop type="write" options="count=16 size=64"/>
+                </transaction>
+                <transaction iterations="1">
+                  <flowop type="disconnect"/>
+                </transaction>
+              </group>
+            </profile>
+            XMLEOF
+            sed -i "s/SERVER_IP_PLACEHOLDER/$h/g" /tmp/uperf-test.xml
+            uperf -v -a -R -i 1 -m /tmp/uperf-test.xml -P 30000 > /tmp/uperf-out.out 2>&1
+            echo '{"test_type":"stream","protocol":"tcp","message_size":64,"num_threads":1,"bytes":0,"ops":0,"norm_byte":0,"norm_ops":0,"norm_ltcy":0,"duration":2}'
+            exit 0
+      restartPolicy: Never

--- a/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-test123
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: test-uuid-123
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-test123
+        type: uperf-bench-server-test123
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never

--- a/tests/integration/benchmark_runner/templates/uperf_vm_direct_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_vm_direct_template.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: benchmark-runner
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-test123
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-test123
+    type: uperf-server-test123
+    benchmark-uuid: test-uuid-123
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-test123
+    spec:
+      domain:
+        cpu:
+          sockets: 1
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity

--- a/tests/integration/benchmark_runner/workloads/test_oc_benchmark_runner.py
+++ b/tests/integration/benchmark_runner/workloads/test_oc_benchmark_runner.py
@@ -3,6 +3,7 @@
 
 import pytest
 from benchmark_runner.common.oc.oc import OC, VMStatus
+from benchmark_runner.common.oc.oc_exceptions import YAMLNotExist, PodNotCreateTimeout, PodTerminateTimeout, VMNotCreateTimeout
 from benchmark_runner.common.virtctl.virtctl import Virtctl
 from benchmark_runner.common.template_operations.render_yaml_from_template import render_yaml_file
 from tests.integration.benchmark_runner.test_environment_variables import *
@@ -53,10 +54,21 @@ def before_after_each_test_fixture():
     kinds = ('pod', 'vm')
     for kind in kinds:
         __generate_yamls(workloads=['vdbench', 'bootstorm'], kind=kind)
+    # Generate stressng and uperf native templates
+    for kind in ('pod_job', 'vm_direct'):
+        __generate_yamls(workloads=['stressng'], kind=kind)
+    __generate_yamls(workloads=['uperf'], kind='pod_server')
+    __generate_yamls(workloads=['uperf'], kind='pod_client')
+    __generate_yamls(workloads=['uperf'], kind='vm_direct')
     yield
     # After all tests
     for kind in kinds:
         __delete_test_objects(workloads=['vdbench', 'bootstorm'], kind=kind)
+    __delete_test_objects(workloads=['stressng'], kind='pod_job')
+    __delete_test_objects(workloads=['stressng'], kind='vm_direct')
+    __delete_test_objects(workloads=['uperf'], kind='pod_server')
+    __delete_test_objects(workloads=['uperf'], kind='pod_client')
+    __delete_test_objects(workloads=['uperf'], kind='vm_direct')
     oc.delete_namespace(namespace=test_environment_variable['namespace'])
     # revert to defaults namespace
     test_environment_variable['namespace'] = 'benchmark-operator'
@@ -105,6 +117,143 @@ def test_benchmark_runner_vdbench_vm_create_ready_complete_delete():
     virtctl = Virtctl()
     virtctl.save_vm_log(vm_name=vm_name, output_filename=os.path.join(f'{templates_path}', 'vdbench_vm.log'), namespace=test_environment_variable['namespace'])
     assert oc.wait_for_vm_log_completed(vm_name=vm_name, end_stamp='@@~@@END-WORKLOAD@@~@@', output_filename=os.path.join(f'{templates_path}', 'vdbench_vm.log'))
+
+
+def test_benchmark_runner_stressng_pod_create_complete_get_pod_info():
+    """
+    This method tests stressng pod create, complete, get_pod, get_pod_ip, get_pod_node, get_cluster_name
+    Tests: wait_for_pod_create (label), wait_for_pod_completed, get_pod, get_pod_ip, get_pod_node, get_cluster_name
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    namespace = test_environment_variable['namespace']
+    assert oc.create_async(yaml=os.path.join(f'{templates_path}', 'stressng_pod_job.yaml'))
+    assert oc.wait_for_pod_create(label='app=stressng_workload-test123', namespace=namespace)
+    assert oc.wait_for_pod_completed(label='app=stressng_workload-test123', label_uuid=False, job=True, namespace=namespace)
+    # Test get_pod, get_pod_ip, get_pod_node on completed pod
+    pod_name = oc.get_pod(label='stressng-pod', namespace=namespace)
+    assert pod_name
+    pod_ip = oc.get_pod_ip(pod_name=pod_name, namespace=namespace)
+    assert pod_ip
+    pod_node = oc.get_pod_node(pod_name=pod_name, namespace=namespace)
+    assert pod_node
+    # Test get_cluster_name
+    cluster_name = oc.get_cluster_name()
+    assert cluster_name
+
+
+
+def test_benchmark_runner_uperf_pod_server_client_create_ready_get_ip_node_delete():
+    """
+    This method tests uperf pod server+client create, ready, get_pod_ip, get_pod_node, delete
+    Tests: create_async, wait_for_pod_create (pod_name), wait_for_initialized, wait_for_ready,
+           get_pod_ip (label and pod_name), get_pod_node (label and pod_name)
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    namespace = test_environment_variable['namespace']
+    # Create server
+    assert oc.create_async(yaml=os.path.join(f'{templates_path}', 'uperf_pod_server.yaml'))
+    assert oc.wait_for_pod_create(pod_name='uperf-server', namespace=namespace)
+    server_label = 'app=uperf-bench-server-0-test123'
+    assert oc.wait_for_initialized(label=server_label, label_uuid=False, namespace=namespace)
+    assert oc.wait_for_ready(label=server_label, label_uuid=False, namespace=namespace)
+    # Test get_pod_ip and get_pod_node by label
+    server_ip = oc.get_pod_ip(label=server_label, namespace=namespace)
+    assert server_ip
+    server_node = oc.get_pod_node(label=server_label, namespace=namespace)
+    assert server_node
+    # Create client with server IP
+    client_yaml = os.path.join(f'{templates_path}', 'uperf_pod_client.yaml')
+    with open(client_yaml, 'r') as f:
+        content = f.read()
+    content = content.replace('SERVER_IP_PLACEHOLDER', server_ip)
+    with open(client_yaml, 'w') as f:
+        f.write(content)
+    assert oc.create_async(yaml=client_yaml)
+    assert oc.wait_for_pod_create(pod_name='uperf-client', namespace=namespace)
+    assert oc.wait_for_initialized(label='app=uperf-bench-client', label_uuid=False, namespace=namespace)
+    assert oc.wait_for_ready(label='app=uperf-bench-client', label_uuid=False, namespace=namespace)
+    # Test get_pod_ip and get_pod_node by pod_name
+    client_pod = oc.get_pod(label='uperf-client', namespace=namespace)
+    assert client_pod
+    client_ip = oc.get_pod_ip(pod_name=client_pod, namespace=namespace)
+    assert client_ip
+    client_node = oc.get_pod_node(pod_name=client_pod, namespace=namespace)
+    assert client_node
+
+
+def test_benchmark_runner_uperf_vm_create_ready_get_vmi_ip_delete():
+    """
+    This method tests uperf vm server create, ready, get_vmi_ip, get_vm_node, delete
+    Tests: create_vm_sync, wait_for_vm_create, wait_for_initialized, wait_for_ready,
+           get_vmi_ip, get_vm_node, delete_vm_sync
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    namespace = test_environment_variable['namespace']
+    vm_name = 'uperf-server-test123'
+    assert oc.create_vm_sync(yaml=os.path.join(f'{templates_path}', 'uperf_vm_direct.yaml'),
+                             vm_name=vm_name, namespace=namespace)
+    assert oc.wait_for_initialized(label='app=uperf-server-test123', label_uuid=False, namespace=namespace)
+    assert oc.wait_for_ready(label='app=uperf-server-test123', label_uuid=False, namespace=namespace)
+    # Test get_vmi_ip and get_vm_node
+    vmi_ip = oc.get_vmi_ip(namespace=namespace, vm_name=vm_name)
+    assert vmi_ip
+    vm_node = oc.get_vm_node(vm_name=vm_name, namespace=namespace)
+    assert vm_node
+    # Cleanup
+    assert oc.delete_vm_sync(yaml=os.path.join(f'{templates_path}', 'uperf_vm_direct.yaml'),
+                             vm_name=vm_name, namespace=namespace)
+
+
+def test_yaml_file_not_exist_error():
+    """
+    This method tests YAMLNotExist exception when YAML file does not exist
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    with pytest.raises(YAMLNotExist) as err:
+        oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_nonexistent.yaml'), pod_name='stressng-pod-test123', timeout=1)
+
+
+def test_create_sync_pod_timeout_error():
+    """
+    This method creates pod with timeout error
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    with pytest.raises(PodNotCreateTimeout) as err:
+        oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod_job.yaml'), pod_name='stressng-pod-nonexistent', namespace=test_environment_variable['namespace'], timeout=1)
+
+
+def test_delete_sync_pod_timeout_error():
+    """
+    This method deletes pod with timeout error
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    namespace = test_environment_variable['namespace']
+    oc.create_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod_job.yaml'), pod_name='stressng-pod-test123', namespace=namespace)
+    with pytest.raises(PodTerminateTimeout) as err:
+        oc.delete_pod_sync(yaml=os.path.join(f'{templates_path}', 'stressng_pod_job.yaml'), pod_name='stressng-pod-test123', namespace=namespace, timeout=1)
+
+
+def test_get_long_short_uuid():
+    """
+    This method tests UUID propagation in native workloads.
+    In benchmark-operator, UUID was stored in CRD status (get_long_uuid);
+    in native workloads, UUID is a pod label (benchmark-uuid).
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    namespace = test_environment_variable['namespace']
+    assert oc.create_async(yaml=os.path.join(f'{templates_path}', 'stressng_pod_job.yaml'))
+    assert oc.wait_for_pod_create(label='app=stressng_workload-test123', namespace=namespace)
+    # Verify benchmark-uuid label is propagated from template
+    assert oc.pod_label_exists(label_name='benchmark-uuid=test-uuid-123', namespace=namespace)
+
+
+def test_create_sync_vm_timeout_error():
+    """
+    This method creates vm with timeout error
+    """
+    oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
+    with pytest.raises(VMNotCreateTimeout) as err:
+        oc.create_vm_sync(yaml=os.path.join(f'{templates_path}', 'stressng_vm_direct.yaml'), vm_name='stressng-vm-nonexistent', namespace=test_environment_variable['namespace'], timeout=1)
 
 
 @pytest.mark.skip(reason="Disable kata")

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 120
+
+    # cpu stressor
+    cpu 60
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 60G
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 60
-      requests_memory: 75Gi
-      limits_cpu: 60
-      limits_memory: 75Gi
-      # general options
-      runtype: "sequential"
-      timeout: "120"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "60"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "60G"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "120"
+          - name: cpu_stressors
+            value: "60"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "60G"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 60 --cpu-load 100 --vm 1 --vm-bytes 60G --memcpy 1 --verbose --metrics-brief --timeout 120 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 120
+
+    # cpu stressor
+    cpu 60
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 60G
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 60
-      requests_memory: 75Gi
-      limits_cpu: 60
-      limits_memory: 75Gi
-      # general options
-      runtype: "sequential"
-      timeout: "120"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "60"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "60G"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "120"
+          - name: cpu_stressors
+            value: "60"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "60G"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 60 --cpu-load 100 --vm 1 --vm-bytes 60G --memcpy 1 --verbose --metrics-brief --timeout 120 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 120
+
+    # cpu stressor
+    cpu 60
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 60G
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 60
-      requests_memory: 75Gi
-      limits_cpu: 60
-      limits_memory: 75Gi
-      # general options
-      runtype: "sequential"
-      timeout: "120"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "60"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "60G"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "120"
+          - name: cpu_stressors
+            value: "60"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "60G"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 60 --cpu-load 100 --vm 1 --vm-bytes 60G --memcpy 1 --verbose --metrics-brief --timeout 120 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 120
+
+    # cpu stressor
+    cpu 60
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 60G
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 60
-      requests_memory: 75Gi
-      limits_cpu: 60
-      limits_memory: 75Gi
-      # general options
-      runtype: "sequential"
-      timeout: "120"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "60"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "60G"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "120"
+          - name: cpu_stressors
+            value: "60"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "60G"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 60 --cpu-load 100 --vm 1 --vm-bytes 60G --memcpy 1 --verbose --metrics-brief --timeout 120 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 120
+
+    # cpu stressor
+    cpu 60
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 60G
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "120"
+          - name: cpu_stressors
+            value: "60"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "60G"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "120"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "60"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "60G"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 60
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 75Gi
-        requests:
-          memory: 75Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 60
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 60 --cpu-load 100 --vm 1 --vm-bytes 60G --memcpy 1 --verbose --metrics-brief --timeout 120 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 120
+
+    # cpu stressor
+    cpu 60
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 60G
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "120"
+          - name: cpu_stressors
+            value: "60"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "60G"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "120"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "60"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "60G"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 60
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 75Gi
-        requests:
-          memory: 75Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 60
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 60
+            memory: 75Gi
+          limits:
+            cpu: 60
+            memory: 75Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 60 --cpu-load 100 --vm 1 --vm-bytes 60G --memcpy 1 --verbose --metrics-brief --timeout 120 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,161 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-8 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-1 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-8 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,318 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="60"
+        for tt in stream rr; do
+          for sz in 64 1024 8192; do
+            for nt in 1 8; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,161 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-8 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-1 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-8 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,318 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="60"
+        for tt in stream rr; do
+          for sz in 64 1024 8192; do
+            for nt in 1 8; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,160 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-8 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-1 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-8 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,317 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="60"
+        for tt in stream rr; do
+          for sz in 64 1024 8192; do
+            for nt in 1 8; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,160 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-8 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-1 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-8 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,317 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="60"
+        for tt in stream rr; do
+          for sz in 64 1024 8192; do
+            for nt in 1 8; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,160 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-8 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-1 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-8 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,317 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -1,82 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="60"
+        for tt in stream rr; do
+          for sz in 64 1024 8192; do
+            for nt in 1 8; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-       - rr
-     protos:
-       - tcp
-     sizes:
-       - 64
-       - 1024
-       - 8192
-     nthrs:
-       - 1
-       - 8
-     runtime: 60
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 8
-       cores: 1
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 8Gi
-       requests:
-         memory: 8Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 8
-       cores: 1
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 8Gi
-       requests:
-         memory: 8Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 8
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 8
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,160 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-8 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-stream-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-1 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-64-64-8 > /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-64-64-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-64-64-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-64-64-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-1 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-1024-1024-8 > /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-1024-1024-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-1024-1024-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-1 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-rr-tcp-8192-8192-8 > /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            cat /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8
+            OUTFILE="/tmp/uperf-out-rr-tcp-8192-8192-8.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-rr-tcp-8192-8192-8 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,317 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-stream-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="count=16 size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-64-64-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-64-64-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=64"/>
+            <flowop type=read  options="size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-1024-1024-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-1024-1024-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=1024"/>
+            <flowop type=read  options="size=1024"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-1: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf-rr-tcp-8192-8192-8: |
+    <?xml version=1.0?>
+    <profile name="rr-tcp-8192-8192-8">
+      <group nthreads="8">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="60">
+            <flowop type=write options="size=8192"/>
+            <flowop type=read  options="size=8192"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -1,82 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="60"
+        for tt in stream rr; do
+          for sz in 64 1024 8192; do
+            for nt in 1 8; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-       - rr
-     protos:
-       - tcp
-     sizes:
-       - 64
-       - 1024
-       - 8192
-     nthrs:
-       - 1
-       - 8
-     runtime: 60
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 8
-       cores: 1
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 8Gi
-       requests:
-         memory: 8Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 8
-       cores: 1
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 8Gi
-       requests:
-         memory: 8Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 8 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 8
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 8
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 8
+            memory: 8Gi
+          limits:
+            cpu: 8
+            memory: 8Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng-test-ci
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -1,43 +1,128 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-kata
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-kata-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng-test-ci
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      runtime_class: kata
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      runtimeClassName: kata
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng-test-ci
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -1,42 +1,127 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: stressng-pod
-  namespace: benchmark-operator
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-pod-deadbeef
+  namespace: benchmark-runner
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng-test-ci
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      image: "quay.io/benchmark-runner/stressng:latest"
-      resources: True # enable for resources requests/limits
-      requests_cpu: 10m
-      requests_memory: 1Gi
-      limits_cpu: 2
-      limits_memory: 1Gi
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -1,0 +1,65 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng-test-ci
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stressng-workload-deadbeef
+  namespace: benchmark-runner
+data:
+  jobfile: |
+    run sequential
+    verbose
+    metrics-brief
+    timeout 30
+
+    # cpu stressor
+    cpu 1
+    cpu-load 100
+    cpu-method all
+
+    # vm stressor
+    vm 1
+    vm-bytes 128M
+    vm-keep
+    vm-populate
+
+    # memcpy stressor
+    memcpy 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+spec:
+  parallelism: 1
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: stressng_workload-deadbeef
+        type: stressng-bench-workload-deadbeef
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        benchmark-runner-workload: stressng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      containers:
+      - name: stressng
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+        image: quay.io/benchmark-runner/stressng:latest
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: runtype
+            value: "sequential"
+          - name: timeout
+            value: "30"
+          - name: cpu_stressors
+            value: "1"
+          - name: cpu_percentage
+            value: "100"
+          - name: cpu_method
+            value: "all"
+          - name: vm_stressors
+            value: "1"
+          - name: vm_bytes
+            value: "128M"
+          - name: mem_stressors
+            value: "1"
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            cd /tmp
+            stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
+            # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)
+            if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then
+              python3 << 'PYEOF'
+            import yaml, json, os
+            from datetime import datetime, timezone
+            try:
+                with open("/tmp/stressng.yml") as f:
+                    d = yaml.safe_load(f)
+            except Exception:
+                d = {}
+            metrics = d.get("metrics", [])
+            doc = {
+                "workload": "stressng",
+                "kind": "pod",
+                "runtype": os.environ.get("runtype", ""),
+                "timeout": int(os.environ.get("timeout", 0) or 0),
+                "vm_stressors": os.environ.get("vm_stressors", ""),
+                "vm_bytes": os.environ.get("vm_bytes", ""),
+                "mem_stressors": os.environ.get("mem_stressors", ""),
+                "cpu_method": os.environ.get("cpu_method", ""),
+            }
+            for m in metrics:
+                s = m.get("stressor", "")
+                b = m.get("bogo-ops", 0)
+                doc[s] = b
+                if s == "cpu": doc["cpu_bogomips"] = b
+                elif s == "vm": doc["vm_bogomips"] = b
+            bogo_total = sum(doc.get(s, 0) for s in ["cpu", "vm", "mem", "memcpy"])
+            doc["bogo_ops"] = bogo_total
+            print(json.dumps(doc))
+            PYEOF
+            fi
+        volumeMounts:
+        - name: stressng-workload-volume
+          mountPath: "/workload"
+          readOnly: false
+      volumes:
+      - name: stressng-workload-volume
+        configMap:
+          name: stressng-workload-deadbeef
+          defaultMode: 0660
+      restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -1,55 +1,65 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
 metadata:
-  name: stressng-vm
-  namespace: benchmark-operator
+  name: stressng-vm-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: stressng-vm-deadbeef
+    type: stressng-vm-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: stressng
 spec:
-  system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
-  elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: stressng-test-ci
-  metadata:
-    collection: false
-  workload:
-    name: stressng
-    args:
-      pin: True # enable for nodeSelector
-      pin_node: "pin-node-1"
-      # general options
-      runtype: "sequential"
-      timeout: "30"
-      instances: 1
-      # cpu stressor options
-      cpu_stressors: "1"
-      cpu_percentage: "100"
-      cpu_method: "all"
-      # vm stressor option
-      vm_stressors: "1"
-      vm_bytes: "128M"
-      # mem stressor options
-      mem_stressors: "1"
-      kind: vm
-      client_vm:
-        dedicatedcpuplacement: false
-        sockets: 2
-        cores: 1
-        threads: 1
-        image: quay.io/benchmark-runner/fedora-container-disk:43
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 1Gi
-        network:
-          front_end: masquerade
-          multiqueue:
-            enabled: false # if set to true, highly recommend to set selinux to permissive on the nodes where the vms would be scheduled
-            queues: 0 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-        extra_options:
-          - none
-          #- hostpassthrough
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: stressng-vm
+        app: stressng-vm-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 2
+          cores: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - stress-ng
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - |
+                  stress-ng --cpu 1 --cpu-load 100 --vm 1 --vm-bytes 128M --memcpy 1 --verbose --metrics-brief --timeout 30 2>&1 | tee /tmp/stressng_output.txt /dev/ttyS0
+                - python3 -c "import re,json;t=open('/tmp/stressng_output.txt').read();c=re.search(r'\scpu\s+([\d.]+)',t);v=re.search(r'\svm\s+([\d.]+)',t);m=re.search(r'\smemcpy\s+([\d.]+)',t);cb=float(c.group(1)) if c else 0.0;vb=float(v.group(1)) if v else 0.0;mb=float(m.group(1)) if m else 0.0;json.dump({'cpu':cb,'cpu_bogomips':cb,'vm':vb,'vm_bogomips':vb,'memcpy':mb,'bogo_ops':cb+vb+mb},open('/tmp/stressng.json','w'))"
+                - echo "STRESSNG_COMPLETE" > /dev/ttyS0

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-kata
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-pod
-  namespace: benchmark-operator
+  namespace: benchmark-runner
 spec:
   system_metrics:
     collection: True

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 
+          cores: 
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf-test-ci
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/namespace.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: benchmark-operator
+  name: benchmark-runner
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: client
+        app: uperf-bench-client
+        type: uperf-bench-client-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        env:
+          - name: uuid
+            value: "deadbeef-0123-3210-cdef-01234567890abcdef"
+          - name: test_user
+            value: "user"
+          - name: clustername
+            value: ""
+          - name: client_node
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: server_node
+            value: "pin-node-1"
+          - name: server_ip
+            value: ""
+          - name: run_id
+            value: "NA"
+          - name: client_ips
+            value: ""
+          - name: service_ip
+            value: "False"
+          - name: service_type
+            value: ""
+          - name: port
+            value: "30000"
+          - name: num_pairs
+            value: ""
+          - name: multus_client
+            value: ""
+          - name: networkpolicy
+            value: "False"
+          - name: density
+            value: ""
+          - name: nodes_in_iter
+            value: ""
+          - name: step_size
+            value: ""
+          - name: colocate
+            value: ""
+          - name: density_range
+            value: ""
+          - name: node_range
+            value: ""
+          - name: hostnetwork
+            value: "False"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Server IP passed from Python code
+            export h=""
+            export port=30000
+            export hostnet=False
+            export num_pairs=1
+            export ips=$(hostname -I)
+            exit_status=0
+
+            # Create workdir and process each test file, replacing placeholder with actual server IP
+            mkdir -p /tmp/uperf-workdir
+            SERVER_IP=""
+
+            # Run each test combination and upload metrics to ES
+            # Replace placeholder and save to workdir
+            sed "s/SERVER_IP_PLACEHOLDER/$SERVER_IP/g" /tmp/uperf-test/uperf-stream-tcp-64-64-1 > /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            cat /tmp/uperf-workdir/uperf-stream-tcp-64-64-1
+            OUTFILE="/tmp/uperf-out-stream-tcp-64-64-1.out"
+            uperf -v -a -R -i 1 -m /tmp/uperf-workdir/uperf-stream-tcp-64-64-1 -P 30000 2>&1 | tee "$OUTFILE" || exit_status=1
+
+            # Parse all test results into JSON (visible in pod logs)
+            python3 /tmp/uperf-test/uperf_parser.py
+
+            exit $exit_status
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/uperf-test"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: uperf-test-deadbeef
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uperf-test-deadbeef
+  namespace: benchmark-runner
+data:
+  uperf-stream-tcp-64-64-1: |
+    <?xml version=1.0?>
+    <profile name="stream-tcp-64-64-1">
+      <group nthreads="1">
+          <transaction iterations="1">
+            <flowop type="connect" options="remotehost=SERVER_IP_PLACEHOLDER protocol=tcp port=30001"/>
+          </transaction>
+          <transaction duration="2">
+            <flowop type=write options="count=16 size=64"/>
+          </transaction>
+          <transaction iterations="1">
+            <flowop type=disconnect />
+          </transaction>
+      </group>
+    </profile>
+  uperf_parser.py: |
+    #!/usr/bin/env python3
+    import re, json, sys, glob
+
+    def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+        result = {
+            'test_type': test_type, 'protocol': protocol,
+            'message_size': message_size, 'num_threads': num_threads,
+            'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+            'norm_ltcy': 0.0, 'duration': 0
+        }
+        ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+        if len(ts_results) > 1:
+            first_ts = float(ts_results[0][0])
+            last_ts = float(ts_results[-1][0])
+            total_bytes = int(ts_results[-1][1])
+            total_ops = int(ts_results[-1][2])
+            duration_sec = (last_ts - first_ts) / 1000.0
+            if duration_sec > 0:
+                result['bytes'] = total_bytes
+                result['norm_byte'] = total_bytes / duration_sec
+                result['ops'] = total_ops
+                result['norm_ops'] = total_ops / duration_sec
+                result['duration'] = int(duration_sec)
+                lat_samples = []
+                prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                for ts_str, _, ops_str in ts_results[1:]:
+                    ts, ops = float(ts_str), int(ops_str)
+                    norm_ops = ops - prev_ops
+                    if norm_ops > 0 and prev_ts > 0:
+                        lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                    prev_ts, prev_ops = ts, ops
+                if lat_samples:
+                    lat_samples.sort()
+                    rank = 0.95 * (len(lat_samples) - 1)
+                    lower = int(rank)
+                    frac = rank - lower
+                    result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+        return result
+
+    import os
+    from datetime import datetime, timezone
+
+    results = []
+    for f in sorted(glob.glob('/tmp/uperf-out-*.out')):
+        name = f.replace('/tmp/uperf-out-', '').replace('.out', '')
+        parts = name.split('-')
+        if len(parts) >= 5:
+            tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+        else:
+            tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+        output = open(f).read()
+        parsed = parse_single_test(output, tt, proto, sz, nt)
+        doc = {
+            'uuid': os.environ.get('uuid', ''),
+            'workload': 'uperf',
+            'kind': 'pod',
+            'test_type': parsed['test_type'],
+            'protocol': parsed['protocol'],
+            'message_size': parsed['message_size'],
+            'read_message_size': parsed['message_size'],
+            'num_threads': parsed['num_threads'],
+            'bytes': parsed['bytes'],
+            'ops': parsed['ops'],
+            'norm_byte': parsed['norm_byte'],
+            'norm_ops': parsed['norm_ops'],
+            'norm_ltcy': parsed['norm_ltcy'],
+            'duration': parsed['duration'],
+            'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'uperf_ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'),
+            'user': os.environ.get('test_user', 'user'),
+            'run_id': os.environ.get('run_id', 'NA'),
+            'cluster_name': os.environ.get('clustername', ''),
+            'iteration': 0,
+            'client_ips': os.environ.get('ips', ''),
+            'remote_ip': os.environ.get('server_ip', ''),
+            'service_ip': os.environ.get('service_ip', 'False'),
+            'service_type': os.environ.get('service_type', ''),
+            'port': os.environ.get('port', '30000'),
+            'client_node': os.environ.get('client_node', ''),
+            'server_node': os.environ.get('server_node', ''),
+            'pod_id': os.environ.get('POD_NAME', ''),
+            'num_pairs': os.environ.get('num_pairs', ''),
+            'multus_client': os.environ.get('multus_client', ''),
+            'networkpolicy': os.environ.get('networkpolicy', ''),
+            'density': os.environ.get('density', ''),
+            'nodes_in_iter': os.environ.get('nodes_in_iter', ''),
+            'step_size': os.environ.get('step_size', ''),
+            'colocate': os.environ.get('colocate', ''),
+            'density_range': os.environ.get('density_range', ''),
+            'node_range': os.environ.get('node_range', ''),
+            'hostnetwork': os.environ.get('hostnetwork', 'False'),
+        }
+        results.append(doc)
+    # Print one JSON per line for bash to loop and curl
+    for doc in results:
+        print(json.dumps(doc))
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+        workload: uperf
+        role: server
+        app: uperf-bench-server-0-deadbeef
+        index: "0"
+        type: uperf-bench-server-deadbeef
+    spec:
+      containers:
+      - name: benchmark
+        image: quay.io/benchmark-runner/uperf:latest
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args: ["uperf -s -v -P 30000"]
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -1,78 +1,235 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
+apiVersion: v1
+kind: Secret
 metadata:
- name: uperf-vm
- namespace: benchmark-operator
+  name: uperf-client-cloudinit-deadbeef
+  namespace: benchmark-runner
+stringData:
+  userdata: |
+    #cloud-config
+    user: fedora
+    password: fedora
+    chpasswd: { expire: False }
+    ssh_pwauth: true
+    packages:
+      - uperf
+    write_files:
+      - path: /tmp/uperf_parser.py
+        permissions: '0755'
+        content: |
+          #!/usr/bin/env python3
+          import re, json, sys
+
+          def parse_single_test(output_section, test_type='stream', protocol='tcp', message_size=64, num_threads=1):
+              result = {
+                  'test_type': test_type, 'protocol': protocol,
+                  'message_size': message_size, 'num_threads': num_threads,
+                  'bytes': 0, 'ops': 0, 'norm_byte': 0, 'norm_ops': 0,
+                  'norm_ltcy': 0.0, 'duration': 0
+              }
+              ts_results = re.findall(r'timestamp_ms:([\d.]+)\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)', output_section)
+              if len(ts_results) > 1:
+                  first_ts = float(ts_results[0][0])
+                  last_ts = float(ts_results[-1][0])
+                  total_bytes = int(ts_results[-1][1])
+                  total_ops = int(ts_results[-1][2])
+                  duration_sec = (last_ts - first_ts) / 1000.0
+                  if duration_sec > 0:
+                      result['bytes'] = total_bytes
+                      result['norm_byte'] = total_bytes / duration_sec
+                      result['ops'] = total_ops
+                      result['norm_ops'] = total_ops / duration_sec
+                      result['duration'] = int(duration_sec)
+                      lat_samples = []
+                      prev_ts, prev_ops = float(ts_results[0][0]), int(ts_results[0][2])
+                      for ts_str, _, ops_str in ts_results[1:]:
+                          ts, ops = float(ts_str), int(ops_str)
+                          norm_ops = ops - prev_ops
+                          if norm_ops > 0 and prev_ts > 0:
+                              lat_samples.append(((ts - prev_ts) / norm_ops) * 1000)
+                          prev_ts, prev_ops = ts, ops
+                      if lat_samples:
+                          lat_samples.sort()
+                          rank = 0.95 * (len(lat_samples) - 1)
+                          lower = int(rank)
+                          frac = rank - lower
+                          result['norm_ltcy'] = round(lat_samples[lower] + frac * (lat_samples[min(lower + 1, len(lat_samples) - 1)] - lat_samples[lower]), 4)
+              return result
+
+          output = open(sys.argv[1]).read()
+          test_sections = re.split(r'=== TEST (\S+) ===', output)
+          results = []
+          i = 1
+          while i < len(test_sections) - 1:
+              test_name = test_sections[i]
+              test_output = test_sections[i + 1]
+              i += 2
+              parts = test_name.split('-')
+              if len(parts) >= 5:
+                  tt, proto, sz, nt = parts[0], parts[1], int(parts[2]), int(parts[4])
+              else:
+                  tt, proto, sz, nt = 'stream', 'tcp', 64, 1
+              results.append(parse_single_test(test_output, tt, proto, sz, nt))
+          if not results:
+              results.append(parse_single_test(output))
+          json.dump(results, open(sys.argv[2], 'w'))
+    runcmd:
+      - export HOME=/root
+      - export TMP=/tmp
+      - export TEMP=/tmp
+      - dnf install -y uperf || true
+      - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+      - sleep 30
+      - |
+        SERVER=""
+        RT="2"
+        for tt in stream; do
+          for sz in 64; do
+            for nt in 1; do
+              XML=/tmp/uperf_test.xml
+              if [ "$tt" = "rr" ]; then
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="size=%s"/>\n      <flowop type="read" options="size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" "$sz" > $XML
+              else
+                printf '<?xml version="1.0"?>\n<profile name="%s-tcp-%s-%s-%s">\n  <group nthreads="%s">\n    <transaction iterations="1">\n      <flowop type="connect" options="remotehost=%s protocol=tcp port=30001"/>\n    </transaction>\n    <transaction duration="%s">\n      <flowop type="write" options="count=16 size=%s"/>\n    </transaction>\n    <transaction iterations="1">\n      <flowop type="disconnect"/>\n    </transaction>\n  </group>\n</profile>\n' "$tt" "$sz" "$sz" "$nt" "$nt" "$SERVER" "$RT" "$sz" > $XML
+              fi
+              echo "=== TEST $tt-tcp-$sz-$sz-$nt ===" >> /tmp/uperf_output.txt
+              uperf -v -R -m $XML -P 30000 >> /tmp/uperf_output.txt 2>/dev/null
+            done
+          done
+        done
+      - python3 /tmp/uperf_parser.py /tmp/uperf_output.txt /tmp/uperf.json
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-server-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-server-deadbeef
+    type: uperf-server-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: server
 spec:
- clustername: test-cluster
- test_user: user # user is a key that points to user triggering benchmark-operator, useful to search results in ES
- system_metrics:
-    collection: True
-    prom_url: "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-    es_url: "http://elasticsearch.example.com:gol9999"
-    prom_token: "fake_prom_token"
-    metrics_profile: "node-metrics.yml"
-    index_name: system-metrics-test-ci
- elasticsearch:
-    url: "http://elasticsearch.example.com:gol9999"
-    index_name: uperf-test-ci
- metadata:
-   collection: false
- cleanup: false
- workload:
-   name: uperf
-   args:
-     hostnetwork: false # irrelevant for vms
-     serviceip: false # irrelevant for vms
-     networkpolicy: False
-     pin: True
-     pin_server: "pin-node-1"
-     pin_client: "pin-node-2"
-     samples: 1
-     pair: 1
-     test_types:
-       - stream
-     protos:
-       - tcp
-     sizes:
-       - 64
-     nthrs:
-       - 1
-     runtime: 2
-     kind: vm
-     server_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
-     client_vm:
-       dedicatedcpuplacement: false
-       sockets: 1
-       cores: 2
-       threads: 1
-       image: quay.io/benchmark-runner/fedora-container-disk:43
-       limits:
-         memory: 1Gi
-       requests:
-         memory: 1Gi
-       network:
-         front_end: masquerade
-         multiqueue:
-           enabled: true
-           queues: 4 # must be given if enabled is set to true and ideally should be set to vcpus ideally so sockets*threads*cores, your image must've ethtool installed
-       extra_options:
-         - none
-         #- hostpassthrough
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-server
+        app: uperf-server-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-1'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+              ports:
+                - port: 30000
+                - port: 30001
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: { expire: False }
+              ssh_pwauth: true
+              packages:
+                - uperf
+              runcmd:
+                - export HOME=/root
+                - export TMP=/tmp
+                - export TEMP=/tmp
+                - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
+                - uperf -s -P 30000 > /tmp/uperf_server.log 2>&1 &
+                - sleep infinity
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: uperf-client-deadbeef
+  namespace: benchmark-runner
+  labels:
+    app: uperf-client-deadbeef
+    type: uperf-client-deadbeef
+    benchmark-uuid: deadbeef-0123-3210-cdef-01234567890abcdef
+    benchmark-runner-workload: uperf
+    role: client
+spec:
+  runStrategy: Once
+  template:
+    metadata:
+      labels:
+        kubevirt-vm: uperf-client
+        app: uperf-client-deadbeef
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 'pin-node-2'
+      domain:
+        cpu:
+          sockets: 1
+          cores: 2
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              masquerade: {}
+          networkInterfaceMultiqueue: true
+        machine:
+          type: ""
+        resources:
+          requests:
+            cpu: 10m
+            memory: 1Gi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      terminationGracePeriodSeconds: 180
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/benchmark-runner/fedora-container-disk:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: uperf-client-cloudinit-deadbeef


### PR DESCRIPTION
### What changed

- Remove benchmark-operator and snafu/benchmark-wrapper dependencies
- Pod workloads use native Kubernetes Jobs with inline JSON parsers
- VM workloads use native KubeVirt VirtualMachines with cloud-init
- VM results extracted via virtctl SSH/SCP (SSH keys injected via cloud-init)
- SSH/SCP methods added to Virtctl class: `wait_for_vm_workload_completed`, `_ssh_ready`, `_wait_for_file_created`, `_scp_file`
- Extended existing `oc.py` methods (`get_pod`, `wait_for_pod_create`, `delete_vm_sync`) instead of adding new ones
- Added `get_pod_ip`, `get_pod_node`, `get_vmi_ip`, `get_cluster_name` helpers to `oc.py`
- Replaced all `subprocess.run` calls with OC/Virtctl methods
- Added `@typechecked`, `@logger_time_stamp` annotations, moved initializations to `__init__`
- Combined YAML templates (Namespace + ConfigMap/Secret + Job/VM in single file)
- Fixed `stressng_timeout` variable collision with general `timeout` env var
- ES upload handled by benchmark-runner Python (not inside pods/VMs)
- 95th percentile latency with numpy-equivalent linear interpolation
- All ES fields match existing schema for Grafana compatibility
- Prometheus metrics populated
- Added integration tests for OC methods (error handling, timeout, UUID) and Virtctl SSH/SCP
- Updated README.md and podman.md: removed benchmark-operator references, default namespace changed to `benchmark-runner`
