### PR TITLE
Fix test_get_ocp_minor_version for OCP 5.0

### DIFF
--- a/tests/integration/benchmark_runner/common/oc/test_oc.py
+++ b/tests/integration/benchmark_runner/common/oc/test_oc.py
@@ -37,7 +37,7 @@ def test_get_ocp_minor_version():
     """
     oc = OC(kubeadmin_password=test_environment_variable['kubeadmin_password'])
 
-    assert oc.get_ocp_minor_version()
+    assert isinstance(oc.get_ocp_minor_version(), int)
 
 
 def test_get_virtctl_version():


### PR DESCRIPTION
## Summary

`test_get_ocp_minor_version` fails on OCP 5.0.0 because the minor version is `0` which is falsy in Python.

## Root Cause

```python
# Before — fails on OCP 5.0 since minor version is 0 (falsy)
assert oc.get_ocp_minor_version()

# After — correctly validates return type regardless of value
assert isinstance(oc.get_ocp_minor_version(), int)
```

- OCP 4.22 → minor version `22` → truthy ✓
- OCP 5.0 → minor version `0` → falsy ✗ (fixed by isinstance check)

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened integration test coverage by verifying that the reported platform minor version is returned as an integer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->