### PR TITLE
Support HammerDB flat run using the HAMMERDB_CONFIG environment variable

### DIFF
--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -150,6 +150,11 @@ class TemplateOperations:
 
         render_data = self.__build_template_data(template_render_data, workload_data)
 
+        hammerdb_config = self.__environment_variables_dict.get('hammerdb_config', {})
+        if hammerdb_config:
+            logger.info(f'HAMMERDB_CONFIG override: {hammerdb_config}')
+            render_data.update(hammerdb_config)
+
         out_files = []
         standard_template_path = os.path.join(workload_dir_path, 'internal_data', self.__standard_template_file)
         if os.path.isfile(standard_template_path):

--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -153,6 +153,14 @@ class TemplateOperations:
 
         render_data = self.__build_template_data(template_render_data, workload_data)
 
+        hammerdb_config = self.__environment_variables_dict.get('hammerdb_config', {})
+        if hammerdb_config and 'hammerdb' in self.__workload_name:
+            unknown_keys = set(hammerdb_config.keys()) - set(render_data.keys())
+            if unknown_keys:
+                logger.warning(f'HAMMERDB_CONFIG unknown keys (will be ignored): {unknown_keys}')
+            logger.info(f'HAMMERDB_CONFIG override: {hammerdb_config}')
+            render_data.update(hammerdb_config)
+
         out_files = []
         standard_template_path = os.path.join(workload_dir_path, 'internal_data', self.__standard_template_file)
         if os.path.isfile(standard_template_path):

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -9,6 +9,8 @@ template_data:
     pin_node2: "{{ pin_node2 }}"
     odf_pvc: {{ odf_pvc }}
     transactions: 100000
+    db_min_workers: 1
+    iterations: 2
     rampup: 1
     runtime: 1
   run_type:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_configmap.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_configmap.yaml
@@ -94,7 +94,7 @@ data:
     set workers {{ db_num_workers }}
     set transactions {{ transactions }}
     set samples 1
