### PR TITLE
Upgrade moto to 5.1.22 to fix DeprecationWarning

### DIFF
--- a/tests/unittest/benchmark_runner/common/clouds/shared/s3/test_s3_operations.py
+++ b/tests/unittest/benchmark_runner/common/clouds/shared/s3/test_s3_operations.py
@@ -6,14 +6,10 @@ from os import listdir
 from os.path import isfile, join
 from benchmark_runner.common.clouds.shared.s3.s3_operations import S3Operations
 
-# walk around for moto DeprecationWarning
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    from moto import mock_s3
+from moto import mock_aws
 
 
-@mock_s3
+@mock_aws
 def test_upload_file():
     """ This test for testing upload data into s3 bucket"""
     expected_file_name = 'file.txt'
@@ -30,7 +26,7 @@ def test_upload_file():
         assert s3operations.file_exist(bucket='benchmark', key='test-data', file_name=expected_file_name)
 
 
-@mock_s3
+@mock_aws
 def test_download_file():
     """ This test for testing upload data into s3 bucket"""
     expected_file_name = 'file.txt'
@@ -48,7 +44,7 @@ def test_download_file():
             assert os.path.exists(os.path.join(temp_local_directory2, expected_file_name))
 
 
-@mock_s3
+@mock_aws
 def test_upload_objects():
     """ This test for testing upload data into s3 bucket"""
     expected_files_list = ['file1.txt', 'file2.txt']
@@ -68,7 +64,7 @@ def test_upload_objects():
     assert sorted(actual_files_list) == sorted(expected_files_list)
 
 
-@mock_s3
+@mock_aws
 def test_upload_objects_no_key():
     """ This test for testing upload data into s3 bucket"""
     expected_files_list = ['file1.txt', 'file2.txt']
@@ -89,7 +85,7 @@ def test_upload_objects_no_key():
         assert sorted(actual_files_list) == sorted(expected_files_list)
 
 
-@mock_s3
+@mock_aws
 def test_download_objects():
     """ This test for testing upload data into s3 bucket"""
     expected_files_list = ['file1.txt', 'file2.txt']
@@ -108,7 +104,7 @@ def test_download_objects():
     assert sorted(actual_files_list) == sorted(expected_files_list)
 
 
-@mock_s3
+@mock_aws
 def test_download_objects_no_key():
     """ This test for testing upload data into s3 bucket"""
     expected_files_list = ['file1.txt', 'file2.txt']
@@ -128,7 +124,7 @@ def test_download_objects_no_key():
         assert sorted(actual_files_list) == sorted(expected_files_list)
 
 
-@mock_s3
+@mock_aws
 def test_file_exist():
     """ This test for testing upload data into s3 bucket"""
     expected_file_name = 'file.txt'
@@ -143,7 +139,7 @@ def test_file_exist():
         assert s3operations.file_exist(bucket='benchmark', key='test-data', file_name=expected_file_name)
 
 
-@mock_s3
+@mock_aws
 def test_file_delete():
     """ This test for testing upload data into s3 bucket"""
     expected_file_name = 'file.txt'
@@ -159,7 +155,7 @@ def test_file_delete():
         assert not s3operations.file_exist(bucket='benchmark', key='test-data', file_name=expected_file_name)
 
 
-@mock_s3
+@mock_aws
 def test_folder_delete():
     """ This test for testing upload data into s3 bucket"""
     expected_files_list = ['file1.txt', 'file2.txt']

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -3,7 +3,7 @@ elasticsearch==7.16.1
 elasticsearch_dsl==7.4.0
 jinja2==3.1.6
 mock
-moto==4.0.1
+moto==5.1.22
 pandas
 pytest
 PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- Upgrade moto from 4.0.1 to 5.1.22 in `tests_requirements.txt`
- Replace deprecated `mock_s3` decorator with `mock_aws` in S3 tests
- Remove the `warnings` suppression workaround that was no longer effective at runtime

Fixes the `datetime.datetime.utcnow()` DeprecationWarning in test output.

## Test plan
- [x] All 9 S3 tests pass with zero warnings locally
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)