### PR TITLE
Add PySocks dependency for SOCKS proxy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pandas",
     "paramiko==3.4.0",
     "PyGitHub==1.55",
+    "PySocks>=1.7.1",
     "PyYAML==6.0.1",
     "setuptools",
     "sphinx==5.0.0",


### PR DESCRIPTION
## Summary
Add PySocks to pyproject.toml dependencies.

## Why
Prometheus queries fail in Prow CI because the CI pod routes through a SOCKS proxy to reach the target cluster's private VLAN. The `requests` library needs PySocks installed to handle SOCKS proxies configured via `HTTP_PROXY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies with PySocks package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/benchmark-runner/pull/1231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->