### PR TITLE
Update Windows VM templates with performance optimizations

### DIFF
--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
@@ -38,13 +38,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
-          cores: 1
-          sockets: {{ sockets }}
+          cores: {{ cores }}
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - {% if scale -%}
             name: windows-{{ kind }}-root-disk-{{ trunc_uuid }}-{{ scale }}
@@ -74,8 +73,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/benchmark_runner/common/template_operations/templates/windows/windows_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/windows_data_template.yaml
@@ -15,12 +15,12 @@ template_data:
       requests_cpu: 1
       limit_memory: 4G
       limit_cpu: 2
-      sockets: 1
+      cores: 1
       storage: 76Gi
     default:
       requests_memory: 2G
       requests_cpu: 1
       limit_memory: 4G
       limit_cpu: 2
-      sockets: 1
+      cores: 1
       storage: 76Gi

--- a/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
@@ -38,13 +38,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: {{ sockets }}
+          cores: {{ cores }}
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - {% if scale -%}
             name: winfio-{{ kind }}-root-disk-{{ trunc_uuid }}-{{ scale }}
@@ -84,8 +83,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
@@ -34,12 +34,12 @@ template_data:
       SIZE: 4G
       requests_memory: 4G
       requests_cpu: 1
-      sockets: 2
+      cores: 2
       storage: 76Gi
       data_disk_storage: 64Gi
     default:
       requests_memory: 4G
       requests_cpu: 1
-      sockets: 2
+      cores: 2
       storage: 76Gi
       data_disk_storage: 64Gi

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
@@ -38,13 +38,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: {{ sockets }}
+          cores: {{ cores }}
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - {% if scale -%}
             name: windows-{{ kind }}-root-disk-{{ trunc_uuid }}-{{ scale }}
@@ -84,8 +83,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
@@ -30,12 +30,12 @@ template_data:
       db_warehouses: 96
       database_requests_memory: 32G
       database_requests_cpu: 32
-      sockets: 32
+      cores: 32
       storage: 76Gi
     default:
       db_num_workers: 2
       db_warehouses: 2
       database_requests_memory: 16G
       database_requests_cpu: 16
-      sockets: 16
+      cores: 16
       storage: 76Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 32
+          cores: 32
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_False_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_True_CDI_s3/windows_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          model: host-passthrough
           cores: 1
           sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -56,8 +55,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 2
+          cores: 2
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: winfio-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_False/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_False_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_True/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_scale_ODF_PVC_True_CDI_s3/winmssql_vm.yaml
@@ -24,13 +24,12 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
-          model: host-passthrough
-          sockets: 16
+          cores: 16
+          sockets: 1
           threads: 1
         devices:
           autoattachMemBalloon: false
-          blockMultiQueue: false
+          blockMultiQueue: true
           disks:
           - name: windows-vm-root-disk-deadbeef
             disk:
@@ -62,8 +61,8 @@ spec:
               direct: {}
             spinlocks:
               spinlocks: 8191
-            evmcs:
-              enabled: true
+            reenlightenment: {}
+            reset: {}
             relaxed: {}
             vpindex: {}
             runtime: {}


### PR DESCRIPTION
## Summary
- Apply consistent VM configuration across all Windows templates (windows, winfio, winmssql)
- Align with KubeVirt best practices and tested reference configuration
- Address review feedback from @jeniferh

## Changes (applied to all 3 Windows VM templates)

| Setting | Before | After |
|---|---|---|
| `cpu.model` | `host-passthrough` | removed (defaults to `host-model`) |
| CPU topology | `cores: 1`, `sockets: N` | `cores: N`, `sockets: 1` |
| `autoattachMemBalloon` | missing | `false` |
| `blockMultiQueue` | `false` | `true` (required for iothreads) |
| `bootOrder` | missing | `1` on root disk |
| `dedicatedIOThread` | `false` | removed |
| Tablet input | missing | virtio tablet added |
| `tpm` | interface level | device level |
| `networkInterfaceMultiqueue` | interface level | device level |
| `evmcs` | `enabled: true` | removed (not in default templates) |
| `reenlightenment` | removed | re-added `{}` |
| `reset` | removed | re-added `{}` |
| `ioThreads` | missing | `supplementalPoolThreadCount: 8` |
| `ioThreadsPolicy` | missing | `supplementalPool` |
| `terminationGracePeriodSeconds` | `0` | `180` |
| `evictionStrategy` | domain level | spec level |
| `firmware` position | before clock | after features |

## Test plan
- [x] All 26 unit tests pass
- [x] Golden files regenerated and verified
- [x] All 3 Windows templates have identical settings
- [ ] Bootstorm 111 VMs scale test

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated Windows guest VM CPU topology to use cores-based sizing with a fixed single-socket layout, and removed the previous CPU model selection.
  * Enabled device multiqueue (`blockMultiQueue`) and updated Hyper-V spinlock-related settings by replacing eVMCS enablement with `reenlightenment` and `reset`.
  * Applied live-migration settings, including `evictionStrategy: LiveMigrate`, network configuration for `nic-0`, and `terminationGracePeriodSeconds: 180`.
* **Tests**
  * Refreshed and expanded golden VM manifests to validate the new CPU, device, and Hyper-V configuration outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->