### PR TITLE
Update Grafana dashboard versions to match current product versions

### DIFF
--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kubevirt.io/vm: windows-{{ kind }}-{{ trunc_uuid }}-{{ scale }}
   {%- else -%}
-  name:  windows-{{ kind }}-{{ trunc_uuid }}
+  name: windows-{{ kind }}-{{ trunc_uuid }}
   labels:
     kubevirt.io/vm: windows-{{ kind }}-{{ trunc_uuid }}
   {%- endif %}
@@ -26,13 +26,7 @@ spec:
         kubevirt.io/vm: windows-{{ kind }}-{{ trunc_uuid }}
         {%- endif %}
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -44,46 +38,58 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: {{ sockets }}
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
-              bus: virtio
-            {% if scale -%}
+          - {% if scale -%}
             name: windows-{{ kind }}-root-disk-{{ trunc_uuid }}-{{ scale }}
             {%- else -%}
             name: windows-{{ kind }}-root-disk-{{ trunc_uuid }}
             {%- endif %}
-            dedicatedIOThread: false
+            disk:
+              bus: virtio
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -93,9 +99,11 @@ spec:
           limits:
             cpu: {{ limit_cpu }}
             memory: {{ limit_memory }}
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           {% if scale -%}

--- a/benchmark_runner/common/template_operations/templates/windows/windows_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/windows_data_template.yaml
@@ -10,14 +10,14 @@ template_data:
     perf_ci:
       requests_memory: 2G
       requests_cpu: 1
-      limit_memory: 2G
-      limit_cpu: 1
+      limit_memory: 4G
+      limit_cpu: 2
       sockets: 1
       storage: 76Gi
     default:
       requests_memory: 2G
       requests_cpu: 1
-      limit_memory: 2G
-      limit_cpu: 1
+      limit_memory: 4G
+      limit_cpu: 2
       sockets: 1
       storage: 76Gi

--- a/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
@@ -26,13 +26,7 @@ spec:
         kubevirt.io/vm: winfio-{{ kind }}-{{ trunc_uuid }}
         {%- endif %}
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -49,16 +43,17 @@ spec:
           sockets: {{ sockets }}
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
-              bus: virtio
-            {% if scale -%}
+          - {% if scale -%}
             name: winfio-{{ kind }}-root-disk-{{ trunc_uuid }}-{{ scale }}
             {%- else -%}
             name: winfio-{{ kind }}-root-disk-{{ trunc_uuid }}
             {%- endif %}
-            dedicatedIOThread: false
+            disk:
+              bus: virtio
+            bootOrder: 1
           - disk:
               bus: virtio
             {% if scale -%}
@@ -69,40 +64,53 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: {{ requests_cpu }}
             memory: {{ requests_memory }}
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           {% if scale -%}

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
@@ -26,13 +26,7 @@ spec:
         kubevirt.io/vm: windows-{{ kind }}-{{ trunc_uuid }}
         {%- endif %}
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -49,16 +43,17 @@ spec:
           sockets: {{ sockets }}
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
-              bus: virtio
-            {% if scale -%}
+          - {% if scale -%}
             name: windows-{{ kind }}-root-disk-{{ trunc_uuid }}-{{ scale }}
             {%- else -%}
             name: windows-{{ kind }}-root-disk-{{ trunc_uuid }}
             {%- endif %}
-            dedicatedIOThread: false
+            disk:
+              bus: virtio
+            bootOrder: 1
           - disk:
               bus: virtio
             {% if scale -%}
@@ -69,40 +64,53 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: {{ database_requests_cpu }}
             memory: {{ database_requests_memory }}
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           {% if scale -%}

--- a/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
+++ b/benchmark_runner/grafana/perf/jsonnet/main.libsonnet
@@ -447,7 +447,7 @@ g.dashboard.new('PerfCI-Regression-Summary')
 
           g.panel.stateTimeline.new('HammerDB KTPM')
             + stateTimeline.queryOptions.withDatasource('Elasticsearch-hammerdb-results')
