### PR TITLE
Replace stressng/uperf pod images with Fedora 43

### DIFF
--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
@@ -54,8 +54,11 @@ spec:
       {%- if kind == 'kata' %}
       runtimeClassName: kata
       {%- endif %}
+      serviceAccountName: {{ namespace }}
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         {%- if resources == 'true' or resources == true %}
         resources:
           requests:
@@ -65,7 +68,7 @@ spec:
             cpu: {{ limits_cpu }}
             memory: {{ limits_memory }}
         {%- endif %}
-        image: {{ image | default('quay.io/benchmark-runner/stressng:latest') }}
+        image: {{ image | default('quay.io/fedora/fedora:43') }}
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -106,6 +109,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
@@ -54,11 +54,8 @@ spec:
       {%- if kind == 'kata' %}
       runtimeClassName: kata
       {%- endif %}
-      serviceAccountName: {{ namespace }}
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         {%- if resources == 'true' or resources == true %}
         resources:
           requests:
@@ -68,7 +65,7 @@ spec:
             cpu: {{ limits_cpu }}
             memory: {{ limits_memory }}
         {%- endif %}
-        image: {{ image | default('quay.io/fedora/fedora:43') }}
+        image: {{ image | default('quay.io/benchmark-runner/fedora:43') }}
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -109,7 +106,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
@@ -109,7 +109,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_pod_template.yaml
@@ -65,7 +65,7 @@ spec:
             cpu: {{ limits_cpu }}
             memory: {{ limits_memory }}
         {%- endif %}
-        image: {{ image | default('quay.io/benchmark-runner/fedora:43') }}
+        image: {{ image | default(fedora) }}
         imagePullPolicy: Always
         env:
           - name: uuid

--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -12,7 +12,7 @@ template_data:
     run_id: NA
     runtype: sequential
     instances: 1
-    image: quay.io/benchmark-runner/stressng:latest
+    image: quay.io/fedora/fedora:43
     # cpu stressor options
     cpu_percentage: 100
     cpu_method: all

--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -12,7 +12,7 @@ template_data:
     run_id: NA
     runtype: sequential
     instances: 1
-    image: quay.io/fedora/fedora:43
+    image: quay.io/benchmark-runner/fedora:43
     # cpu stressor options
     cpu_percentage: 100
     cpu_method: all

--- a/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/stressng_data_template.yaml
@@ -12,7 +12,7 @@ template_data:
     run_id: NA
     runtype: sequential
     instances: 1
-    image: quay.io/benchmark-runner/fedora:43
+    image: "{{ fedora }}"
     # cpu stressor options
     cpu_percentage: 100
     cpu_method: all

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
@@ -20,12 +20,9 @@ spec:
       {%- if hostnetwork == 'true' or hostnetwork == true %}
       hostNetwork: true
       {%- endif %}
-      serviceAccountName: {{ namespace }}
       containers:
       - name: benchmark
-        image: {{ image | default('quay.io/fedora/fedora:43') }}
-        securityContext:
-          runAsUser: 0
+        image: {{ image | default('quay.io/benchmark-runner/fedora:43') }}
         env:
           - name: uuid
             value: "{{ uuid }}"
@@ -88,7 +85,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h="{{ server_ip }}"
             export port=30000

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
@@ -20,9 +20,12 @@ spec:
       {%- if hostnetwork == 'true' or hostnetwork == true %}
       hostNetwork: true
       {%- endif %}
+      serviceAccountName: {{ namespace }}
       containers:
       - name: benchmark
-        image: {{ image | default('quay.io/benchmark-runner/uperf:latest') }}
+        image: {{ image | default('quay.io/fedora/fedora:43') }}
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "{{ uuid }}"
@@ -85,6 +88,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h="{{ server_ip }}"
             export port=30000

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
@@ -22,7 +22,7 @@ spec:
       {%- endif %}
       containers:
       - name: benchmark
-        image: {{ image | default('quay.io/benchmark-runner/fedora:43') }}
+        image: {{ image | default(fedora) }}
         env:
           - name: uuid
             value: "{{ uuid }}"

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_client_template.yaml
@@ -88,7 +88,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h="{{ server_ip }}"
             export port=30000

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
@@ -178,12 +178,9 @@ spec:
       {%- if hostnetwork == 'true' or hostnetwork == true %}
       hostNetwork: true
       {%- endif %}
