### PR TITLE
Add pre-push workflow, skills, and unittest requirement to CLAUDE.md

### DIFF
--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -1,0 +1,21 @@
+# /integration-test
+
+Run integration tests against a live OCP cluster.
+
+## Steps
+
+1. **Run all integration tests**:
+   ```bash
+   PYTHONPATH=. python3 -m pytest -v tests/integration/
+   ```
+
+2. **Run a specific workload test**:
+   ```bash
+   PYTHONPATH=. python3 -m pytest -v tests/integration/benchmark_runner/workloads/test_oc_benchmark_runner.py -k "<workload_name>"
+   ```
+
+## Notes
+
+- Requires a live OCP cluster with valid kubeconfig at `~/.kube/config`
+- Tests create and delete real workloads on the cluster
+- ODF-dependent tests are skipped on clusters without ODF

--- a/.claude/skills/pr-push/SKILL.md
+++ b/.claude/skills/pr-push/SKILL.md
@@ -1,0 +1,29 @@
+# /pr-push
+
+Prepare and push the current branch: rebase onto main, run all unit tests, and push.
+
+## Steps
+
+1. **Rebase onto main**
+   ```bash
+   git fetch origin main && git rebase origin/main
+   ```
+   If there are conflicts, resolve them and continue the rebase before proceeding.
+
+2. **Run all unit tests**
+   ```bash
+   PYTHONPATH=. python3 -m pytest -v tests/unittest/
+   ```
+   All 26 tests must pass. If any fail, fix them before pushing.
+
+3. **Push**
+   ```bash
+   git push
+   ```
+   Use `--force-with-lease` if the branch was rebased.
+
+## Notes
+
+- Never push if any unit test fails
+- Never skip the rebase step — always stay up to date with main before pushing
+- If `git push` is rejected after rebase, use `git push --force-with-lease`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,21 @@ PYTHONPATH=. python3 -m pytest -v tests/unittest/benchmark_runner/common/templat
 python -m benchmark_runner.main.main
 ```
 
-**Important**: Always run `PYTHONPATH=. python3 -m pytest -v tests/unittest/` before pushing any commit. All unit tests must pass.
+## Before Every Push
+
+Always run these two steps before pushing any commit:
+
+1. **Rebase onto main** to stay up to date and avoid conflicts:
+   ```bash
+   git fetch origin main && git rebase origin/main
+   ```
+
+2. **Run all unit tests** to ensure nothing is broken:
+   ```bash
+   PYTHONPATH=. python3 -m pytest -v tests/unittest/
+   ```
+
+All unit tests must pass before pushing.
 
 Pre-commit hooks run automatically on commit (rh-pre-commit, YAML/JSON validation, trailing whitespace, private key detection).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,17 @@ make golden_files
 # Run both
 make all
 
+# Run all unit tests (required before pushing any commit)
+PYTHONPATH=. python3 -m pytest -v tests/unittest/
+
 # Run specific test
 PYTHONPATH=. python3 -m pytest -v tests/unittest/benchmark_runner/common/template_operations/test_golden_files.py
 
 # Run the benchmark workload
 python -m benchmark_runner.main.main
 ```
+
+**Important**: Always run `PYTHONPATH=. python3 -m pytest -v tests/unittest/` before pushing any commit. All unit tests must pass.
 
 Pre-commit hooks run automatically on commit (rh-pre-commit, YAML/JSON validation, trailing whitespace, private key detection).
 


### PR DESCRIPTION
## Summary

Adds development workflow tooling to help Claude Code work consistently across sessions.

### CLAUDE.md updates
- Add `## Before Every Push` section with two mandatory steps:
  1. Rebase onto main: `git fetch origin main && git rebase origin/main`
  2. Run all unit tests: `PYTHONPATH=. python3 -m pytest -v tests/unittest/`

### New skills
- **`/pr-push`** (`.claude/skills/pr-push/SKILL.md`) — one-command workflow: rebase onto main → run unit tests → push. Invoke before every push.
- **`/integration-test`** (`.claude/skills/integration-test/SKILL.md`) — run integration tests against a live OCP cluster: `PYTHONPATH=. python3 -m pytest -v tests/integration/`

Both skills are also copied to `~/.claude/skills/` for global availability after a session restart.

## Why

- Prevents regressions by enforcing tests before every push
- Ensures the branch stays up to date with main to avoid merge conflicts
- Makes common workflows invocable with a single command

🤖 Assisted-by: Claude Code