### PR TITLE
Fix Python version detection to skip unreleased versions

### DIFF
--- a/hack/get_latest_python_patch.py
+++ b/hack/get_latest_python_patch.py
@@ -2,65 +2,77 @@
 """
 Find the latest point release for a given Python minor version (e.g. 3.14)
 by parsing https://www.python.org/ftp/python/
+Validates that the source tarball actually exists (not just an RC directory).
 Used at Docker build time to install the latest bugfix release.
 """
 from html.parser import HTMLParser
+import logging
 import sys
 import urllib.request
 import urllib.error
+
+logger = logging.getLogger(__name__)
 
 URL = 'https://www.python.org/ftp/python/'
 
 
 def find_best_python_version(release):
-    class FindPythonVersion(HTMLParser):
+    class FindPythonVersions(HTMLParser):
         def __init__(self, release):
             super().__init__()
             self.release = release
             self.start = f'{release}.'
-            self.best_found_version = None
+            self.candidates = []
 
         def handle_starttag(self, tag, attrs):
             if tag == 'a':
-                try:
-                    for name, value in attrs:
-                        if name == 'href':
-                            if value.startswith(self.start):
-                                point = int(value.removeprefix(self.start).rstrip('/'))
-                                if self.best_found_version is None or point > self.best_found_version:
-                                    self.best_found_version = point
-                                    return
-                except Exception:
-                    pass
-
-        def get_best_version(self):
-            return self.best_found_version
+                for name, value in attrs:
+                    if name != 'href' or not value.startswith(self.start):
+                        continue
+                    suffix = value.removeprefix(self.start).rstrip('/')
+                    if suffix.isdigit():
+                        self.candidates.append(int(suffix))
+                        return
 
     try:
-        with urllib.request.urlopen(URL) as response:
+        with urllib.request.urlopen(URL, timeout=30) as response:
             data = response.read().decode('utf-8')
     except urllib.error.HTTPError as e:
-        print(f'HTTP error: {e.code} {e.reason}', file=sys.stderr)
+        logger.error(f'HTTP error: {e.code} {e.reason}')
         sys.exit(1)
     except urllib.error.URLError as e:
-        print(f'URL error: {e.reason}', file=sys.stderr)
+        logger.error(f'URL error: {e.reason}')
         sys.exit(1)
 
-    parser = FindPythonVersion(release)
+    parser = FindPythonVersions(release)
     try:
         parser.feed(data)
-        if parser.get_best_version() is not None:
-            print(parser.get_best_version())
-        else:
-            print(f'Cannot find python version for {release}', file=sys.stderr)
-            sys.exit(1)
     except Exception as e:
-        print(f'Cannot find python version for {release}: {e}', file=sys.stderr)
+        logger.error(f'Cannot parse python versions for {release}: {e}')
         sys.exit(1)
+
+    if not parser.candidates:
+        logger.error(f'Cannot find python version for {release}')
+        sys.exit(1)
+
+    for patch in sorted(parser.candidates, reverse=True):
+        tarball_url = f'{URL}{release}.{patch}/Python-{release}.{patch}.tgz'
+        try:
+            req = urllib.request.Request(tarball_url, method='HEAD')
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status == 200:
+                    print(patch)
+                    return
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            continue
+
+    logger.error(f'No downloadable python tarball found for {release}')
+    sys.exit(1)
 
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     if len(sys.argv) != 2:
-        print(f'Usage: {sys.argv[0]} <minor_version> (e.g. 3.14)', file=sys.stderr)
+        logger.error(f'Usage: {sys.argv[0]} <minor_version> (e.g. 3.14)')
         sys.exit(1)
     find_best_python_version(sys.argv[1])


### PR DESCRIPTION
## Summary
- Fix get_latest_python_patch.py to validate the source tarball exists via HTTP HEAD before accepting a version
- Prevents CI failures when python.org creates a directory for an RC but the final tarball isn't released yet
- Currently broken: script returns 3.14.5 (RC directory exists) but Python-3.14.5.tgz doesn't exist, causing 404 in Dockerfile build
- With fix: correctly returns 3.14.4 (latest version with actual tarball)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable selection of Python patch releases by confirming source tarballs are reachable before choosing a patch.
  * Clearer, consistent error reporting when parsing fails or when no suitable patches are found.

* **Refactor**
  * Improved discovery logic to gather and validate multiple candidate patches for more robust selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->