-      serviceAccountName: {{ namespace }}
       containers:
       - name: benchmark
-        image: {{ image | default('quay.io/fedora/fedora:43') }}
-        securityContext:
-          runAsUser: 0
+        image: {{ image | default('quay.io/benchmark-runner/fedora:43') }}
         {%- if server_resources is defined and server_resources %}
         resources:
           requests:
@@ -195,7 +192,7 @@ spec:
         {%- endif %}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       {%- if pin == 'true' or pin == true %}
       nodeSelector:

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
@@ -195,7 +195,7 @@ spec:
         {%- endif %}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       {%- if pin == 'true' or pin == true %}
       nodeSelector:

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
@@ -178,9 +178,12 @@ spec:
       {%- if hostnetwork == 'true' or hostnetwork == true %}
       hostNetwork: true
       {%- endif %}
+      serviceAccountName: {{ namespace }}
       containers:
       - name: benchmark
-        image: {{ image | default('quay.io/benchmark-runner/uperf:latest') }}
+        image: {{ image | default('quay.io/fedora/fedora:43') }}
+        securityContext:
+          runAsUser: 0
         {%- if server_resources is defined and server_resources %}
         resources:
           requests:
@@ -192,7 +195,7 @@ spec:
         {%- endif %}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       {%- if pin == 'true' or pin == true %}
       nodeSelector:

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
@@ -180,7 +180,7 @@ spec:
       {%- endif %}
       containers:
       - name: benchmark
-        image: {{ image | default('quay.io/benchmark-runner/fedora:43') }}
+        image: {{ image | default(fedora) }}
         {%- if server_resources is defined and server_resources %}
         resources:
           requests:

--- a/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
@@ -21,7 +21,7 @@ template_data:
     multus: false
     samples: 1
     pair: 1
-    image: quay.io/benchmark-runner/uperf:latest
+    image: quay.io/fedora/fedora:43
     protos:
       - tcp
   run_type:

--- a/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
@@ -21,7 +21,7 @@ template_data:
     multus: false
     samples: 1
     pair: 1
-    image: quay.io/fedora/fedora:43
+    image: quay.io/benchmark-runner/fedora:43
     protos:
       - tcp
   run_type:

--- a/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/uperf_data_template.yaml
@@ -21,7 +21,7 @@ template_data:
     multus: false
     samples: 1
     pair: 1
-    image: quay.io/benchmark-runner/fedora:43
+    image: "{{ fedora }}"
     protos:
       - tcp
   run_type:

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -88,6 +88,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['vm_password'] = EnvironmentVariables.get_env('VM_PASSWORD', '')
         self._environment_variables_dict['fedora_container_disk'] = EnvironmentVariables.get_env(
             'FEDORA_CONTAINER_DISK', 'quay.io/benchmark-runner/fedora-container-disk:43')
+        self._environment_variables_dict['fedora'] = EnvironmentVariables.get_env(
+            'FEDORA', 'quay.io/benchmark-runner/fedora:43')
         # windows url
         self._environment_variables_dict['windows_url'] = EnvironmentVariables.get_env('WINDOWS_URL', '')
         # Delete all resources before and after the run, default True

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -140,7 +140,9 @@ class EnvironmentVariables:
             'mariadb': 10.5,
             'db_vm_os_version': 'centos-stream9',
             'vm_os_version': 'fedora43',
-            'hammerdb': 4.12
+            'hammerdb': 4.12,
+            'stressng': '0.20.01',
+            'uperf': '1.0.8'
         }
 
         # Set namespace based on workload.

--- a/benchmark_runner/workloads/stressng_pod.py
+++ b/benchmark_runner/workloads/stressng_pod.py
@@ -68,6 +68,7 @@ class StressngPod(WorkloadsOperations):
             self._environment_variables_dict['kind'] = self.__kind
 
             self._oc.apply_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            self._oc.apply_security_privileged()
 
             self._oc.create_async(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),

--- a/benchmark_runner/workloads/stressng_pod.py
+++ b/benchmark_runner/workloads/stressng_pod.py
@@ -68,7 +68,6 @@ class StressngPod(WorkloadsOperations):
             self._environment_variables_dict['kind'] = self.__kind
 
             self._oc.apply_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
