### PR TITLE
Fix ODF subscription catalog source based on OCP version

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -401,6 +401,7 @@ class OC(SSH):
         env['kata_channel'] = self._get_kata_channel()
         env['kata_catalog_source'] = self._get_kata_catalog_source()
         env['kata_namespace'] = self._get_kata_namespace()
+        env['ocp_version'] = self.get_ocp_server_version()
 
     def is_cnv_installed(self):
         """

--- a/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
@@ -7,5 +7,5 @@ spec:
   channel: "stable-{{ odf_version }}"
   installPlanApproval: Automatic
   name: odf-operator
-  source: "{% if odf_version.split('.')[1] | int >= 21 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
+  source: "redhat-operators-v{{ odf_version | replace('.', '') }}"
   sourceNamespace: openshift-marketplace

--- a/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
@@ -7,5 +7,5 @@ spec:
   channel: "stable-{{ odf_version }}"
   installPlanApproval: Automatic
   name: odf-operator
-  source: "redhat-operators-v{{ odf_version | replace('.', '') }}"
+  source: "{% if odf_version.split('.')[1] | int >= 21 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
   sourceNamespace: openshift-marketplace

--- a/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
@@ -7,5 +7,5 @@ spec:
   channel: "stable-{{ odf_version }}"
   installPlanApproval: Automatic
   name: odf-operator
-  source: "{% if odf_version.split('.')[1] | int >= 21 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
+  source: "{% if ocp_version.split('.')[0] | int >= 5 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
   sourceNamespace: openshift-marketplace

--- a/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
@@ -7,5 +7,5 @@ spec:
   channel: "stable-{{ odf_version }}"
   installPlanApproval: Automatic
   name: odf-operator
-  source: redhat-operators
+  source: "{% if odf_version.split('.')[1] | int >= 21 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Summary

- For OCP 5.0+, ODF operators are exclusively in the versioned catalog source (`redhat-operators-v421`, `redhat-operators-v422`, etc.) rather than the generic `redhat-operators` catalog
- For OCP < 5.0 (4.20, 4.21, 4.22), `redhat-operators` is correct
- The hardcoded `source: redhat-operators` caused `wait_for_csv` to time out after 62 minutes with: `no operators found in package odf-operator in the catalog referenced by subscription odf-operator`

## Root Cause

On OCP 5.0, `redhat-operators` catalog source points to `registry.redhat.io/redhat/redhat-operator-index:v5.0` which does not include ODF 4.21 packages. ODF 4.21 is only available in `redhat-operators-v421` (`registry.redhat.io/redhat/redhat-operator-index:v4.21`).

On OCP 4.x, `redhat-operators` includes ODF packages — no versioned catalog needed.

## Fix

- Add `ocp_version` to `populate_additional_template_variables` in `oc.py` by calling `get_ocp_server_version()` — reads the actual running OCP version from the cluster
- Use `ocp_version` in the ODF subscription template to select the correct catalog source:

```yaml
source: "{% if ocp_version.split('.')[0] | int >= 5 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
```

| OCP Version | ODF Version | Catalog Source |
|---|---|---|
| 4.20 | 4.20 | `redhat-operators` |
| 4.22 | 4.21 | `redhat-operators` |
| 5.0 | 4.21 | `redhat-operators-v421` |
| 5.1 | 4.22 | `redhat-operators-v422` |

## Verified

Manually patched the subscription on OCP 5.0 cluster to `redhat-operators-v421` — ODF 4.21 installed successfully (CSV `Succeeded`, pods `Running` within 30 seconds).

🤖 Assisted-by: Claude Code