### PR TITLE
Add --pids-limit=-1 to podman run commands in PerfCI Jenkinsfile

### DIFF
--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -143,7 +143,7 @@ END
                                     // bootstorm_vm_scale: no need redis for synchronization but need SCALE and THREADS_LIMIT
                                     if (workload == "bootstorm_vm_scale") {
                                         // Warm-up: Pull the Fedora image from quay.io for each node
-                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                                        sh """ sudo podman run --rm -t --pids-limit=-1 -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                                         SCALE = BOOTSTORM_SCALE
                                     }
                                     if (WORKLOAD == "windows_vm") {
@@ -161,7 +161,7 @@ END
                                                 error "Unknown Windows scale workload ${workload}"
                                         }
 
-                                        sh """ sudo podman run --rm -t -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e WINDOWS_URL='${WINDOWS_URL}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
+                                        sh """ sudo podman run --rm -t --pids-limit=-1 -e WORKLOAD='${WORKLOAD}' -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' -e RUN_TYPE='${RUN_TYPE}' -e SCALE='1' -e SCALE_NODES='${SCALE_NODES}' -e WINDOWS_URL='${WINDOWS_URL}' -e TIMEOUT='${TIMEOUT}' -e log_level='INFO' -v '${KUBECONFIG_PATH}:${KUBECONFIG_PATH}' --privileged '${QUAY_BENCHMARK_RUNNER_REPOSITORY}' """
                                         SCALE = WINDOWS_SCALE
                                     }
                                   workload = WORKLOAD
@@ -183,7 +183,7 @@ END
                                 // Create a stage for each workload
                                 stage(workload_name) {
                                     sh """
-                                        sudo podman run --rm -t \
+                                        sudo podman run --rm -t --pids-limit=-1 \
                                         -e WORKLOAD='${workload}' \
                                         -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' \
                                         -e PIN_NODE0='${PIN_NODE0}' \


### PR DESCRIPTION
## Summary
- Add `--pids-limit=-1` to all 3 podman run commands in the PerfCI workloads deployment Jenkinsfile
- Prevents transient `failed to create new OS thread (errno=11)` errors

## Problem
When running `hammerdb_vm_mssql_scale` (6 VMs), `virtctl ssh` polls all VMs in parallel. Each `virtctl ssh` spawns Go threads. If leftover processes from a previous workload run haven't fully cleaned up, the container hits its PID limit:

```
virtctl ssh failed: runtime: failed to create new OS thread (have 15 already; errno=11)
runtime: may need to increase max user processes (ulimit -u)
fatal error: newosproc
```

## Fix
Add `--pids-limit=-1` to remove the container PID limit for all podman run commands:
- Main workload run (line 186)
- Bootstorm warm-up run (line 146)
- Windows warm-up run (line 164)

## Test plan
- [x] Second run without fix succeeded (confirms transient nature)
- [ ] Verify no recurrence with `--pids-limit=-1`

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload deployment reliability by removing process-limit restrictions on container runs.
  * Reduced the chance of deployment failures during warm-up and workload execution stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->