### PR TITLE
Remove stale CI status params and add explicit vm_user for stressng/uperf

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.965
+current_version = 1.0.964
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -301,29 +301,12 @@ jobs:
         RUN_TYPE: 'perf_ci'
       run: |
         # get repository last id
-        declare -a repositories=('redhat-performance/benchmark-runner' 'cloud-bulldozer/benchmark-operator' 'cloud-bulldozer/benchmark-wrapper')
-        for repository in "${repositories[@]}"
-        do
-            git clone "https://github.com/$repository" "$RUNNER_PATH/$repository"
-            pushd "$RUNNER_PATH/$repository"
-            case $repository in
-               'redhat-performance/benchmark-runner')
-                    echo "BENCHMARK_RUNNER_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
-                    BENCHMARK_RUNNER_ID=$(git rev-parse @)
-                    echo $BENCHMARK_RUNNER_ID
-                    ;;
-               'cloud-bulldozer/benchmark-operator')
-                    echo "BENCHMARK_OPERATOR_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
-                    BENCHMARK_OPERATOR_ID=$(git rev-parse @)
-                    echo $BENCHMARK_OPERATOR_ID
-                    ;;
-               'cloud-bulldozer/benchmark-wrapper')
-                    echo "BENCHMARK_WRAPPER_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
-                    BENCHMARK_WRAPPER_ID=$(git rev-parse @)
-                    echo $BENCHMARK_WRAPPER_ID
-                    ;;
-            esac
-        done
+        git clone "https://github.com/redhat-performance/benchmark-runner" "$RUNNER_PATH/redhat-performance/benchmark-runner"
+        pushd "$RUNNER_PATH/redhat-performance/benchmark-runner"
+        echo "BENCHMARK_RUNNER_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
+        BENCHMARK_RUNNER_ID=$(git rev-parse @)
+        echo $BENCHMARK_RUNNER_ID
+        popd
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"
         end=$(printf '%(%s)T' -1)
@@ -331,7 +314,7 @@ jobs:
         # Check for workload failure or success => return pass/failed
         if [[ "${{needs.workload.outputs.job_status}}" == "failure" || "${{needs.workload.outputs.job_status}}" == "cancelled" ]]; then status="failed"; else status="pass"; fi
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Update CI status $status >>>>>>>>>>>>>>>>>>>>>>>>>>'
-        ssh -t provision "podman run --rm -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e BUILD_VERSION='$build_version' -e CI_STATUS='$status' -e CI_MINUTES_TIME='$ci_minutes_time' -e BENCHMARK_RUNNER_ID='$BENCHMARK_RUNNER_ID' -e BENCHMARK_OPERATOR_ID='$BENCHMARK_OPERATOR_ID' -e BENCHMARK_WRAPPER_ID='$BENCHMARK_WRAPPER_ID' -e RUN_TYPE='$RUN_TYPE' -e TIMEOUT='3600' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged '${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}'"
+        ssh -t provision "podman run --rm -e KUBEADMIN_PASSWORD='$KUBEADMIN_PASSWORD' -e PIN_NODE_BENCHMARK_OPERATOR='$PIN_NODE_BENCHMARK_OPERATOR' -e PIN_NODE1='$PIN_NODE1' -e PIN_NODE2='$PIN_NODE2' -e ELASTICSEARCH='$ELASTICSEARCH' -e ELASTICSEARCH_PORT='$ELASTICSEARCH_PORT' -e ELASTICSEARCH_USER='$ELASTICSEARCH_USER' -e ELASTICSEARCH_PASSWORD='$ELASTICSEARCH_PASSWORD' -e BUILD_VERSION='$build_version' -e CI_STATUS='$status' -e CI_MINUTES_TIME='$ci_minutes_time' -e BENCHMARK_RUNNER_ID='$BENCHMARK_RUNNER_ID' -e RUN_TYPE='$RUN_TYPE' -e TIMEOUT='3600' -e log_level='INFO' -v '$CONTAINER_KUBECONFIG_PATH':'$CONTAINER_KUBECONFIG_PATH' --privileged '${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}'"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Remove image on provision >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
         echo "if [[ \"\$(sudo podman images -q ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }} 2> /dev/null)\" != \"\" ]]; then sudo podman rmi -f \$(sudo podman images -q ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }} 2> /dev/null); fi" > "$RUNNER_PATH/remove_image.sh"
         scp -r "$RUNNER_PATH/remove_image.sh" provision:"/tmp/remove_image.sh"