-            + stateTimeline.withDescription("MSSQL2022 \n\nMariaDB10.5 \n\nPostgreSQL13\n\n HammerDB4.0")
+            + stateTimeline.withDescription("MSSQL2025 \n\nMariaDB10.11 \n\nPostgreSQL16\n\n HammerDB4.12")
             + stateTimeline.standardOptions.color.withMode('thresholds')
             + stateTimeline.fieldConfig.defaults.custom.withFillOpacity(70)
             + stateTimeline.fieldConfig.defaults.custom.withLineWidth(0)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 32
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 32
             memory: 32G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 32
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 32
             memory: 32G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_False/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_windows_vm_ODF_PVC_True/windows_vm.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name:  windows-vm-deadbeef
+  name: windows-vm-deadbeef
   labels:
     kubevirt.io/vm: windows-vm-deadbeef
   namespace: benchmark-runner
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -30,42 +24,54 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 1
           model: host-passthrough
+          cores: 1
           sockets: 1
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
@@ -73,11 +79,13 @@ spec:
             cpu: 1
             memory: 2G
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: 2
+            memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: winfio-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 2
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: winfio-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: winfio-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: winfio-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 1
             memory: 4G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: winfio-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_False/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_winmssql_vm_ODF_PVC_True/winmssql_vm.yaml
@@ -12,13 +12,7 @@ spec:
       labels:
         kubevirt.io/vm: windows-vm-deadbeef
     spec:
-      terminationGracePeriodSeconds: 0
-      evictionStrategy: LiveMigrate
       domain:
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: false
         clock:
           timer:
             hpet:
@@ -35,52 +29,66 @@ spec:
           sockets: 16
           threads: 1
         devices:
+          autoattachMemBalloon: false
           blockMultiQueue: false
           disks:
-          - disk:
+          - name: windows-vm-root-disk-deadbeef
+            disk:
               bus: virtio
-            name: windows-vm-root-disk-deadbeef
-            dedicatedIOThread: false
+            bootOrder: 1
           - disk:
               bus: virtio
             name: windows-vm-data-disk-deadbeef
           - disk:
               bus: virtio
             name: cloudinitdisk
+          inputs:
+          - bus: virtio
+            name: tablet
+            type: tablet
+          tpm: {}
           interfaces:
-          - masquerade: {}
+          - name: nic-0
+            masquerade: {}
             model: virtio
-            name: nic-0
-            networkInterfaceMultiqueue: true
-            tpm: { }
+          networkInterfaceMultiqueue: true
         features:
           acpi: {}
           apic: {}
           hyperv:
-            frequencies: {}
             ipi: {}
-            reenlightenment: {}
-            tlbflush: {}
-            relaxed: {}
-            reset: {}
-            runtime: {}
-            spinlocks:
-              spinlocks: 8191
             synic: {}
             synictimer:
-                direct: {}
-            vapic: {}
+              direct: {}
+            spinlocks:
+              spinlocks: 8191
+            evmcs:
+              enabled: true
+            relaxed: {}
             vpindex: {}
+            runtime: {}
+            tlbflush: {}
+            frequencies: {}
+            vapic: {}
           smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+        ioThreads:
+          supplementalPoolThreadCount: 8
+        ioThreadsPolicy: supplementalPool
         machine:
           type: q35
         resources:
           requests:
             cpu: 16
             memory: 16G
+      evictionStrategy: LiveMigrate
       networks:
       - name: nic-0
         pod: {}
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: windows-vm-root-disk-deadbeef


### PR DESCRIPTION
## Summary
- Update HammerDB dashboard description to match current product versions from `environment_variables.py`

| Product | Before | After |
|---|---|---|
| MSSQL | 2022 | 2025 |
| MariaDB | 10.5 | 10.11 |
| PostgreSQL | 13 | 16 |
| HammerDB | 4.0 | 4.12 |

## Test plan
- [x] Pre-commit hooks pass

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Windows VM templates with more explicit CPU, device, and network settings.
  * Added support for tablet input, TPM, and improved I/O threading configuration.
  * Grafana dashboards now open with a 45-day time range, dark styling, refresh controls, and extra dashboard links.

* **Bug Fixes**
  * Increased VM startup/shutdown grace periods for more reliable lifecycle handling.
  * Raised resource limits in benchmark templates to better match heavier workloads.
  * Refined VM hardware settings and feature flags for more consistent guest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->