### PR TITLE
Remove @logger_time_stamp from parse_prometheus_metrics

### DIFF
--- a/benchmark_runner/common/prometheus/prometheus_metrics_operations.py
+++ b/benchmark_runner/common/prometheus/prometheus_metrics_operations.py
@@ -9,7 +9,7 @@ from urllib3 import disable_warnings
 disable_warnings(InsecureRequestWarning)
 
 from benchmark_runner.main.environment_variables import environment_variables
-from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
+from benchmark_runner.common.logger.logger_time_stamp import logger
 
 
 class PrometheusMetricsOperation:
@@ -166,7 +166,6 @@ class PrometheusMetricsOperation:
             raise Exception('Missing ElasticSearch data')
 
     @staticmethod
-    @logger_time_stamp
     def parse_prometheus_metrics(data: dict):
         """
         This method parses prometheus metrics and returns summary result


### PR DESCRIPTION
## Summary
- The `@logger_time_stamp` decorator on `parse_prometheus_metrics` logs all `kwargs` on method entry
- Since callers pass `data=metric_results`, the entire Prometheus metrics data blob gets dumped into CI output (thousands of lines of raw metric values)
- Remove the decorator — this method is just a parser and doesn't need timing instrumentation

## Test plan
- [ ] Run a workload with `ENABLE_PROMETHEUS_SNAPSHOT=True` and verify Prometheus metrics data is no longer dumped to CI output
- [ ] Verify Prometheus metrics are still correctly parsed and uploaded to Elasticsearch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logging implementation for metrics operations, removing redundant timestamp injection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->