### PR TITLE
Fix SSH connection reset by enabling paramiko keepalive

### DIFF
--- a/benchmark_runner/common/remote_ssh/remote_ssh.py
+++ b/benchmark_runner/common/remote_ssh/remote_ssh.py
@@ -42,6 +42,8 @@ class RemoteSsh:
             else:
                 raise SshConnectionError
 
+            # Send keepalive every 60 seconds to prevent firewalls from dropping idle connections
+            self.__p_client.get_transport().set_keepalive(60)
             self.__p_sftp = self.__p_client.open_sftp()
 
         except socket.timeout as err:


### PR DESCRIPTION
## Summary

- Add `set_keepalive(60)` on the paramiko SSH transport in `RemoteSsh.connect()`

## Problem

IBM Cloud firewalls drop idle SSH connections after ~600 seconds. The `verify_ibm_install_complete` step uses `SHORT_TIMEOUT=600` as its sleep interval between install log polls. During that 600-second sleep the SSH connection sits completely idle, causing the firewall to kill it with `Connection reset by peer (104)`.

This then raises `RunCommandError: SSH session not active`, failing the step and causing the subsequent `oc login` to fail (the cluster API hasn't been confirmed ready yet).

## Fix

One line in `RemoteSsh.connect()` — after establishing the connection, before opening SFTP:

```python
self.__p_client.get_transport().set_keepalive(60)
```

This sends an SSH keepalive packet every 60 seconds, preventing the firewall from treating the connection as idle during long waits.

🤖 Assisted-by: Claude Code

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote SSH connection stability by implementing keepalive messages to prevent idle connections from timing out due to firewall inactivity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->