--- a/.github/workflows/Release_ClusterBuster_Perf_Env_CI.yml
+++ b/.github/workflows/Release_ClusterBuster_Perf_Env_CI.yml
@@ -215,21 +215,12 @@ jobs:
         CONTAINER_KUBECONFIG_PATH: ${{ secrets.CONTAINER_KUBECONFIG_PATH }}
       run: |
         # get repository last id
-        declare -a repositories=('benchmark-operator' 'benchmark-wrapper')
-        for repository in "${repositories[@]}"
-        do
-            git clone "https://github.com/cloud-bulldozer/$repository" "$RUNNER_PATH/$repository"
-            pushd "$RUNNER_PATH/$repository"
-            if [[ $repository == 'benchmark-operator' ]]
-            then
-                echo "BENCHMARK_OPERATOR_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
-                BENCHMARK_OPERATOR_ID=$(git rev-parse @)
-            else
-                echo "BENCHMARK_WRAPPER_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
-                BENCHMARK_WRAPPER_ID=$(git rev-parse @)
-            fi
-            popd
-        done
+        # get benchmark-runner last id
+        git clone "https://github.com/redhat-performance/benchmark-runner" "$RUNNER_PATH/benchmark-runner"
+        pushd "$RUNNER_PATH/benchmark-runner"
+        echo "BENCHMARK_RUNNER_ID=$(git rev-parse @)" >> "$GITHUB_ENV"
+        BENCHMARK_RUNNER_ID=$(git rev-parse @)
+        popd
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"
         end=$(printf '%(%s)T' -1)
@@ -237,7 +228,7 @@ jobs:
         # Check for workload failure or success => return pass/failed
         if [[ "${{needs.workload.outputs.job_status}}" == "failure" || "${{needs.workload.outputs.job_status}}" == "cancelled" ]]; then status="failed"; else status="pass"; fi
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Update CI status $status >>>>>>>>>>>>>>>>>>>>>>>>>>'
-        podman run --rm -e KUBEADMIN_PASSWORD="$KUBEADMIN_PASSWORD" -e PIN_NODE_BENCHMARK_OPERATOR="$PIN_NODE_BENCHMARK_OPERATOR" -e PIN_NODE1="$PIN_NODE1" -e PIN_NODE2="$PIN_NODE2" -e ELASTICSEARCH="$ELASTICSEARCH" -e ELASTICSEARCH_PORT="$ELASTICSEARCH_PORT" -e ELASTICSEARCH_USER="$ELASTICSEARCH_USER" -e ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" -e BUILD_VERSION="$build_version" -e CI_STATUS="$status" -e CI_MINUTES_TIME="$ci_minutes_time" -e BENCHMARK_OPERATOR_ID="$BENCHMARK_OPERATOR_ID" -e BENCHMARK_WRAPPER_ID="$BENCHMARK_WRAPPER_ID" -e RUN_TYPE="perf_ci" -e TIMEOUT="3600" -e log_level="INFO" -v "$KUBECONFIG_PATH":"$CONTAINER_KUBECONFIG_PATH" --privileged "${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}"
+        podman run --rm -e KUBEADMIN_PASSWORD="$KUBEADMIN_PASSWORD" -e PIN_NODE_BENCHMARK_OPERATOR="$PIN_NODE_BENCHMARK_OPERATOR" -e PIN_NODE1="$PIN_NODE1" -e PIN_NODE2="$PIN_NODE2" -e ELASTICSEARCH="$ELASTICSEARCH" -e ELASTICSEARCH_PORT="$ELASTICSEARCH_PORT" -e ELASTICSEARCH_USER="$ELASTICSEARCH_USER" -e ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" -e BUILD_VERSION="$build_version" -e CI_STATUS="$status" -e CI_MINUTES_TIME="$ci_minutes_time" -e BENCHMARK_RUNNER_ID="$BENCHMARK_RUNNER_ID" -e RUN_TYPE="perf_ci" -e TIMEOUT="3600" -e log_level="INFO" -v "$KUBECONFIG_PATH":"$CONTAINER_KUBECONFIG_PATH" --privileged "${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }}"
         echo '>>>>>>>>>>>>>>>>>>>>>>>>>> Remove image on provision >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>'
         echo "if [[ \"\$(sudo podman images -q ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }} 2> /dev/null)\" != \"\" ]]; then sudo podman rmi -f \$(sudo podman images -q ${{ secrets.QUAY_BENCHMARK_RUNNER_REPOSITORY }} 2> /dev/null); fi" > "$RUNNER_PATH/remove_image.sh"
         scp -r "$RUNNER_PATH/remove_image.sh" provision:"/tmp/remove_image.sh"

