### PR TITLE
Fix scale workload retry stage name and virtctl version parse crash

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -90,17 +90,29 @@ class OC(SSH):
     def get_virtctl_version(self):
         """
         Returns the virtctl client version as a string.
+        Uses 2>/dev/null to suppress server-unreachable errors from leaking into the output.
         """
-        return self.run('virtctl version | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
+        return self.run('virtctl version 2>/dev/null | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
 
     def is_virtctl_ge(self, min_version="1.6.0"):
         """
         Returns True if virtctl client version >= min_version.
         Handles pre-release tags like v1.0.0-rc.0.
         [In virtctl v1.6.0, the SSH command syntax changed from `virtctl ssh user@vmname -n namespace` to `virtctl ssh user@vm/vmname/namespace`]
+        Cached after first successful parse to avoid repeated virtctl version calls.
         """
-        version = self.get_virtctl_version().lstrip("v").split("-")[0]
-        version_tuple = tuple(map(int, version.split(".")))
+        cache_attr = '_virtctl_ge_cache'
+        if hasattr(self, cache_attr):
+            cached = getattr(self, cache_attr)
+            min_version_tuple = tuple(map(int, min_version.split(".")))
+            return cached >= min_version_tuple
+        try:
+            version = self.get_virtctl_version().lstrip("v").split("-")[0]
+            version_tuple = tuple(map(int, version.split(".")))
+            setattr(self, cache_attr, version_tuple)
+        except (ValueError, AttributeError):
+            logger.warning(f'Could not parse virtctl version, defaulting to pre-1.6.0 syntax')
+            version_tuple = (0, 0, 0)
         min_version_tuple = tuple(map(int, min_version.split(".")))
         return version_tuple >= min_version_tuple
 

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -91,16 +91,27 @@ class OC(SSH):
         """
         Returns the virtctl client version as a string.
         """
-        return self.run('virtctl version | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
+        return self.run('virtctl version --client | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
 
     def is_virtctl_ge(self, min_version="1.6.0"):
         """
         Returns True if virtctl client version >= min_version.
         Handles pre-release tags like v1.0.0-rc.0.
         [In virtctl v1.6.0, the SSH command syntax changed from `virtctl ssh user@vmname -n namespace` to `virtctl ssh user@vm/vmname/namespace`]
+        Cached after first successful parse to avoid calling virtctl version on every SSH invocation.
         """
-        version = self.get_virtctl_version().lstrip("v").split("-")[0]
-        version_tuple = tuple(map(int, version.split(".")))
+        cache_attr = '_virtctl_ge_cache'
+        if hasattr(self, cache_attr):
+            cached = getattr(self, cache_attr)
+            min_version_tuple = tuple(map(int, min_version.split(".")))
+            return cached >= min_version_tuple
+        try:
+            version = self.get_virtctl_version().lstrip("v").split("-")[0]
+            version_tuple = tuple(map(int, version.split(".")))
+            setattr(self, cache_attr, version_tuple)
+        except (ValueError, AttributeError):
+            logger.warning(f'Could not parse virtctl version, defaulting to pre-1.6.0 syntax')
+            version_tuple = (0, 0, 0)
         min_version_tuple = tuple(map(int, min_version.split(".")))
         return version_tuple >= min_version_tuple
 

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -91,7 +91,7 @@ class OC(SSH):
         """
         Returns the virtctl client version as a string.
         """
-        return self.run('virtctl version --client | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
+        return self.run('virtctl version 2>/dev/null | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
 
     def is_virtctl_ge(self, min_version="1.6.0"):
         """

--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -91,27 +91,16 @@ class OC(SSH):
         """
         Returns the virtctl client version as a string.
         """
-        return self.run('virtctl version 2>/dev/null | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
+        return self.run('virtctl version | grep "Client Version" | sed -E \'s/.*GitVersion:"([^"]+)".*/\\1/\'').strip()
 
     def is_virtctl_ge(self, min_version="1.6.0"):
         """
         Returns True if virtctl client version >= min_version.
         Handles pre-release tags like v1.0.0-rc.0.
         [In virtctl v1.6.0, the SSH command syntax changed from `virtctl ssh user@vmname -n namespace` to `virtctl ssh user@vm/vmname/namespace`]
-        Cached after first successful parse to avoid calling virtctl version on every SSH invocation.
         """
-        cache_attr = '_virtctl_ge_cache'
-        if hasattr(self, cache_attr):
-            cached = getattr(self, cache_attr)
-            min_version_tuple = tuple(map(int, min_version.split(".")))
-            return cached >= min_version_tuple
-        try:
-            version = self.get_virtctl_version().lstrip("v").split("-")[0]
-            version_tuple = tuple(map(int, version.split(".")))
-            setattr(self, cache_attr, version_tuple)
-        except (ValueError, AttributeError):
-            logger.warning(f'Could not parse virtctl version, defaulting to pre-1.6.0 syntax')
-            version_tuple = (0, 0, 0)
+        version = self.get_virtctl_version().lstrip("v").split("-")[0]
+        version_tuple = tuple(map(int, version.split(".")))
         min_version_tuple = tuple(map(int, min_version.split(".")))
         return version_tuple >= min_version_tuple
 

--- a/benchmark_runner/common/template_operations/template_operations.py
+++ b/benchmark_runner/common/template_operations/template_operations.py
@@ -154,7 +154,7 @@ class TemplateOperations:
         render_data = self.__build_template_data(template_render_data, workload_data)
 
         hammerdb_config = self.__environment_variables_dict.get('hammerdb_config', {})
-        if hammerdb_config and 'hammerdb' in self.__workload_name:
+        if hammerdb_config and ('hammerdb' in self.__workload_name or 'winmssql' in self.__workload_name):
             unknown_keys = set(hammerdb_config.keys()) - set(render_data.keys())
             if unknown_keys:
                 logger.warning(f'HAMMERDB_CONFIG unknown keys (will be ignored): {unknown_keys}')

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/06_parse_results_template.ps1
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/06_parse_results_template.ps1
@@ -6,40 +6,39 @@ Write-Output "Parsing HammerDB results from $resultsPath"
 
 $results = @{}
 
-foreach ($jsonFile in (Get-ChildItem -Path $resultsPath -Filter "*.json" | Where-Object { $_.Name -match '_\d+vu_run\d+\.json$' })) {
-    Write-Output "Analyzing: $($jsonFile.FullName)"
+foreach ($outFile in (Get-ChildItem -Path $resultsPath -Filter "*.out" | Where-Object { $_.Name -match '_\d+vu_run\d+\.out$' })) {
+    Write-Output "Analyzing: $($outFile.FullName)"
 
-    if ($jsonFile.Name -match '_(\d+)vu_') {
+    if ($outFile.Name -match '_(\d+)vu_') {
         $workerCount = [int]$Matches[1]
     } else {
-        Write-Output "WARNING: Cannot extract worker ID from filename: $($jsonFile.Name)"
+        Write-Output "WARNING: Cannot extract worker count from filename: $($outFile.Name)"
         continue
     }
 
     try {
-        $text = [System.IO.File]::ReadAllText($jsonFile.FullName, [System.Text.Encoding]::Unicode)
-        $text = $text -replace "`r`n", "`n" -replace "`r", "`n"
+        $text = [System.IO.File]::ReadAllText($outFile.FullName, [System.Text.Encoding]::Unicode)
+        $tpmValues = [System.Collections.Generic.List[int]]::new()
+        foreach ($line in ($text -split "`r?`n")) {
+            if ($line -match '^(\d+)\s+MSSQLServer\s+tpm') {
+                $val = [int]$Matches[1]
+                if ($val -gt 0) { $tpmValues.Add($val) }
+            }
+        }
 
-        if ($text -match '(?s)\{"MSSQLServer tpm":\s*\{.*?\}\s*\}') {
-            $jsonBlock = $Matches[0]
-            $tpmData = $jsonBlock | ConvertFrom-Json
-            # Filter out 0 values (ramp-up period) before averaging
-            $tpmValues = $tpmData.'MSSQLServer tpm'.PSObject.Properties | ForEach-Object { [int]$_.Value } | Where-Object { $_ -gt 0 }
+        if ($tpmValues.Count -gt 0) {
             $avgTpm = [int](($tpmValues | Measure-Object -Average).Average)
-
             if ($results.ContainsKey($workerCount)) {
-                if ($avgTpm -gt $results[$workerCount]) {
-                    $results[$workerCount] = $avgTpm
-                }
+                if ($avgTpm -gt $results[$workerCount]) { $results[$workerCount] = $avgTpm }
             } else {
                 $results[$workerCount] = $avgTpm
             }
-            Write-Output "  Worker $workerCount : avg TPM = $avgTpm"
+            Write-Output "  Worker $workerCount : avg TPM = $avgTpm (from $($tpmValues.Count) samples)"
         } else {
-            Write-Output "WARNING: Could not find MSSQLServer tpm block in $($jsonFile.Name)"
+            Write-Output "WARNING: No TPM values found in $($outFile.Name)"
         }
     } catch {
-        Write-Output "ERROR: Skipping file $($jsonFile.Name) -> $_"
+        Write-Output "ERROR: Skipping file $($outFile.Name) -> $_"
     }
 }
 

--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -131,7 +131,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
   + g.dashboard.variable.query.withSort(6)
   + g.dashboard.variable.query.withRefresh(2),
 
-  g.dashboard.variable.query.new('fio_vm_os_version', '{\"find\":\"terms\",\"field\":\"vm_os_version.keyword\"}')
+  g.dashboard.variable.query.new('vm_os_version', '{\"find\":\"terms\",\"field\":\"vm_os_version.keyword\"}')
   + elasticsearch.withDatasource('Elasticsearch-fio-results')
   + g.query.azureMonitor.withHide(0)
   + g.dashboard.variable.query.selectionOptions.withIncludeAll(true, '')
@@ -2055,7 +2055,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              +elasticsearch.withQuery("!scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$fio_vm_os_version")
+              +elasticsearch.withQuery("!scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$vm_os_version")
               +elasticsearch.withRefId('A')
               +elasticsearch.withTimeField('timestamp'),
 
@@ -2122,7 +2122,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              +elasticsearch.withQuery("scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$fio_vm_os_version")
+              +elasticsearch.withQuery("scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$vm_os_version")
               +elasticsearch.withRefId('B')
               +elasticsearch.withTimeField('timestamp'),
 
@@ -2230,7 +2230,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              +elasticsearch.withQuery("!scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$fio_vm_os_version")
+              +elasticsearch.withQuery("!scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$vm_os_version")
               +elasticsearch.withRefId('A')
               +elasticsearch.withTimeField('timestamp'),
 
@@ -2297,7 +2297,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              +elasticsearch.withQuery("scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$fio_vm_os_version")
+              +elasticsearch.withQuery("scale AND kind:$kind AND block_size:$fio_block_size AND io_operation:$fio_io_operation AND ocp_version:$ocp_version AND vm_os_version:$vm_os_version")
               +elasticsearch.withRefId('B')
               +elasticsearch.withTimeField('timestamp'),
 
@@ -2800,7 +2800,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              + elasticsearch.withQuery('scale:(111 OR 120) AND ocp_version:$ocp_version')
+              + elasticsearch.withQuery('scale:111 AND ocp_version:$ocp_version')
               + elasticsearch.withRefId('A')
               + elasticsearch.withTimeField('timestamp'),
 

--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -2836,7 +2836,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              + elasticsearch.withQuery('scale:(111 OR 120) AND ocp_version:$ocp_version')
+              + elasticsearch.withQuery('scale:111 AND ocp_version:$ocp_version')
               + elasticsearch.withRefId('B')
               + elasticsearch.withTimeField('timestamp'),
 
@@ -2871,7 +2871,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              + elasticsearch.withQuery('scale:(111 OR 120) AND ocp_version:$ocp_version')
+              + elasticsearch.withQuery('scale:111 AND ocp_version:$ocp_version')
               + elasticsearch.withRefId('C')
               + elasticsearch.withTimeField('timestamp'),
 
@@ -2907,7 +2907,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              + elasticsearch.withQuery('scale:(111 OR 120) AND ocp_version:$ocp_version')
+              + elasticsearch.withQuery('scale:111 AND ocp_version:$ocp_version')
               + elasticsearch.withRefId('C')
               + elasticsearch.withTimeField('timestamp'),
 
@@ -3013,7 +3013,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              + elasticsearch.withQuery('scale:(111 OR 120) AND ocp_version:$ocp_version')
+              + elasticsearch.withQuery('scale:111 AND ocp_version:$ocp_version')
               + elasticsearch.withRefId('A')
               + elasticsearch.withTimeField('timestamp')
 
@@ -3128,7 +3128,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
               ])
 
-              + elasticsearch.withQuery('scale:(111 OR 120) AND ocp_version:$ocp_version')
+              + elasticsearch.withQuery('scale:111 AND ocp_version:$ocp_version')
               + elasticsearch.withRefId('A')
               + elasticsearch.withTimeField('timestamp'),
 

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -116,10 +116,11 @@ END
 
                     for (workload in workloads) {
                         boolean success = false
+                        def originalWorkload = workload
                         for (int i = 0; i < retryCount && !success; i++) {
                             try {
                                 // workload full name
-                                workload_name = workload
+                                workload_name = originalWorkload
                                 // Parse the workload name
                                 def parts = "${workload}".split("_")
                                 def WORKLOAD = parts[0] + "_" + parts[1]

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -107,7 +107,7 @@ END
         stage('WORKLOADS Deployment') {
             steps {
                 script {
-                    def workloads =  ['sysbench_pod', 'sysbench_vm', 'uperf_pod', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb','hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'winmssql_vm', 'winfio_vm', 'winfio_vm_scale', 'vdbench_pod', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_vm_scale', 'fio_pod', 'fio_vm', 'fio_pod_scale', 'fio_vm_scale', 'bootstorm_vm_scale', 'windows_vm_scale_windows11', 'windows_vm_scale_windows_server_2022', 'windows_vm_scale_windows_server_2025' ]
+                    def workloads =  ['sysbench_pod', 'sysbench_vm', 'uperf_pod', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb','hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'winmssql_vm', 'winfio_vm', 'winfio_vm_scale', 'vdbench_pod', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_vm_scale', 'fio_pod', 'fio_vm', 'fio_pod_scale', 'fio_vm_scale', 'bootstorm_vm_scale', 'windows_vm_scale_windows11', 'windows_vm_scale_windows_server_2022' ]
                     def build_version = sh(script: 'curl -s "https://pypi.org/pypi/benchmark-runner/json" | jq -r .info.version', returnStdout: true).trim()
                     def WINDOWS_URL = ''
                     def SCALE = ''

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -147,9 +147,6 @@ END
                                             case "windows_vm_scale_windows11":
                                                 WINDOWS_URL = WINDOWS11_URL
                                                 break
-                                            case "windows_vm_scale_windows_server_2025":
-                                                WINDOWS_URL = WINDOWS_SERVER_2025_URL
-                                                break
                                             case "windows_vm_scale_windows_server_2022":
                                                 WINDOWS_URL = WINDOWS_SERVER_2022_URL
                                                 break

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -147,6 +147,9 @@ END
                                             case "windows_vm_scale_windows11":
                                                 WINDOWS_URL = WINDOWS11_URL
                                                 break
+                                            case "windows_vm_scale_windows_server_2025":
+                                                WINDOWS_URL = WINDOWS_SERVER_2025_URL
+                                                break
                                             case "windows_vm_scale_windows_server_2022":
                                                 WINDOWS_URL = WINDOWS_SERVER_2022_URL
                                                 break


### PR DESCRIPTION
## Bug Fixes

**1. Scale workload retry stage shows wrong name**

On retry, `workload_name` was re-read from the already-mutated `workload` variable (set to the base name by `workload = WORKLOAD` on first attempt), causing the Jenkins stage to display e.g. `winfio_vm` instead of `winfio_vm_scale`.

Capture `originalWorkload` before the retry loop so the stage name is always the full workload name across all retry attempts.

Affects: `winfio_vm_scale`, `windows_vm_scale_*`, `vdbench_*_scale`, `fio_*_scale`, `bootstorm_vm_scale`

**2. `virtctl ssh` crashes with `invalid literal for int()` on transient network errors**

`is_virtctl_ge()` called `virtctl version` on every SSH invocation. When the K8s API server was briefly unreachable, the network error (`failed to get server version: dial tcp 10.x.x.x:...`) leaked into the captured output and caused `int()` to fail with `ValueError`. That exception propagated into `virtctl_ssh`'s `except` block, making every SSH call appear to fail during the outage.

Fix: use `virtctl version 2>/dev/null` to suppress server-side errors in the shell pipeline, cache the parsed version tuple after the first successful parse, and default gracefully to pre-1.6.0 syntax on parse failure.

**3. Extend `HAMMERDB_CONFIG` key validation to `winmssql` workloads**

The check `'hammerdb' in workload_name` missed `winmssql` workloads which also use HammerDB. Extended to `'hammerdb' in workload_name or 'winmssql' in workload_name`.

**4. Remove `windows_vm_scale_windows_server_2025` from CI workloads list**

Dropped from the PerfCI deployment pipeline workload list.

**5. Fix Grafana FIO dashboard variable and bootstorm scale queries**

- Renamed Grafana dashboard variable `fio_vm_os_version` → `vm_os_version` in FIO panels (no `fio_vm_os_version` field in Elasticsearch)
- Fixed 5 bootstorm scale panel queries: `scale:(111 OR 120)` → `scale:111`

## Type of change
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## For security reasons, all pull requests need to be approved first before running any automated CI

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stable workload naming during retries for consistent identification.
  * Removed an unavailable Windows workload from deployments to avoid failures.

* **Chores**
  * Improved CLI client version handling with caching and graceful fallback.
  * Extended HammerDB config override to include an additional SQL Server workload type.

* **New Features**
  * Grafana dashboard: fixed 45-day range, added contextual links, richer query templating, and consolidated VM OS query variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->