-            self._oc.apply_security_privileged()
 
             self._oc.create_async(
                 yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}.yaml'),

--- a/benchmark_runner/workloads/uperf_pod.py
+++ b/benchmark_runner/workloads/uperf_pod.py
@@ -72,6 +72,7 @@ class UperfPod(WorkloadsOperations):
             self._environment_variables_dict['kind'] = self.__kind
 
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
+            self._oc.apply_security_privileged()
 
             logger.info("Creating uperf server job")
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_server.yaml'))

--- a/benchmark_runner/workloads/uperf_pod.py
+++ b/benchmark_runner/workloads/uperf_pod.py
@@ -72,7 +72,6 @@ class UperfPod(WorkloadsOperations):
             self._environment_variables_dict['kind'] = self.__kind
 
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', 'namespace.yaml'))
-            self._oc.apply_security_privileged()
 
             logger.info("Creating uperf server job")
             self._oc.create_async(yaml=os.path.join(f'{self._run_artifacts_path}', f'{self.__name}_server.yaml'))

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -475,6 +475,10 @@ class WorkloadsOperations:
             metadata.update({'db_type': 'mariadb', 'db_version': product_versions.get('mariadb', 10.5), 'storage_type': self._storage_type})
         if database:
             metadata.update({'hammerdb_version': self._product_versions.get('hammerdb', 4.12)})
+        if 'stressng' in self._workload:
+            metadata.update({'stressng_version': self._product_versions.get('stressng', '0.20.01')})
+        if 'uperf' in self._workload:
+            metadata.update({'uperf_version': self._product_versions.get('uperf', '1.0.8')})
         if self._test_name:
             metadata.update({'test_name': self._test_name})
         if result:

--- a/dockerfiles/fedora43-pod/Dockerfile
+++ b/dockerfiles/fedora43-pod/Dockerfile
@@ -1,2 +1,2 @@
 FROM quay.io/fedora/fedora:43
-RUN dnf install -y stress-ng python3-pyyaml uperf && dnf clean all
+RUN dnf install -y stress-ng-0.20.01 python3-pyyaml-6.0.2 uperf-1.0.8 && dnf clean all

--- a/dockerfiles/fedora43-pod/Dockerfile
+++ b/dockerfiles/fedora43-pod/Dockerfile
@@ -1,0 +1,2 @@
+FROM quay.io/fedora/fedora:43
+RUN dnf install -y stress-ng python3-pyyaml uperf && dnf clean all

--- a/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
@@ -40,12 +40,9 @@ spec:
         benchmark-uuid: test-uuid-123
         benchmark-runner-workload: stressng
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -72,7 +69,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then

--- a/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
@@ -40,9 +40,12 @@ spec:
         benchmark-uuid: test-uuid-123
         benchmark-runner-workload: stressng
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
         image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -69,6 +72,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then

--- a/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: stressng
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid

--- a/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
+++ b/tests/integration/benchmark_runner/templates/stressng_pod_job_template.yaml
@@ -72,7 +72,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             if [ -f /tmp/stressng.yml ] && python3 -c 'import yaml' 2>/dev/null; then

--- a/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
         env:
           - name: uuid
             value: "test-uuid-123"

--- a/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
@@ -49,7 +49,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             export h="SERVER_IP_PLACEHOLDER"
             export port=30000
             # Simple stream test

--- a/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-test123
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
         image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "test-uuid-123"
@@ -46,6 +49,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             export h="SERVER_IP_PLACEHOLDER"
             export port=30000
             # Simple stream test

--- a/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_client_template.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-test123
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "test-uuid-123"
@@ -49,7 +46,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             export h="SERVER_IP_PLACEHOLDER"
             export port=30000
             # Simple stream test

--- a/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
@@ -28,5 +28,5 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never

--- a/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args: ["uperf -s -v -P 30000"]

--- a/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
@@ -20,10 +20,13 @@ spec:
         app: uperf-bench-server-0-test123
         type: uperf-bench-server-test123
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
         image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never

