### PR TITLE
Fix MSSQL pod permission denied by running container as root

### DIFF
--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_pod_template.yaml
@@ -80,7 +80,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           {%- if storage_type == 'lso' or odf_pvc == True %}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_kata_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -38,7 +38,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
       volumes:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -51,7 +51,10 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
+        # MSSQL 2022 defaults to non-root user 'mssql' which cannot create /.system;
+        # runAsUser: 0 + allowPrivilegeEscalation are both required for sqlservr to start.
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
           - name: mssql-persistent-storage


### PR DESCRIPTION
## Summary
- MSSQL 2022 runs as non-root user `mssql` by default and fails to create `/.system` at startup with `Permission denied`
- Add `runAsUser: 0` to the MSSQL container `securityContext` in the pod template so it runs as root (permitted by the existing `anyuid` SCC)
- Update all 20 MSSQL golden test files to match

## Test plan
- [ ] Run `hammerdb_pod_mssql` workload and verify MSSQL starts without permission errors
- [ ] Run `hammerdb_pod_mssql_lso` workload and verify the same
- [ ] Verify HammerDB results are parsed and uploaded to Elasticsearch
- [ ] Run unit tests to confirm golden files match


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment templates updated to run the SQL Server container as UID 0 (root) while retaining privilege escalation to ensure the database starts correctly with MSSQL 2022 defaults.

* **Tests**
  * Golden test fixtures across CI/perf/release scenarios updated to reflect the adjusted container runtime/security configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->