### PR TITLE
Increase vdbench VM ephemeral test timeout

### DIFF
--- a/tests/integration/benchmark_runner/common/virtctl/test_virtctl.py
+++ b/tests/integration/benchmark_runner/common/virtctl/test_virtctl.py
@@ -166,7 +166,7 @@ def test_virtctl_vdbench_vm_ephemeral_file_count_scp_and_parse():
     # Wait for CSV files (IO_OPERATION=oltp1,oltp2 => 2 files expected)
     assert virtctl.wait_for_vm_completed_by_file_count(
         vm_name=vm_name, remote_dir='/workload/', expected_count=2,
-        namespace=namespace, key_path=key_path, username='cloud-user', timeout=600)
+        namespace=namespace, key_path=key_path, username='cloud-user', timeout=1200)
 
     # Verify count_remote_vm_files
     csv_count = virtctl.count_remote_vm_files(


### PR DESCRIPTION
## Summary
Increase timeout from 600s to 1200s for `wait_for_vm_completed_by_file_count` in vdbench VM ephemeral test.

## Why
Cloud-init pulls a 2GB vdbench container image via podman inside the VM. On fresh clusters without image cache, the pull +[ vdbench execution exceeds 600s.](https://github.com/redhat-performance/benchmark-runner/actions/runs/26305556488/attempts/1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies with a new required package.
  * Adjusted test timing parameters to improve test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-performance/benchmark-runner/pull/1232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->