### PR TITLE
Fix regression for uperf and stressng to match original behavior

### DIFF
--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
@@ -37,10 +37,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: {{ requests_cpu }}
             memory: {{ requests_memory }}
           limits:
-            cpu: {{ limits_cpu }}
             memory: {{ limits_memory }}
       terminationGracePeriodSeconds: 180
       volumes:

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
@@ -149,10 +149,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: {{ requests_cpu }}
             memory: {{ requests_memory }}
           limits:
-            cpu: {{ limits_cpu }}
             memory: {{ limits_memory }}
       terminationGracePeriodSeconds: 180
       networks:
@@ -228,10 +226,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: {{ requests_cpu }}
             memory: {{ requests_memory }}
           limits:
-            cpu: {{ limits_cpu }}
             memory: {{ limits_memory }}
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 60
             memory: 75Gi
           limits:
-            cpu: 60
             memory: 75Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 60
             memory: 75Gi
           limits:
-            cpu: 60
             memory: 75Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 60
             memory: 75Gi
           limits:
-            cpu: 60
             memory: 75Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 60
             memory: 75Gi
           limits:
-            cpu: 60
             memory: 75Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 60
             memory: 75Gi
           limits:
-            cpu: 60
             memory: 75Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 60
             memory: 75Gi
           limits:
-            cpu: 60
             memory: 75Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 8
             memory: 8Gi
           limits:
-            cpu: 8
             memory: 8Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -35,10 +35,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -143,10 +143,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:
@@ -216,10 +214,8 @@ spec:
           type: ""
         resources:
           requests:
-            cpu: 10m
             memory: 1Gi
           limits:
-            cpu: 2
             memory: 1Gi
       terminationGracePeriodSeconds: 180
       networks:


### PR DESCRIPTION
## Type of change
- [x] bug

## Description
Removed CPU resource limits from uperf and stressng VM templates to match original benchmark-operator behavior. The explicit CPU limits forced Guaranteed QoS with CFS throttling, causing around 30% throughput regression on uperf 64-byte 8-thread VM tests (earlier was 3.5 Gbps, now 4.93 Gbps). 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit CPU requests and limits from VirtualMachine templates used by benchmarks; memory requests/limits remain configured.
  * As a result, CPU scheduling and capping for benchmark VMs will follow cluster defaults rather than previously specified values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->