### PR TITLE
Per-parameter Orion regression detection for all workloads

### DIFF
--- a/jenkins/PerfCI/06_PerfCI_Orion_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/06_PerfCI_Orion_Deployment/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                         'fio': 'fio-results',
                         'vdbench': 'vdbench-results',
                         'sysbench': 'sysbench-results',
-                        'winmssql': 'windows-results',
+                        'winmssql': 'hammerdb-results',
                         'winfio': 'fio-results'
                     ]
 

--- a/orion-configs/perfci-fio.yaml
+++ b/orion-configs/perfci-fio.yaml
@@ -1,47 +1,801 @@
 tests:
-  - name: fio-vm
-    metadata:
-      kind: vm
-      run_status: complete
-    metrics:
-      - name: total-iops
-        metric_of_interest: total_iops
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: lat-avg
-        metric_of_interest: lat_avg_usec
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-      - name: bandwidth
-        metric_of_interest: total_bw_kbs
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-  - name: fio-pod
-    metadata:
-      kind: pod
-      run_status: complete
-    metrics:
-      - name: total-iops
-        metric_of_interest: total_iops
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: lat-avg
-        metric_of_interest: lat_avg_usec
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-      - name: bandwidth
-        metric_of_interest: total_bw_kbs
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
+- name: fio-vm-4k-read
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-4k-write
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-4k-randread
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-4k-randwrite
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-8k-read
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-8k-write
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-8k-randread
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-8k-randwrite
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-32k-read
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-32k-write
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-32k-randread
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-32k-randwrite
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-1M-read
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-1M-write
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-1M-randread
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-vm-1M-randwrite
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-4k-read
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 4k
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-4k-write
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 4k
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-4k-randread
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 4k
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-4k-randwrite
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 4k
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-8k-read
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 8k
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-8k-write
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 8k
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-8k-randread
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 8k
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-8k-randwrite
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 8k
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-32k-read
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 32k
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-32k-write
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 32k
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-32k-randread
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 32k
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-32k-randwrite
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 32k
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-1M-read
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 1M
+    io_operation: read
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-1M-write
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 1M
+    io_operation: write
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-1M-randread
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 1M
+    io_operation: randread
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: fio-pod-1M-randwrite
+  metadata:
+    kind: pod
+    run_status: complete
+    block_size: 1M
+    io_operation: randwrite
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1

--- a/orion-configs/perfci-hammerdb.yaml
+++ b/orion-configs/perfci-hammerdb.yaml
@@ -1,10 +1,11 @@
 tests:
-  - name: hammerdb-vm-mssql-odf
+  - name: hammerdb-vm-mssql-odf-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -12,12 +13,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-vm-mariadb-odf
+  - name: hammerdb-vm-mssql-odf-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-odf-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-odf-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-odf-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-odf-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-odf-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: mariadb
       storage_type: odf
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -25,12 +97,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-vm-pg-odf
+  - name: hammerdb-vm-mariadb-odf-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-odf-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-odf-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-odf-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-odf-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-odf-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: pg
       storage_type: odf
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -38,12 +181,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-pod-mssql-odf
+  - name: hammerdb-vm-pg-odf-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-odf-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-odf-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-odf-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-odf-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-odf-1vu
     metadata:
       kind: pod
       run_status: complete
       db_type: mssql
       storage_type: odf
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -51,12 +265,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-pod-mariadb-odf
+  - name: hammerdb-pod-mssql-odf-2vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-odf-4vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-odf-8vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-odf-16vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-odf-32vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-odf-1vu
     metadata:
       kind: pod
       run_status: complete
       db_type: mariadb
       storage_type: odf
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -64,12 +349,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-pod-pg-odf
+  - name: hammerdb-pod-mariadb-odf-2vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-odf-4vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-odf-8vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-odf-16vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-odf-32vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: odf
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-odf-1vu
     metadata:
       kind: pod
       run_status: complete
       db_type: pg
       storage_type: odf
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -77,12 +433,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-vm-mssql-lso
+  - name: hammerdb-pod-pg-odf-2vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-odf-4vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-odf-8vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-odf-16vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-odf-32vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: odf
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-lso-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -90,12 +517,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-vm-mariadb-lso
+  - name: hammerdb-vm-mssql-lso-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-lso-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-lso-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-lso-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-lso-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-lso-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: mariadb
       storage_type: lso
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -103,12 +601,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-vm-pg-lso
+  - name: hammerdb-vm-mariadb-lso-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-lso-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-lso-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-lso-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mariadb-lso-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-lso-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: pg
       storage_type: lso
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -116,12 +685,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-pod-mssql-lso
+  - name: hammerdb-vm-pg-lso-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-lso-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-lso-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-lso-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-pg-lso-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-lso-1vu
     metadata:
       kind: pod
       run_status: complete
       db_type: mssql
       storage_type: lso
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -129,12 +769,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-pod-mariadb-lso
+  - name: hammerdb-pod-mssql-lso-2vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-lso-4vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-lso-8vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-lso-16vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mssql-lso-32vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-lso-1vu
     metadata:
       kind: pod
       run_status: complete
       db_type: mariadb
       storage_type: lso
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -142,12 +853,83 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-pod-pg-lso
+  - name: hammerdb-pod-mariadb-lso-2vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-lso-4vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-lso-8vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-lso-16vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-mariadb-lso-32vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: mariadb
+      storage_type: lso
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-lso-1vu
     metadata:
       kind: pod
       run_status: complete
       db_type: pg
       storage_type: lso