-    for {set w 1} { $w <= $workers } { set w [expr {$w*2}] } {
+    for {set w {{ db_min_workers }}} { $w <= $workers } { set w [expr {$w*2}] } {
     puts "$w VU TEST"
     for {set i 1} {$i <= $samples} {incr i} {
         puts "============ RUNNING SAMPLE $i: $w WORKERS ============"

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_configmap.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_configmap.yaml
@@ -106,7 +106,7 @@ data:
     set workers {{ db_num_workers }}
     set transactions {{ transactions }}
     set samples 1
-    for {set w 1} { $w <= $workers } { set w [expr {$w*2}] } {
+    for {set w {{ db_min_workers }}} { $w <= $workers } { set w [expr {$w*2}] } {
     puts "$w VU TEST"
     for {set i 1} {$i <= $samples} {incr i} {
         puts "============ RUNNING SAMPLE $i: $w WORKERS ============"

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_configmap.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_configmap.yaml
@@ -94,7 +94,7 @@ data:
     set workers {{ db_num_workers }}
     set transactions {{ transactions }}
     set samples 1
-    for {set w 1} { $w <= $workers } { set w [expr {$w*2}] } {
+    for {set w {{ db_min_workers }}} { $w <= $workers } { set w [expr {$w*2}] } {
     puts "$w VU TEST"
     for {set i 1} {$i <= $samples} {incr i} {
         puts "============ RUNNING SAMPLE $i: $w WORKERS ============"

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/05_hammerdb-auto-runs_template.ps1
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/05_hammerdb-auto-runs_template.ps1
@@ -48,11 +48,17 @@ close $of
 '@
 
 $maxVU = {{ db_num_workers }}
+if ({{ db_min_workers }} -gt $maxVU) {
+    throw "db_min_workers ({{ db_min_workers }}) must be <= db_num_workers ({{ db_num_workers }})"
+}
 $vuCounts = @()
 $vu = {{ db_min_workers }}
 while ($vu -le $maxVU) {
     $vuCounts += $vu
     $vu *= 2
+}
+if ($vuCounts -notcontains $maxVU) {
+    $vuCounts += $maxVU
 }
 
 for ($i=1; $i -le {{ iterations }}; $i++) {

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/05_hammerdb-auto-runs_template.ps1
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/05_hammerdb-auto-runs_template.ps1
@@ -26,8 +26,8 @@ diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
 diset tpcc mssqls_dbase tpcc
 diset tpcc mssqls_driver timed
 diset tpcc mssqls_total_iterations 10000000
-diset tpcc mssqls_rampup 1
-diset tpcc mssqls_duration 1
+diset tpcc mssqls_rampup {{ rampup }}
+diset tpcc mssqls_duration {{ runtime }}
 diset tpcc mssqls_checkpoint false
 diset tpcc mssqls_timeprofile true
 diset tpcc mssqls_allwarehouse true
@@ -49,13 +49,13 @@ close $of
 
 $maxVU = {{ db_num_workers }}
 $vuCounts = @()
-$vu = 1
+$vu = {{ db_min_workers }}
 while ($vu -le $maxVU) {
     $vuCounts += $vu
     $vu *= 2
 }
 
-for ($i=1; $i -le 2; $i++) {
+for ($i=1; $i -le {{ iterations }}; $i++) {
     Write-Output "Iteration $i started"
 
     foreach ($vu in $vuCounts) {

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/05_hammerdb-auto-runs_template.ps1
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/05_hammerdb-auto-runs_template.ps1
@@ -26,8 +26,8 @@ diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
 diset tpcc mssqls_dbase tpcc
 diset tpcc mssqls_driver timed
 diset tpcc mssqls_total_iterations 10000000
-diset tpcc mssqls_rampup 1
-diset tpcc mssqls_duration 1
+diset tpcc mssqls_rampup {{ rampup }}
+diset tpcc mssqls_duration {{ runtime }}
 diset tpcc mssqls_checkpoint false
 diset tpcc mssqls_timeprofile true
 diset tpcc mssqls_allwarehouse true
@@ -48,14 +48,20 @@ close $of
 '@
 
 $maxVU = {{ db_num_workers }}
+if ({{ db_min_workers }} -gt $maxVU) {
+    throw "db_min_workers ({{ db_min_workers }}) must be <= db_num_workers ({{ db_num_workers }})"
+}
 $vuCounts = @()
-$vu = 1
+$vu = {{ db_min_workers }}
 while ($vu -le $maxVU) {
     $vuCounts += $vu
     $vu *= 2
 }
+if ($vuCounts -notcontains $maxVU) {
+    $vuCounts += $maxVU
+}
 
-for ($i=1; $i -le 2; $i++) {
+for ($i=1; $i -le {{ iterations }}; $i++) {
     Write-Output "Iteration $i started"
 
     foreach ($vu in $vuCounts) {

--- a/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
@@ -16,6 +16,8 @@ template_data:
     uuid: {{ uuid }}
     url: {{ windows_url }}
     transactions: 100000
+    db_min_workers: 1
+    iterations: 2
     rampup: 1
     runtime: 1
   run_type:

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -135,6 +135,10 @@ class EnvironmentVariables:
             'krknhub': 'krknhub',
         }
 
+        # HammerDB config override (optional), overrides template defaults.
+        # test_ci defaults: HAMMERDB_CONFIG="{'db_min_workers': 1, 'db_num_workers': 2, 'db_warehouses': 2, 'runtime': 1, 'rampup': 1, 'iterations': 2, 'transactions': 100000}"
+        self._environment_variables_dict['hammerdb_config'] = literal_eval(EnvironmentVariables.get_env('HAMMERDB_CONFIG', '{}'))
+
         # Versions
         self._environment_variables_dict['product_versions'] = {
             'mssql': 2025,

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -140,6 +140,10 @@ class EnvironmentVariables:
             'krknhub': 'krknhub',
         }
 
+        # HammerDB config override (optional), overrides template defaults.
+        # test_ci defaults: HAMMERDB_CONFIG="{'db_min_workers': 1, 'db_num_workers': 2, 'db_warehouses': 2, 'runtime': 1, 'rampup': 1, 'iterations': 2, 'transactions': 100000}"
+        self._environment_variables_dict['hammerdb_config'] = literal_eval(EnvironmentVariables.get_env('HAMMERDB_CONFIG', '{}'))
+
         # Versions
         self._environment_variables_dict['product_versions'] = {
             'mssql': 2025,

--- a/benchmark_runner/workloads/winmssql_vm.py
+++ b/benchmark_runner/workloads/winmssql_vm.py
@@ -1,6 +1,7 @@
 
 import os
 import time
+import urllib.request
 from multiprocessing import Process
 
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
@@ -19,6 +20,10 @@ class WinMSSQLVM(BootstormVM):
         super().__init__()
         if not self._windows_url:
             raise ValueError('Missing Windows DV URL')
+        try:
+            urllib.request.urlopen(urllib.request.Request(self._windows_url, method='HEAD'), timeout=10)
+        except Exception as err:
+            raise ValueError(f'Windows DV URL not accessible: {self._windows_url} ({err})')
         self.__namespace = self._environment_variables_dict.get('namespace', 'benchmark-runner')
         self.__username = self._environment_variables_dict.get('vm_user') or 'Administrator'
         self.__ssh_key_path = self._ssh_key_path
@@ -75,7 +80,17 @@ class WinMSSQLVM(BootstormVM):
             if not self._virtctl._wait_for_virtctl_ssh(vm_name=vm_name, namespace=self.__namespace,
                                                        key_path=self.__ssh_key_path, username=self.__username,
                                                        timeout=self._timeout):
-                raise Windows_HammerDB_NOT_Succeeded(f'SSH never became ready on VM {vm_name}')
+                raise Windows_HammerDB_NOT_Succeeded(
+                    f'SSH key auth never became ready on VM {vm_name}. '
+                    f'Cloudbase-init may not have executed runcmd (image needs sysprep). '
+                    f'Verify: virtctl ssh --username=Administrator vmi/{vm_name} -n {self.__namespace}')
+
+            verify = self._virtctl.virtctl_ssh(vm_name=vm_name,
+                                               command='powershell -Command "if (Test-Path C:\\ProgramData\\ssh\\administrators_authorized_keys) { echo key_ok }"',
+                                               namespace=self.__namespace, key_path=self.__ssh_key_path,
+                                               username=self.__username, timeout=60)
+            if not verify or 'key_ok' not in verify:
+                logger.warning(f'SSH key file not found on VM {vm_name} — cloudbase-init runcmd may not have executed (image needs sysprep)')
 
             scripts = ['run_prepare_hammerdb.ps1', 'run_hammerdb_benchmark.ps1',
                        '01_provision-data-disk.ps1', '02_create_db.sql',

--- a/benchmark_runner/workloads/winmssql_vm.py
+++ b/benchmark_runner/workloads/winmssql_vm.py
@@ -1,6 +1,8 @@
 
 import os
 import time
+import urllib.request
+from multiprocessing import Process
 
 from benchmark_runner.common.logger.logger_time_stamp import logger_time_stamp, logger
 from benchmark_runner.common.elasticsearch.elasticsearch_exceptions import ElasticSearchDataNotUploaded
@@ -18,6 +20,10 @@ class WinMSSQLVM(BootstormVM):
         super().__init__()
         if not self._windows_url:
             raise ValueError('Missing Windows DV URL')
+        try:
+            urllib.request.urlopen(urllib.request.Request(self._windows_url, method='HEAD'), timeout=10)
+        except Exception as err:
+            raise ValueError(f'Windows DV URL not accessible: {self._windows_url} ({err})')
         self.__namespace = self._environment_variables_dict.get('namespace', 'benchmark-runner')
         self.__username = self._environment_variables_dict.get('vm_user') or 'Administrator'
         self.__ssh_key_path = self._ssh_key_path
@@ -74,7 +80,17 @@ class WinMSSQLVM(BootstormVM):
             if not self._virtctl._wait_for_virtctl_ssh(vm_name=vm_name, namespace=self.__namespace,
                                                        key_path=self.__ssh_key_path, username=self.__username,
                                                        timeout=self._timeout):
-                raise Windows_HammerDB_NOT_Succeeded(f'SSH never became ready on VM {vm_name}')
+                raise Windows_HammerDB_NOT_Succeeded(
+                    f'SSH key auth never became ready on VM {vm_name}. '
+                    f'Cloudbase-init may not have executed runcmd (image needs sysprep). '
+                    f'Verify: virtctl ssh --username={self.__username} vmi/{vm_name} -n {self.__namespace}')
+
+            verify = self._virtctl.virtctl_ssh(vm_name=vm_name,
+                                               command='powershell -Command "if (Test-Path C:\\ProgramData\\ssh\\administrators_authorized_keys) { echo key_ok }"',
+                                               namespace=self.__namespace, key_path=self.__ssh_key_path,
+                                               username=self.__username, timeout=60)
+            if not verify or 'key_ok' not in verify:
+                logger.warning(f'SSH key file not found on VM {vm_name} — cloudbase-init runcmd may not have executed (image needs sysprep)')
 
             scripts = ['run_prepare_hammerdb.ps1', 'run_hammerdb_benchmark.ps1',
                        '01_provision-data-disk.ps1', '02_create_db.sql',


### PR DESCRIPTION
## Summary
- Add optional `HAMMERDB_CONFIG` env var to override HammerDB template defaults at runtime
- Supports: `db_min_workers`, `db_num_workers`, `db_warehouses`, `runtime`, `rampup`, `iterations`, `transactions`
- For flat run (no ramp-up): set `db_min_workers` = `db_num_workers`
- Fix hardcoded `rampup`/`runtime` in winmssql `05_hammerdb-auto-runs` script (was always 1)
- Add SSH key verification with diagnostic message for cloudbase-init failures
- Add `WINDOWS_URL` accessibility check at startup

## Usage
```bash
# test_ci defaults (no override needed):
# db_min_workers=1, db_num_workers=2, db_warehouses=2, runtime=1, rampup=1, iterations=2

# Flat 32-thread, 60 min run:
HAMMERDB_CONFIG="{'db_min_workers': 32, 'db_num_workers': 32, 'runtime': 60, 'iterations': 1}"

# Custom warehouses + duration:
HAMMERDB_CONFIG="{'db_warehouses': 192, 'runtime': 120}"
```

## Test plan
- [x] Verify default behavior unchanged (no HAMMERDB_CONFIG set)
- [x] Verify flat run with db_min_workers = db_num_workers
- [x] Verify runtime override renders correctly in generated scripts
- [x] Golden file tests pass

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-variable override for HammerDB template data
  * New template parameters to configure minimum workers and iteration count

* **Improvements**
  * Workload generation respects configurable min-worker and iteration settings
  * Windows VM initialization: URL reachability check, clearer SSH/setup guidance, and non-fatal SSH key presence warning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/benchmark-runner/pull/1221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->