### PR TITLE
Update Windows server 2025 in bootstorm workload

### DIFF
--- a/.github/workflows/Nightly_Perf_Env_CI.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI.yml
@@ -108,10 +108,9 @@ jobs:
 #              - 'vdbench_vm_scale'
 #              - 'clusterbuster'
 #              - 'bootstorm_vm_scale'
-#              - 'windows_vm_scale_windows10'
 #              - 'windows_vm_scale_windows11'
-#              - 'windows_vm_scale_windows_server_2019'
 #              - 'windows_vm_scale_windows_server_2022'
+#              - 'windows_vm_scale_windows_server_2025'
 
     steps:
     - uses: actions/checkout@v6
@@ -183,10 +182,9 @@ jobs:
         THREADS_LIMIT: 20
         RUN_TYPE: 'test_ci'
         ENABLE_PROMETHEUS_SNAPSHOT: 'True'
-        WINDOWS10_URL: ${{ secrets.PERF_WINDOWS10_URL }}
         WINDOWS11_URL: ${{ secrets.PERF_WINDOWS11_URL }}
-        WINDOWS_SERVER_2019_URL: ${{ secrets.PERF_WINDOWS_SERVER_2019_URL }}
         WINDOWS_SERVER_2022_URL: ${{ secrets.PERF_WINDOWS_SERVER_2022_URL }}
+        WINDOWS_SERVER_2025_URL: ${{ secrets.PERF_WINDOWS_SERVER_2025_URL }}
       run: |
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"
@@ -206,10 +204,9 @@ jobs:
             elif [[ "$WORKLOAD" == "windows_vm" ]]
             then
               case "${{ matrix.workload }}" in
-                   "windows_vm_scale_windows10") WINDOWS_URL=$WINDOWS10_URL ;;
                    "windows_vm_scale_windows11") WINDOWS_URL=$WINDOWS11_URL ;;
-                   "windows_vm_scale_windows_server_2019") WINDOWS_URL=$WINDOWS_SERVER_2019_URL ;;
                    "windows_vm_scale_windows_server_2022") WINDOWS_URL=$WINDOWS_SERVER_2022_URL ;;
+                   "windows_vm_scale_windows_server_2025") WINDOWS_URL=$WINDOWS_SERVER_2025_URL ;;
                     *) echo "Unknown Windows scale workload ${{ matrix.workload }}"; exit 1 ;;
               esac
               # Warm-up: Load DV for Windows

--- a/.github/workflows/Nightly_Perf_Env_CI_Scale.yml
+++ b/.github/workflows/Nightly_Perf_Env_CI_Scale.yml
@@ -77,10 +77,9 @@ jobs:
               - 'vdbench_kata_scale'
               - 'vdbench_vm_scale'
               - 'bootstorm_vm_scale'
-              - 'windows_vm_scale_windows10'
               - 'windows_vm_scale_windows11'
-              - 'windows_vm_scale_windows_server_2019'
               - 'windows_vm_scale_windows_server_2022'
+              - 'windows_vm_scale_windows_server_2025'
 
     steps:
     - uses: actions/checkout@v6
@@ -152,10 +151,9 @@ jobs:
         THREADS_LIMIT: 20
         RUN_TYPE: 'perf_ci'
         ENABLE_PROMETHEUS_SNAPSHOT: 'True'
-        WINDOWS10_URL: ${{ secrets.PERF_WINDOWS10_URL }}
         WINDOWS11_URL: ${{ secrets.PERF_WINDOWS11_URL }}
-        WINDOWS_SERVER_2019_URL: ${{ secrets.PERF_WINDOWS_SERVER_2019_URL }}
         WINDOWS_SERVER_2022_URL: ${{ secrets.PERF_WINDOWS_SERVER_2022_URL }}
+        WINDOWS_SERVER_2025_URL: ${{ secrets.PERF_WINDOWS_SERVER_2025_URL }}
       run: |
         build=$(pip freeze | grep benchmark-runner | sed 's/==/=/g')
         build_version="$(cut -d'=' -f2 <<<"$build")"
@@ -175,10 +173,9 @@ jobs:
             elif [[ "$WORKLOAD" == "windows_vm" ]]
             then
               case "${{ matrix.workload }}" in
-                   "windows_vm_scale_windows10") WINDOWS_URL=$WINDOWS10_URL ;;
                    "windows_vm_scale_windows11") WINDOWS_URL=$WINDOWS11_URL ;;