+      current_worker: 1
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -155,12 +937,153 @@ tests:
           agg_type: avg
         threshold: 10
         direction: 1
-  - name: hammerdb-vm-mssql-scale
+  - name: hammerdb-pod-pg-lso-2vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-lso-4vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-lso-8vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-lso-16vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-pod-pg-lso-32vu
+    metadata:
+      kind: pod
+      run_status: complete
+      db_type: pg
+      storage_type: lso
+      current_worker: 32
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-scale-1vu
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
+      current_worker: 1
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-scale-2vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 2
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-scale-4vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 4
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-scale-8vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 8
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-scale-16vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 16
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: 1
+  - name: hammerdb-vm-mssql-scale-32vu
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 32
     metrics:
       - name: tpm
         metric_of_interest: tpm

--- a/orion-configs/perfci-sysbench.yaml
+++ b/orion-configs/perfci-sysbench.yaml
@@ -1,59 +1,69 @@
 tests:
-  - name: sysbench-vm
-    metadata:
-      kind: vm
-      run_status: complete
-    metrics:
-      - name: cpu-events-avg
-        metric_of_interest: cpu_events_avg
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: cpu-latency-p95
-        metric_of_interest: cpu_latency_95th
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-      - name: memory-throughput
-        metric_of_interest: memory_throughput_mib
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: memory-latency-p95
-        metric_of_interest: memory_latency_95th
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: sysbench-pod
-    metadata:
-      kind: pod
-      run_status: complete
-    metrics:
-      - name: cpu-events-avg
-        metric_of_interest: cpu_events_avg
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: cpu-latency-p95
-        metric_of_interest: cpu_latency_95th
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-      - name: memory-throughput
-        metric_of_interest: memory_throughput_mib
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: memory-latency-p95
-        metric_of_interest: memory_latency_95th
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
+- name: sysbench-vm-cpu
+  metadata:
+    kind: vm
+    run_status: complete
+  metrics:
+  - name: cpu-events-avg
+    metric_of_interest: cpu_events_avg
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: cpu-latency-p95
+    metric_of_interest: cpu_latency_95th
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: sysbench-vm-memory
+  metadata:
+    kind: vm
+    run_status: complete
+  metrics:
+  - name: memory-throughput
+    metric_of_interest: memory_throughput_mib
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: memory-latency-p95
+    metric_of_interest: memory_latency_95th
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: sysbench-pod-cpu
+  metadata:
+    kind: pod
+    run_status: complete
+  metrics:
+  - name: cpu-events-avg
+    metric_of_interest: cpu_events_avg
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: cpu-latency-p95
+    metric_of_interest: cpu_latency_95th
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: sysbench-pod-memory
+  metadata:
+    kind: pod
+    run_status: complete
+  metrics:
+  - name: memory-throughput
+    metric_of_interest: memory_throughput_mib
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: memory-latency-p95
+    metric_of_interest: memory_latency_95th
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1

