### PR TITLE
Pin stressng/uperf versions in VM cloud-init templates

### DIFF
--- a/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/stressng/internal_data/stressng_vm_template.yaml
@@ -58,7 +58,7 @@ spec:
                 - {{ ssh_public_key }}
               {%- endif %}
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_vm_template.yaml
@@ -15,7 +15,7 @@ stringData:
       - "{{ ssh_public_key }}"
     {%- endif %}
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -80,7 +80,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -173,7 +173,7 @@ spec:
                 - {{ ssh_public_key }}
               {%- endif %}
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_kata_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_pod_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_False/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_stressng_vm_ODF_PVC_True/stressng_vm.yaml
@@ -52,7 +52,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - stress-ng
+                - stress-ng-0.20.01
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_kata_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_vm.yaml
@@ -11,7 +11,7 @@ stringData:
     chpasswd: { expire: False }
     ssh_pwauth: true
     packages:
-      - uperf
+      - uperf-1.0.8
     write_files:
       - path: /tmp/uperf_parser.py
         permissions: '0755'
@@ -76,7 +76,7 @@ stringData:
       - export HOME=/root
       - export TMP=/tmp
       - export TEMP=/tmp
-      - dnf install -y uperf || true
+      - dnf install -y uperf-1.0.8 || true
       - for nic in $(ls /sys/class/net/ | grep -v lo); do ethtool -L $nic combined $(nproc) 2>/dev/null; done || true
       - sleep 30
       - |
@@ -163,7 +163,7 @@ spec:
               chpasswd: { expire: False }
               ssh_pwauth: true
               packages:
-                - uperf
+                - uperf-1.0.8
               runcmd:
                 - export HOME=/root
                 - export TMP=/tmp


### PR DESCRIPTION
## Summary
- Pin stress-ng to 0.20.01 and uperf to 1.0.8 in VM cloud-init templates
- Matches the pinned versions in pod Dockerfile and ES metadata
- Ensures reproducible benchmark results across VM runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned stress-ng to version 0.20.01 across benchmark templates and test configurations to ensure consistent tool versioning.
  * Pinned uperf to version 1.0.8 across benchmark templates and test configurations to ensure consistent tool versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->