### PR TITLE
fix prerecommit and unittest issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,5 @@ repos:
       - id: check-docstring-first
       - id: check-merge-conflict
       - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_direct_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_direct_template.yaml
@@ -22,7 +22,7 @@ spec:
       {%- endif %}
       domain:
         cpu:
-          sockets: {{ sockets }}
+          sockets:{% if sockets %} {{ sockets }}{% endif %}
           cores: 1
           threads: 1
         devices:

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
@@ -37,7 +37,7 @@ spec:
       kind: vm
       client_vm:
         dedicatedcpuplacement: false
-        sockets: {{ sockets }}
+        sockets:{% if sockets %} {{ sockets }}{% endif %}
         cores: 1
         threads: 1
         image: {{ fedora_container_disk }}

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_direct_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_direct_template.yaml
@@ -127,8 +127,8 @@ spec:
       {%- endif %}
       domain:
         cpu:
-          sockets: {{ sockets }}
-          cores: {{ cores }}
+          sockets:{% if sockets %} {{ sockets }}{% endif %}
+          cores:{% if cores %} {{ cores }}{% endif %}
           threads: 1
         devices:
           disks:
@@ -209,8 +209,8 @@ spec:
       {%- endif %}
       domain:
         cpu:
-          sockets: {{ sockets }}
-          cores: {{ cores }}
+          sockets:{% if sockets %} {{ sockets }}{% endif %}
+          cores:{% if cores %} {{ cores }}{% endif %}
           threads: 1
         devices:
           disks:

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
@@ -50,8 +50,8 @@ spec:
      kind: vm
      server_vm:
        dedicatedcpuplacement: false
-       sockets: {{ sockets }}
-       cores: {{ cores }}
+       sockets:{% if sockets %} {{ sockets }}{% endif %}
+       cores:{% if cores %} {{ cores }}{% endif %}
        threads: 1
        image: {{ fedora_container_disk }}
        limits:
@@ -68,8 +68,8 @@ spec:
          #- hostpassthrough
      client_vm:
        dedicatedcpuplacement: false
-       sockets: {{ sockets }}
-       cores: {{ cores }}
+       sockets:{% if sockets %} {{ sockets }}{% endif %}
+       cores:{% if cores %} {{ cores }}{% endif %}
        threads: 1
        image: {{ fedora_container_disk }}
        limits:

--- a/generate_golden_files.sh
+++ b/generate_golden_files.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -e
 
-python3 -m venv .venv
-. .venv/bin/activate
+if [ ! -d "venv" ]; then
+  python3 -m venv venv
+  . venv/bin/activate
+  pip install -e .
+else
+  . venv/bin/activate
+fi
 
 PYTHONPATH=. python3 \
   tests/unittest/benchmark_runner/common/template_operations/generate_golden_files.py

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
+          sockets:
           cores: 1
           threads: 1
         devices:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -121,8 +121,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-1'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:
@@ -197,8 +197,8 @@ spec:
         kubernetes.io/hostname: 'pin-node-2'
       domain:
         cpu:
-          sockets: 
-          cores: 
+          sockets:
+          cores:
           threads: 1
         devices:
           disks:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->

- Fix detect-aws-credentials pre-commit hook failing with exit code 2 when no AWS credentials are configured locally by adding --allow-missing-credentials flag

- Fix generate_golden_files.sh to properly create and reuse a virtual environment instead of creating an empty .venv without dependencies

- Remove trailing whitespace from golden files (auto-fixed by trailing-whitespace pre-commit hook)

Generated with [Cursor](https://cursor.com/)

## For security reasons, all pull requests need to be approved first before running any automated CI
