### PR TITLE
Remove stressng/uperf version pinning

### DIFF
--- a/dockerfiles/fedora43-pod/Dockerfile
+++ b/dockerfiles/fedora43-pod/Dockerfile
@@ -1,2 +1,2 @@
 FROM quay.io/fedora/fedora:43
-RUN dnf install -y stress-ng-0.20.01 python3-pyyaml-6.0.2 uperf-1.0.8 && dnf clean all
+RUN dnf install -y stress-ng python3-pyyaml uperf && dnf clean all


### PR DESCRIPTION
## Summary
- Remove version pinning from Dockerfile, install latest stress-ng/uperf/python3-pyyaml
- Matches benchmark-operator behavior of always using latest versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration to install latest available versions of development tools instead of specific pinned versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->