--- a/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
+++ b/tests/integration/benchmark_runner/templates/uperf_pod_server_template.yaml
@@ -20,13 +20,10 @@ spec:
         app: uperf-bench-server-0-test123
         type: uperf-bench-server-test123
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 60
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 60
             memory: 75Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -315,7 +315,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -307,15 +307,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -307,12 +307,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -315,7 +315,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -307,15 +307,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -307,12 +307,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -306,12 +306,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -306,15 +306,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -314,7 +314,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -306,12 +306,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -306,15 +306,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -314,7 +314,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -306,12 +306,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -306,15 +306,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -314,7 +314,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -306,12 +306,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -306,15 +306,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -314,7 +314,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,8 +44,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -53,7 +56,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -82,6 +85,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -44,11 +44,8 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -56,7 +53,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -85,7 +82,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_pod.yaml
@@ -85,7 +85,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,11 +43,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
-      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
-        securityContext:
-          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -55,7 +52,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/fedora/fedora:43
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -84,7 +81,6 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -84,7 +84,7 @@ spec:
         args:
           - |
             set -e
-            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
+            dnf install -y stress-ng python3-pyyaml > /dev/null || exit 1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_pod.yaml
@@ -43,8 +43,11 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'
+      serviceAccountName: benchmark-runner
       containers:
       - name: stressng
+        securityContext:
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +55,7 @@ spec:
           limits:
             cpu: 2
             memory: 1Gi
-        image: quay.io/benchmark-runner/stressng:latest
+        image: quay.io/fedora/fedora:43
         imagePullPolicy: Always
         env:
           - name: uuid
@@ -81,6 +84,7 @@ spec:
         args:
           - |
             set -e
+            dnf install -y stress-ng python3-pyyaml > /dev/null 2>&1
             cd /tmp
             stress-ng --job /workload/jobfile --log-file /tmp/stressng.log -Y /tmp/stressng.yml || exit 1
             # Parse results into JSON (visible in pod logs, uploaded by benchmark-runner)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,9 +15,12 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -71,6 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -74,7 +74,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_client.yaml
@@ -15,12 +15,9 @@ spec:
         type: uperf-bench-client-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -74,7 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -144,7 +144,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,12 +136,15 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_pod_server.yaml
@@ -136,15 +136,12 @@ spec:
         type: uperf-bench-server-deadbeef
     spec:
       runtimeClassName: kata
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,12 +14,9 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -73,7 +70,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -14,9 +14,12 @@ spec:
         app: uperf-bench-client
         type: uperf-bench-client-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         env:
           - name: uuid
             value: "deadbeef-0123-3210-cdef-01234567890abcdef"
@@ -70,6 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            dnf install -y uperf python3 > /dev/null 2>&1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_client.yaml
@@ -73,7 +73,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            dnf install -y uperf python3 > /dev/null 2>&1
+            dnf install -y uperf python3 > /dev/null || exit 1
             # Server IP passed from Python code
             export h=""
             export port=30000

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,12 +135,15 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
+      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/benchmark-runner/uperf:latest
+        image: quay.io/fedora/fedora:43
+        securityContext:
+          runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["uperf -s -v -P 30000"]
+        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -143,7 +143,7 @@ spec:
           runAsUser: 0
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["dnf install -y uperf > /dev/null 2>&1 && uperf -s -v -P 30000"]
+        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -135,15 +135,12 @@ spec:
         index: "0"
         type: uperf-bench-server-deadbeef
     spec:
-      serviceAccountName: benchmark-runner
       containers:
       - name: benchmark
-        image: quay.io/fedora/fedora:43
-        securityContext:
-          runAsUser: 0
+        image: quay.io/benchmark-runner/fedora:43
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ["(dnf install -y uperf > /dev/null || exit 1) && uperf -s -v -P 30000"]
+        args: ["uperf -s -v -P 30000"]
       restartPolicy: Never
       nodeSelector:
         kubernetes.io/hostname: 'pin-node-1'


### PR DESCRIPTION
## Summary
- Replace old UBI 8 pod images (`stressng:latest`, `uperf:latest`) with single pre-built `quay.io/benchmark-runner/fedora:43`
- New Dockerfile at `dockerfiles/fedora43-pod/` with pinned versions: stress-ng-0.20.01, uperf-1.0.8, python3-pyyaml-6.0.2
- Add `FEDORA` env variable for pod image reference (single place to update)
- Add `stressng_version` and `uperf_version` tracking to ElasticSearch metadata