-                   "windows_vm_scale_windows_server_2019") WINDOWS_URL=$WINDOWS_SERVER_2019_URL ;;
                    "windows_vm_scale_windows_server_2022") WINDOWS_URL=$WINDOWS_SERVER_2022_URL ;;
+                   "windows_vm_scale_windows_server_2025") WINDOWS_URL=$WINDOWS_SERVER_2025_URL ;;
                     *) echo "Unknown Windows scale workload ${{ matrix.workload }}"; exit 1 ;;
               esac
               # Warm-up: Load DV for Windows

--- a/benchmark_runner/jupyterlab/templates/summary_report/summary_report_operations.py
+++ b/benchmark_runner/jupyterlab/templates/summary_report/summary_report_operations.py
@@ -22,7 +22,7 @@ class SummaryReportOperations:
     VDBENCH_LATENCY_METRIC = 'Latency'
     VDBENCH_IOPS_METRIC = 'Iops'
     BOOTSTORM_FEDORA = 'fedora37'
-    BOOTSTORM_WINDOWS = ['windows10', 'windows11', 'windows_server_2019', 'windows_server_2022']
+    BOOTSTORM_WINDOWS = [ 'windows11', 'windows_server_2022', 'windows_server_2025']
     BOOTSTORM_FEDORA_METRIC = '240 VMs run time'
     BOOTSTORM_WINDOWS_METRIC = '111 VMs run time'
 

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -21,9 +21,8 @@ pipeline {
         RUN_ARTIFACTS_URL = credentials('perfci_run_artifacts_url')
         REDIS = credentials('perfci_redis')
         WORKER_DISK_IDS = credentials('perfci_worker_disk_ids')
-        WINDOWS10_URL = credentials('perfci_windows10_url')
         WINDOWS11_URL = credentials('perfci_windows11_url')
-        WINDOWS_SERVER_2019_URL = credentials('perfci_windows_server_2019_url')
+        WINDOWS_SERVER_2025_URL = credentials('perfci_windows_server_2025_url')
         WINDOWS_SERVER_2022_URL = credentials('perfci_windows_server_2022_url')
         WINDOWS_SERVER_MSSQL_2022_URL = credentials('perfci_windows_server_mssql_2022_url')
         LSO_NODE = credentials('perfci_lso_node')
@@ -105,7 +104,7 @@ END
         stage('WORKLOADS Deployment') {
             steps {
                 script {
-                    def workloads =  ['uperf_pod', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb','hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'winmssql_vm', 'vdbench_pod', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_vm_scale', 'bootstorm_vm_scale', 'windows_vm_scale_windows10', 'windows_vm_scale_windows11', 'windows_vm_scale_windows_server_2019', 'windows_vm_scale_windows_server_2022' ]
+                    def workloads =  ['uperf_pod', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb','hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'winmssql_vm', 'vdbench_pod', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_vm_scale', 'bootstorm_vm_scale', 'windows_vm_scale_windows11', 'windows_vm_scale_windows_server_2022', 'windows_vm_scale_windows_server_2025' ]
                     def build_version = sh(script: 'curl -s "https://pypi.org/pypi/benchmark-runner/json" | jq -r .info.version', returnStdout: true).trim()
                     def WINDOWS_URL = ''
                     def SCALE = ''
@@ -134,14 +133,11 @@ END
                                     }
                                     if (WORKLOAD == "windows_vm") {
                                         switch (workload) {
-                                            case "windows_vm_scale_windows10":
-                                                WINDOWS_URL = WINDOWS10_URL
-                                                break
                                             case "windows_vm_scale_windows11":
                                                 WINDOWS_URL = WINDOWS11_URL
                                                 break
-                                            case "windows_vm_scale_windows_server_2019":
-                                                WINDOWS_URL = WINDOWS_SERVER_2019_URL
+                                            case "windows_vm_scale_windows_server_2025":
+                                                WINDOWS_URL = WINDOWS_SERVER_2025_URL
                                                 break
                                             case "windows_vm_scale_windows_server_2022":
                                                 WINDOWS_URL = WINDOWS_SERVER_2022_URL


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Update Windows server 2025
Deleting Windows10 (EOL)
Deleting Windows server 2019 (EOL)

## For security reasons, all pull requests need to be approved first before running any automated CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Discontinued testing and deployment support for Windows 10 and Windows Server 2019.
  * Added Windows Server 2025 to the testing and performance benchmarking infrastructure.
  * Updated CI/CD pipelines and reporting configurations to reflect the new Windows environment matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->