### PR TITLE
Fix LSO PV cleanup and disk selection bugs

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -609,15 +609,15 @@ class OC(SSH):
 
     def delete_available_released_pv(self):
         """
-        This method deletes available or released pv because that avoid launching new pv
+        This method deletes available or released local-sc PVs, removing finalizers first
         """
-        pv_status_list = self.run(fr"{self._cli} get pv -o jsonpath={{..status.phase}}").split()
-        for ind, pv_status in enumerate(pv_status_list):
-            if pv_status == 'Available' or pv_status == 'Released':
-                available_pv = self.run(fr"{self._cli} get pv -o jsonpath={{.items[{ind}].metadata.name}}")
-                logger.info(f'Delete {pv_status} pv {available_pv}')
-                self.run(fr"{self._cli} delete localvolume -n openshift-local-storage local-disks --wait=false")
-                self.run(fr"{self._cli} delete pv {available_pv} --wait=false")
+        pvs = self.run(f"{self._cli} get pv --no-headers -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,SC:.spec.storageClassName")
+        for line in pvs.strip().splitlines():
+            parts = line.split()
+            if len(parts) >= 3 and parts[2] == 'local-sc' and parts[1] in ('Available', 'Released'):
+                logger.info(f'Delete {parts[1]} pv {parts[0]}')
+                self.run(f"{self._cli} patch pv {parts[0]} --type=json -p='[{{\"op\":\"remove\",\"path\":\"/metadata/finalizers\"}}]'")
+                self.run(f"{self._cli} delete pv {parts[0]} --wait=false")
 
     def clear_node_caches(self):
         """

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -111,13 +111,15 @@ class WorkloadsOperations:
             self._snapshot = PrometheusSnapshot(oc=self._oc, artifacts_path=self._run_artifacts_path, verbose=True)
             self._prometheus_snap_interval = self._environment_variables_dict.get('prometheus_snap_interval', '')
             self._prometheus_metrics_operation = PrometheusMetricsOperation()
-                # Extract lso id for LSO workload
         # Extract lso id for LSO workload
         if '_lso' in self._environment_variables_dict.get('workload'):
             self._oc.delete_namespace()
             self._oc.delete_available_released_pv()
-            # Update lso_disk_id only if both worker_disk_ids and a free disk exist
-            if self._environment_variables_dict.get('worker_disk_ids', '') and self._oc.get_free_disk_id(
+            if not self._environment_variables_dict.get('pin_node2', ''):
+                self._environment_variables_dict['pin_node2'] = self._environment_variables_dict.get('lso_node', '')
+            if self._environment_variables_dict.get('lso_disk_id', ''):
+                self._lso_disk_id = self._environment_variables_dict['lso_disk_id']
+            elif self._environment_variables_dict.get('worker_disk_ids', '') and self._oc.get_free_disk_id(
                     node=self._environment_variables_dict['lso_node']):
                 self._lso_disk_id = self._oc.get_free_disk_id(node=self._environment_variables_dict['lso_node'])
                 self._environment_variables_dict['lso_disk_id'] = self._lso_disk_id


### PR DESCRIPTION
## Summary
- Filter `delete_available_released_pv` to only target `local-sc` PVs
- Remove PV finalizers before deletion
- Prefer explicit `LSO_DISK_ID` when set
- Auto-set `PIN_NODE2 = LSO_NODE` for LSO workloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Persistent volume cleanup now more selectively removes only volumes in Available/Released states with the targeted storage class and better finalizer handling to ensure clean deletion.
  * Local storage workload initialization updated with clearer disk selection behavior and more flexible node affinity handling for LSO setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/benchmark-runner/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->