### PR TITLE
Make HammerDB MariaDB InnoDB buffer settings configurable per run_type

### DIFF
--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -44,6 +44,13 @@ template_data:
       db_type: mariadb
       db_user: root
       db_server_pod: mariadb-deployment.mariadb-db
+      run_type:
+        perf_ci:
+          innodb_buffer_pool_size: 8192M
+          innodb_log_buffer_size: 2048M
+        default:
+          innodb_buffer_pool_size: 4096M
+          innodb_log_buffer_size: 1024M
     mssql:
       db_image: mssql2022-centos9-container-disk:latest
       db_pass: s3curePasswordString

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_pod_template.yaml
@@ -63,9 +63,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = {{ innodb_buffer_pool_size }}
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = {{ innodb_log_buffer_size }}
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
@@ -32,9 +32,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = {{ innodb_buffer_pool_size }}
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = {{ innodb_log_buffer_size }}
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ data:
 
         innodb_buffer_pool_size = 8192M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 2048M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -38,7 +38,7 @@ data:
 
         innodb_buffer_pool_size = 8192M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 2048M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -25,7 +25,7 @@ data:
 
         innodb_buffer_pool_size = 8192M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 2048M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -38,7 +38,7 @@ data:
 
         innodb_buffer_pool_size = 8192M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 2048M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -30,7 +30,7 @@ stringData:
 
           innodb_buffer_pool_size = 8192M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 2048M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -30,7 +30,7 @@ stringData:
 
           innodb_buffer_pool_size = 8192M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 2048M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -23,9 +23,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -36,9 +36,9 @@ data:
         myisam_sort_buffer_size = 2M
         max_connections = 151
 
-        innodb_buffer_pool_size = 8192M
+        innodb_buffer_pool_size = 4096M
         innodb_log_file_size = 2457M
-        innodb_log_buffer_size = 2457M
+        innodb_log_buffer_size = 1024M
         innodb_file_per_table = 1
         innodb_flush_method = O_DIRECT
         innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -28,9 +28,9 @@ stringData:
           myisam_sort_buffer_size = 2M
           max_connections = 151
 
-          innodb_buffer_pool_size = 8192M
+          innodb_buffer_pool_size = 4096M
           innodb_log_file_size = 2457M
-          innodb_log_buffer_size = 2457M
+          innodb_log_buffer_size = 1024M
           innodb_file_per_table = 1
           innodb_flush_method = O_DIRECT
           innodb_adaptive_flushing = 1


### PR DESCRIPTION
## Summary
- Templatize `innodb_buffer_pool_size` and `innodb_log_buffer_size` in MariaDB pod and VM templates (previously hardcoded)
- Add per-run_type values: perf_ci (8192M/2048M) and default (4096M/1024M)

## Test plan
- [ ] Run HammerDB MariaDB workload with `default` and `perf_ci` run_types
- [ ] Verify no impact on postgres or mssql workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * MariaDB InnoDB memory configuration parameters are now dynamically configurable by test run type, enabling flexible resource allocation across different benchmark scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->