### PR TITLE
Fix IsADirectoryError in get_sorted_resources by skipping directories

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_ocp_resource.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource.py
@@ -61,8 +61,12 @@ class CreateOCPResource:
         :param resource:
         :return:
         """
-        for resource_file in os.listdir(os.path.join(self.__dir_path, resource, 'template')):
-            with open(os.path.join(self.__dir_path, resource, 'template', resource_file)) as f:
+        template_dir = os.path.join(self.__dir_path, resource, 'template')
+        for resource_file in os.listdir(template_dir):
+            resource_file_path = os.path.join(template_dir, resource_file)
+            if os.path.isdir(resource_file_path):
+                continue
+            with open(resource_file_path) as f:
                 template_str = f.read()
             tm = Template(template_str, keep_trailing_newline=True)
             data = tm.render(self.__environment_variables_dict)


### PR DESCRIPTION
## Summary
- `get_sorted_resources()` was failing with `IsADirectoryError` when `__pycache__` existed in the template directory
Fixing the following cnv installation [error](https://github.com/redhat-performance/benchmark-runner/actions/runs/24820227273/job/72643124018#step:7:130)

- Added a check to skip directories when iterating template files in `cnv/template/`
- Fixes Operators installation failure during OCP resource creation

## Test plan
- [ ] Verify CNV installation completes without `IsADirectoryError`
- [ ] Verify other resource installations (odf, kata, lso) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)