### PR TITLE
Fix bootstorm VM scale: add process join timeout to prevent workflow hangs

### DIFF
--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -6,7 +6,7 @@ from multiprocessing import Process, Manager
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
 from benchmark_runner.workloads.workloads_operations import WorkloadsOperations
-from benchmark_runner.common.oc.oc import VMStatus
+from benchmark_runner.common.oc.oc import OC, VMStatus
 
 
 class BootstormVM(WorkloadsOperations):
@@ -449,7 +449,11 @@ class BootstormVM(WorkloadsOperations):
                             p.start()
                             proc.append(p)
                         for p in proc:
-                            p.join()
+                            p.join(timeout=OC.SHORT_TIMEOUT)
+                            if p.is_alive():
+                                p.terminate()
+                                p.join(timeout=30)
+                                logger.error(f'Process {p.name} timed out in {target.__name__}, terminated')
                         # sleep between bulks
                         time.sleep(self._bulk_sleep_time)
                         proc = []

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -453,7 +453,12 @@ class BootstormVM(WorkloadsOperations):
                             if p.is_alive():
                                 p.terminate()
                                 p.join(timeout=OC.DELAY)
-                                logger.error(f'Process {p.name} timed out in {target.__name__}, terminated')
+                                if p.is_alive():
+                                    p.kill()
+                                    p.join(timeout=OC.DELAY)
+                                    logger.error(f'Process {p.name} killed in {target.__name__} after terminate failed')
+                                else:
+                                    logger.error(f'Process {p.name} timed out in {target.__name__}, terminated')
                         # sleep between bulks
                         time.sleep(self._bulk_sleep_time)
                         proc = []

--- a/benchmark_runner/workloads/bootstorm_vm.py
+++ b/benchmark_runner/workloads/bootstorm_vm.py
@@ -452,7 +452,7 @@ class BootstormVM(WorkloadsOperations):
                             p.join(timeout=OC.SHORT_TIMEOUT)
                             if p.is_alive():
                                 p.terminate()
-                                p.join(timeout=30)
+                                p.join(timeout=OC.DELAY)
                                 logger.error(f'Process {p.name} timed out in {target.__name__}, terminated')
                         # sleep between bulks
                         time.sleep(self._bulk_sleep_time)


### PR DESCRIPTION
## Summary
- `subprocess.getoutput()` used by `virtctl stop` (and other commands) has no timeout, so `p.join()` blocks forever when the command hangs at scale (100+ VMs)
- Add `OC.SHORT_TIMEOUT` (600s) to `p.join()` and terminate hung child processes
- Prevents the workflow from getting stuck on the stop step when `virtctl stop` hangs due to API server overload

## Test plan
- [ ] Run Windows VM bootstorm at scale (100+ VMs) and verify workflow no longer gets stuck on stop step
- [ ] Verify terminated processes are logged with `timed out in <step>, terminated`
- [ ] Verify normal (non-hanging) runs are unaffected by the timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VM workload benchmarks now enforce execution timeouts to prevent indefinite hangs and automatically terminate runaway processes, with a grace period before forceful kill.
  * Error messages enhanced to include the affected process and the active workload step, improving diagnosability and monitoring of timeout events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->