### PR TITLE
Upgrade boto3/botocore to 1.41.0 to fix utcnow deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 dependencies = [
     "attrs==21.4.0",
     "azure==4.0.0",
-    "boto3==1.33.13",
-    "botocore==1.33.13",
+    "boto3==1.41.0",
+    "botocore==1.41.0",
     "cryptography==46.0.7",
     "elasticsearch==7.16.1",
     "elasticsearch-dsl==7.4.0",


### PR DESCRIPTION
## Summary
- Upgrade `boto3` and `botocore` from 1.33.13 to 1.41.0
- Fixes ~56 `DeprecationWarning: datetime.datetime.utcnow()` warnings per CI run on Python 3.12+
- `botocore` 1.41.0 replaced `utcnow()` with timezone-aware `datetime.now(datetime.UTC)`

## Test plan
- [ ] CI passes with no `utcnow` deprecation warnings from botocore
- [ ] S3 integration tests pass unchanged

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS service library versions for improved compatibility and stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/benchmark-runner/pull/1222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->