--- a/orion-configs/perfci-uperf.yaml
+++ b/orion-configs/perfci-uperf.yaml
@@ -1,49 +1,625 @@
 tests:
-  - name: uperf-vm
-    metadata:
-      kind: vm
-      run_status: complete
-      test_type: stream
-    metrics:
-      - name: throughput
-        metric_of_interest: norm_byte
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: latency
-        metric_of_interest: norm_ltcy
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-      - name: operations
-        metric_of_interest: norm_ops
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-  - name: uperf-pod
-    metadata:
-      kind: pod
-      run_status: complete
-      test_type: stream
-    metrics:
-      - name: throughput
-        metric_of_interest: norm_byte
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: latency
-        metric_of_interest: norm_ltcy
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-      - name: operations
-        metric_of_interest: norm_ops
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
+- name: uperf-vm-stream-1thr-64b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: stream
+    num_threads: 1
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-stream-1thr-1024b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: stream
+    num_threads: 1
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-stream-1thr-8192b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: stream
+    num_threads: 1
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-stream-8thr-64b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: stream
+    num_threads: 8
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-stream-8thr-1024b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: stream
+    num_threads: 8
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-stream-8thr-8192b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: stream
+    num_threads: 8
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-rr-1thr-64b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: rr
+    num_threads: 1
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-rr-1thr-1024b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: rr
+    num_threads: 1
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-rr-1thr-8192b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: rr
+    num_threads: 1
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-rr-8thr-64b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: rr
+    num_threads: 8
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-rr-8thr-1024b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: rr
+    num_threads: 8
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-vm-rr-8thr-8192b
+  metadata:
+    kind: vm
+    run_status: complete
+    test_type: rr
+    num_threads: 8
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-stream-1thr-64b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: stream
+    num_threads: 1
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-stream-1thr-1024b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: stream
+    num_threads: 1
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-stream-1thr-8192b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: stream
+    num_threads: 1
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-stream-8thr-64b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: stream
+    num_threads: 8
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-stream-8thr-1024b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: stream
+    num_threads: 8
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-stream-8thr-8192b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: stream
+    num_threads: 8
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-rr-1thr-64b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: rr
+    num_threads: 1
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-rr-1thr-1024b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: rr
+    num_threads: 1
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-rr-1thr-8192b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: rr
+    num_threads: 1
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-rr-8thr-64b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: rr
+    num_threads: 8
+    message_size: 64
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-rr-8thr-1024b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: rr
+    num_threads: 8
+    message_size: 1024
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: uperf-pod-rr-8thr-8192b
+  metadata:
+    kind: pod
+    run_status: complete
+    test_type: rr
+    num_threads: 8
+    message_size: 8192
+  metrics:
+  - name: throughput
+    metric_of_interest: norm_byte
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: norm_ltcy
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: operations
+    metric_of_interest: norm_ops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1

--- a/orion-configs/perfci-vdbench.yaml
+++ b/orion-configs/perfci-vdbench.yaml
@@ -1,35 +1,505 @@
 tests:
-  - name: vdbench-vm
-    metadata:
-      kind: vm
-      run_status: complete
-    metrics:
-      - name: iops
-        metric_of_interest: Rate
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: latency
-        metric_of_interest: Resp
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: vdbench-pod
-    metadata:
-      kind: pod
-      run_status: complete
-    metrics:
-      - name: iops
-        metric_of_interest: Rate
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: latency
-        metric_of_interest: Resp
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
+- name: vdbench-vm-fillup
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: fillup
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-oltp1
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: oltp1
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-oltp2
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: oltp2
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-oltphw
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: oltphw
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-odss2
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: odss2
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-odss128
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: odss128
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-4kb_cache_read_32threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 4kb_cache_read_32threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-4kb_cache_write_32threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 4kb_cache_write_32threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-4kb_read_16threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 4kb_read_16threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-4kb_write_16threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 4kb_write_16threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-64kb_cache_read_4threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 64kb_cache_read_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-64kb_cache_write_4threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 64kb_cache_write_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-64kb_read_4threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 64kb_read_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-vm-64kb_write_4threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 64kb_write_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-fillup
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: fillup
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-oltp1
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: oltp1
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-oltp2
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: oltp2
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-oltphw
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: oltphw
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-odss2
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: odss2
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-odss128
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: odss128
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-4kb_cache_read_32threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 4kb_cache_read_32threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-4kb_cache_write_32threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 4kb_cache_write_32threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-4kb_read_16threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 4kb_read_16threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-4kb_write_16threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 4kb_write_16threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-64kb_cache_read_4threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 64kb_cache_read_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-64kb_cache_write_4threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 64kb_cache_write_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-64kb_read_4threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 64kb_read_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: vdbench-pod-64kb_write_4threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 64kb_write_4threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1

--- a/orion-configs/perfci-winfio.yaml
+++ b/orion-configs/perfci-winfio.yaml
@@ -3,7 +3,6 @@ tests:
     metadata:
       kind: vm
       run_status: complete
-      vm_os_version: windows_server_2k25
     metrics:
       - name: total-iops
         metric_of_interest: total_iops
@@ -18,7 +17,7 @@ tests:
         threshold: 10
         direction: -1
       - name: bandwidth
-        metric_of_interest: bandwidth_MiBsec
+        metric_of_interest: total_bw_kbs
         agg:
           agg_type: avg
         threshold: 10

--- a/orion-configs/perfci-winmssql.yaml
+++ b/orion-configs/perfci-winmssql.yaml
@@ -3,11 +3,10 @@ tests:
     metadata:
       kind: vm
       run_status: complete
-      vm_os_version: winmssql2025
     metrics:
-      - name: bootstorm-time
-        metric_of_interest: bootstorm_time
+      - name: tpm
+        metric_of_interest: tpm
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1

--- a/orion-configs/run-orion-all.sh
+++ b/orion-configs/run-orion-all.sh
@@ -19,6 +19,8 @@ declare -A INDEX_MAP=(
   [fio]="fio-results"
   [vdbench]="vdbench-results"
   [sysbench]="sysbench-results"
+  [winmssql]="hammerdb-results"
+  [winfio]="fio-results"
 )
 
 mkdir -p "$REPORTS"


### PR DESCRIPTION
- Split hammerdb into per-VU tests (1,2,4,8,16,32) × 13 variants = 78 tests
- Split fio by block_size (4k,8k,32k,1M) × io_operation (read,write,randread,randwrite) × kind = 32 tests
- Split uperf by num_threads (1,8) × message_size (64,1024,8192) × test_type (stream,rr) × kind = 24 tests
- Split vdbench by Run profile (14 profiles) × kind = 28 tests
- Split sysbench by test_type (cpu,memory) × kind = 4 tests
- Fix winmssql metric (bootstorm_time → tpm) and Jenkinsfile ES index (windows-results → hammerdb-results)
- Fix winfio bandwidth field (bandwidth_MiBsec → total_bw_kbs)
- Drop vm_os_version filters from winmssql/winfio
- Add winmssql/winfio to run-orion-all.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded performance test coverage across uperf, fio, HammerDB, sysbench, and vdbench for both VM and pod environments.
  - Added additional uperf test matrix variants (stream and rr) across thread counts and message sizes.
  - Split sysbench into dedicated CPU and memory test cases.

- **Updates**
  - Enhanced fio, HammerDB, and vdbench configs with more explicitly defined scenarios and standardized thresholds/metrics.
  - Updated WinFIO to report total bandwidth and WinMSSQL to use TPM instead of bootstorm timing. 
  - Added additional workloads to Orion regression analysis and reporting outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->