--- a/benchmark_runner/main/main.py
+++ b/benchmark_runner/main/main.py
@@ -213,13 +213,9 @@ def update_ci_status():
     """
     ci_minutes_time = environment_variables_dict.get('ci_minutes_time', '')
     benchmark_runner_id = environment_variables_dict.get('benchmark_runner_id', '')
-    benchmark_operator_id = environment_variables_dict.get('benchmark_operator_id', '')
-    benchmark_wrapper_id = environment_variables_dict.get('benchmark_wrapper_id', '')
     benchmark_runner = Workloads()
     benchmark_runner.update_ci_status(status=ci_status, ci_minutes_time=int(ci_minutes_time),
-                                      benchmark_runner_id=benchmark_runner_id,
-                                      benchmark_operator_id=benchmark_operator_id,
-                                      benchmark_wrapper_id=benchmark_wrapper_id)
+                                      benchmark_runner_id=benchmark_runner_id)
 
 
 @logger_time_stamp

--- a/benchmark_runner/workloads/stressng_vm.py
+++ b/benchmark_runner/workloads/stressng_vm.py
@@ -23,6 +23,7 @@ class StressngVM(WorkloadsOperations):
         self.__status = ''
         self.__vm_name = f'{self.__workload_name}-{self._trunc_uuid}'
         self.__namespace = self._environment_variables_dict['namespace']
+        self.__username = self._environment_variables_dict.get('vm_user', '') or 'fedora'
 
     def save_error_logs(self):
         if self._es_host:
@@ -80,6 +81,7 @@ class StressngVM(WorkloadsOperations):
                 local_path=local_json_path,
                 namespace=self.__namespace,
                 key_path=self._ssh_key_path,
+                username=self.__username,
                 timeout=self._timeout
             )
 

--- a/benchmark_runner/workloads/uperf_vm.py
+++ b/benchmark_runner/workloads/uperf_vm.py
@@ -27,6 +27,7 @@ class UperfVM(WorkloadsOperations):
         self.__client_vm_name = f'uperf-client-{self._trunc_uuid}'
         self.__template_ops = TemplateOperations(workload=self._workload)
         self.__namespace = self._environment_variables_dict['namespace']
+        self.__username = self._environment_variables_dict.get('vm_user', '') or 'fedora'
 
     def save_error_logs(self):
         if self._es_host:
@@ -130,6 +131,7 @@ class UperfVM(WorkloadsOperations):
                 local_path=local_json_path,
                 namespace=self.__namespace,
                 key_path=self._ssh_key_path,
+                username=self.__username,
                 timeout=self._timeout
             )
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.965'  # update also .bumpversion.cfg
+__version__ = '1.0.964'  # update also .bumpversion.cfg
 
 
 here = path.abspath(path.dirname(__file__))

--- a/tests/integration/benchmark_runner/common/virtctl/test_virtctl_benchmark_runner.py
+++ b/tests/integration/benchmark_runner/common/virtctl/test_virtctl_benchmark_runner.py
@@ -133,7 +133,7 @@ def test_virtctl_ssh_ready_and_wait():
     # Wait for SSH to be ready (cloud-init needs time to install packages + setup SSH)
     import time
     for i in range(0, 180, 5):
-        result = virtctl.virtctl_ssh(vm_name=vm_name, command='echo hello', namespace=namespace, key_path=key_path)
+        result = virtctl.virtctl_ssh(vm_name=vm_name, command='echo hello', namespace=namespace, key_path=key_path, username='fedora')
         if result is not None and 'hello' in result:
             break
         time.sleep(5)
@@ -144,7 +144,7 @@ def test_virtctl_ssh_ready_and_wait():
     local_path = os.path.join(tempfile.mkdtemp(), 'stressng.json')
     assert virtctl.wait_for_vm_workload_completed(vm_name=vm_name, file_path='/tmp/stressng.json',
                                                    local_path=local_path, namespace=namespace,
-                                                   key_path=key_path, timeout=300)
+                                                   key_path=key_path, username='fedora', timeout=300)
     assert os.path.exists(local_path)
 
     # Cleanup


### PR DESCRIPTION
## Type of change
- [x] bug
- [x] enhancement

## Description
1. Remove stale `benchmark_operator_id` and `benchmark_wrapper_id` from `update_ci_status()` and CI workflows — these were removed in PR #1186 but the callers still passed them, causing `TypeError` at runtime.

2. Add explicit `username='fedora'` to stressng_vm and uperf_vm workloads so they don't rely on the global `vm_user` default (preparation for hammerdb PR #1190 which changes the default to empty).

3. Fix virtctl integration test to pass `username='fedora'` explicitly.
