### PR TITLE
Add project rules to CLAUDE.md and CodeRabbit config

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,53 @@
+# /release
+
+Bump the patch version, commit, push, and trigger the CI release pipeline.
+
+## Steps
+
+1. **Ensure working tree is clean**
+   - Run `git status` — if there are uncommitted changes, run `/push` first and stop.
+
+2. **Rebase onto main**
+   ```bash
+   git fetch origin main && git rebase origin/main
+   ```
+
+3. **Run /unittest**
+   - All tests must pass before releasing.
+
+4. **Bump the patch version**
+   ```bash
+   bumpversion patch
+   ```
+   This updates `pyproject.toml` and `.bumpversion.cfg` and creates a git tag (e.g. `v1.0.1032`).
+
+5. **Commit and push with the tag**
+   ```bash
+   git push origin main --tags
+   ```
+
+6. **Create a GitHub Release from the tag**
+   ```bash
+   version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+   gh release create "v${version}" --repo redhat-performance/benchmark-runner \
+     --title "v${version}" \
+     --generate-notes
+   ```
+   This creates the release at https://github.com/redhat-performance/benchmark-runner/releases.
+
+7. **Trigger the Build Runner workflow**
+   ```bash
+   gh workflow run Build_runner.yml
+   ```
+   Then show the run URL:
+   ```bash
+   gh run list --workflow=Build_runner.yml --limit=1
+   ```
+
+## Notes
+
+- Never release if unit tests fail.
+- The CI pipeline (Build_runner.yml) handles PyPI upload, Quay image push, and auto-bumps the version after a successful release.
+- After pushing, CI may take several minutes — use `gh run watch` to follow progress.
+- Do not bump the version manually in `pyproject.toml`; always use `bumpversion patch`.
+- The GitHub Release is created at https://github.com/redhat-performance/benchmark-runner/releases with auto-generated notes from merged PRs since the last release, including "What's Changed" (all merged PRs) and "New Contributors" (first-time contributors). Both sections are produced automatically by `--generate-notes`.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,10 +33,22 @@ reviews:
       instructions: >
         Verify workload lifecycle: creation, monitoring, data collection, cleanup.
         Check timeout handling and retry logic.
+        Flag any code that makes HTTPS calls (Elasticsearch, Prometheus) in the main process
+        before spawning multiprocessing.Process children that also need HTTPS — this corrupts
+        OpenSSL state across process boundaries and causes SIGSEGV (exitcode=-11).
+        Safe pattern: do all HTTPS in child processes, or only after all child processes complete.
     - path: "benchmark_runner/common/template_operations/**"
       instructions: >
         Verify Jinja2 template variable substitution is correct.
         Check that YAML templates are well-formed.
+    - path: ".claude/skills/**"
+      instructions: >
+        Verify shell commands are correct and will not silently fail.
+        Check that each skill includes the pre-push checklist: rebase onto main and run all unit tests before pushing.
+    - path: "benchmark_runner/main/environment_variables.py"
+      instructions: >
+        Flag any PR that commits local dev defaults into this file — kubeadmin passwords, Elasticsearch hosts,
+        scale node IPs, or any other environment-specific values. These must never be committed.
     - path: ".github/workflows/**"
       instructions: >
         Check for proper secret handling, job dependencies, and workflow triggers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ PYTHONPATH=. python3 -m pytest -v tests/unittest/benchmark_runner/common/templat
 python -m benchmark_runner.main.main
 ```
 
+## Branch and Release Rules
+
+- **Never commit directly to `main`** — always create a feature branch first, then open a PR.
+- **Use `/release` to release** — never manually edit the version in `pyproject.toml` or run `bumpversion` outside the `/release` skill.
+
 ## Before Every Push
 
 Always run these two steps before pushing any commit:


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added branch and release rules — never commit to `main` directly; use `/release` as the only release path
- **CodeRabbit**: Added 3 new path instructions:
  - `.claude/skills/**` — verify shell commands and pre-push checklist (rebase + unittest)
  - `benchmark_runner/workloads/**` — flag multiprocessing + HTTPS in main process (SIGSEGV risk)
  - `benchmark_runner/main/environment_variables.py` — flag committed local dev defaults (passwords, ES hosts, scale nodes)

## Test plan
- [ ] Verify CodeRabbit picks up new path instructions on next PR
- [ ] Verify Claude Code follows branch and release rules

🤖 Assisted-by: Claude Code