### PR TITLE
Add ODF custom catalog source support for dev/pre-release versions

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -488,7 +488,7 @@ class OC(SSH):
         health_check = f"{self._cli} -n {namespace} rsh {self._get_pod_name(pod_name=pod_name, namespace=namespace)} ceph health"
 
         while timeout <= 0 or current_wait_time <= timeout:
-            if 'HEALTH_OK' == self.run(health_check).strip():
+            if self.run(health_check).strip().startswith('HEALTH_OK'):
                 return True
 
             # Sleep for a defined interval and update the wait time

--- a/benchmark_runner/common/ocp_resources/create_ocp_resource.py
+++ b/benchmark_runner/common/ocp_resources/create_ocp_resource.py
@@ -91,7 +91,7 @@ class CreateOCPResource:
             create_lso = CreateLSO(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files, lso_node=self.__lso_node, lso_disk_id=self.__lso_disk_id, ceph_version=self.__ceph_version)
             create_lso.create_lso(upgrade_version)
         elif 'odf' == resource:
-            create_odf = CreateODF(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files, worker_disk_ids=self.__worker_disk_ids, worker_disk_prefix=self.__worker_disk_prefix)
+            create_odf = CreateODF(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files, worker_disk_ids=self.__worker_disk_ids, worker_disk_prefix=self.__worker_disk_prefix, odf_catalog_image=self.__environment_variables_dict.get('odf_catalog_image', ''))
             create_odf.create_odf(upgrade_version)
         elif 'kata' == resource:
             create_kata = CreateKata(self.__oc, path=os.path.join(self.__dir_path, resource), resource_list=resource_files)

--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -13,13 +13,14 @@ class CreateODF(CreateOCPResourceOperations):
     """
     ODF_CSV_NUM = 4
 
-    def __init__(self, oc: OC, path: str, resource_list: list, worker_disk_ids: list, worker_disk_prefix: str):
+    def __init__(self, oc: OC, path: str, resource_list: list, worker_disk_ids: list, worker_disk_prefix: str, odf_catalog_image: str = ''):
         super().__init__(oc)
         self.__oc = oc
         self.__path = path
         self.__resource_list = resource_list
         self.__worker_disk_ids = worker_disk_ids
         self.__worker_disk_prefix = worker_disk_prefix
+        self.__odf_catalog_image = odf_catalog_image
 
     @logger_time_stamp
     def create_odf(self, upgrade_version: str):
@@ -33,6 +34,19 @@ class CreateODF(CreateOCPResourceOperations):
             logger.info(f'Wait till ODF upgrade to version: {upgrade_version}')
             self.verify_csv_installation(namespace='openshift-storage', operator='odf', upgrade_version=upgrade_version, csv_num=self.ODF_CSV_NUM)
         else:
+            if self.__odf_catalog_image:
+                idms_path = os.path.join(self.__path, 'idms.yaml')
+                logger.info(f'Extracting idms.yaml from catalog image: {self.__odf_catalog_image}')
+                self.__oc.run(cmd=f"cd {self.__path} && oc image extract '{self.__odf_catalog_image}' --file='/idms.yaml' --confirm")
+                if os.path.exists(idms_path) and open(idms_path).read().strip():
+                    logger.info('Applying IDMS for catalog image mirrors')
+                    self.__oc.run(cmd=f'oc apply -f {idms_path}')
+                    logger.info('Waiting for MCP rollout after IDMS apply')
+                    self.wait_for_ocp_resource_create(operator='odf',
+                                                      verify_cmd="oc get mcp -o jsonpath='{range .items[*]}{.status.conditions[?(@.type==\"Updated\")].status}{\"\\n\"}{end}' | grep -c True || true",
+                                                      status=str(len(['master', 'worker'])))
+                else:
+                    logger.info(f'No idms.yaml found in catalog image, skipping IDMS apply')
             for resource in self.__resource_list:
                 logger.info(f'run {resource}')
                 if resource.endswith('.sh'):

--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -43,7 +43,7 @@ class CreateODF(CreateOCPResourceOperations):
                     self.__oc.run(cmd=f'oc apply -f {idms_path}')
                     logger.info('Waiting for MCP rollout after IDMS apply')
                     self.wait_for_ocp_resource_create(operator='odf',
-                                                      verify_cmd="oc get mcp -o jsonpath='{range .items[*]}{.status.conditions[?(@.type==\"Updated\")].status}{\"\\n\"}{end}' | grep -c True || true",
+                                                      verify_cmd="oc get mcp master worker -o jsonpath='{range .items[*]}{.status.conditions[?(@.type==\"Updated\")].status}{\"\\n\"}{end}' | grep -cx True || true",
                                                       status=str(len(['master', 'worker'])))
                 else:
                     logger.info(f'No idms.yaml found in catalog image, skipping IDMS apply')

--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -46,7 +46,7 @@ class CreateODF(CreateOCPResourceOperations):
                                                       verify_cmd="oc get mcp master worker -o jsonpath='{range .items[*]}{.status.conditions[?(@.type==\"Updated\")].status}{\"\\n\"}{end}' | grep -cx True || true",
                                                       status=str(len(['master', 'worker'])))
                 else:
-                    logger.info(f'No idms.yaml found in catalog image, skipping IDMS apply')
+                    logger.info('No idms.yaml found in catalog image, skipping IDMS apply')
             for resource in self.__resource_list:
                 logger.info(f'run {resource}')
                 if resource.endswith('.sh'):

--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -49,7 +49,17 @@ class CreateODF(CreateOCPResourceOperations):
                     else:
                         self.__oc.run(cmd=f'chmod +x {os.path.join(self.__path, resource)}; {self.__path}/./{resource}')
                 else:  # yaml
-                    self.__oc.create_async(yaml=os.path.join(self.__path, resource))
+                    yaml_path = os.path.join(self.__path, resource)
+                    # skip empty rendered templates (e.g. catalog source when odf_catalog_image is not set)
+                    if not open(yaml_path).read().strip():
+                        logger.info(f'Skipping empty template: {resource}')
+                        continue
+                    self.__oc.create_async(yaml=yaml_path)
+                    if '00_catalog_source.yaml' in resource:
+                        # wait for catalog source to be ready before subscribing
+                        self.wait_for_ocp_resource_create(operator='odf',
+                                                          verify_cmd="oc get catalogsource odf-catalog-source -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' | grep -c READY || true",
+                                                          status='1')
                     if '04_local_volume_set.yaml' in resource:
                         # openshift local storage - diskmaker
                         self.wait_for_ocp_resource_create(operator='odf',

--- a/benchmark_runner/common/ocp_resources/odf/template/00_catalog_source_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/00_catalog_source_template.yaml
@@ -1,0 +1,15 @@
+{% if odf_catalog_image %}
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: odf-catalog-source
+  namespace: openshift-marketplace
+spec:
+  displayName: ODF Custom Catalog
+  image: {{ odf_catalog_image }}
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+{% endif %}

--- a/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
@@ -7,5 +7,5 @@ spec:
   channel: "stable-{{ odf_version }}"
   installPlanApproval: Automatic
   name: odf-operator
-  source: "{% if ocp_version.split('.')[0] | int >= 5 %}redhat-operators-v{{ odf_version | replace('.', '') }}{% else %}redhat-operators{% endif %}"
+  source: "{% if odf_catalog_image %}odf-catalog-source{% else %}redhat-operators{% endif %}"
   sourceNamespace: openshift-marketplace

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -334,6 +334,7 @@ class EnvironmentVariables:
         self._environment_variables_dict['lso_version'] = EnvironmentVariables.get_env('LSO_VERSION', '')
         # odf version
         self._environment_variables_dict['odf_version'] = EnvironmentVariables.get_env('ODF_VERSION', '')
+        self._environment_variables_dict['odf_catalog_image'] = EnvironmentVariables.get_env('ODF_CATALOG_IMAGE', '')
         # custom kata version, if empty fetch auto latest version
         self._environment_variables_dict['kata_csv'] = EnvironmentVariables.get_env('KATA_CSV', '')
         # number of odf disk for discovery

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -91,8 +91,8 @@ END
                             install -m 600 /dev/null global-pull-secret.json
                             oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json
                             QUAY_AUTH=$(python3 -c "import base64; print(base64.b64encode(b'${QUAY_USERNAME}:${QUAY_PASSWORD}').decode(), end='')")
-                            echo "$QUAY_PASSWORD" | podman login quay.io -u $QUAY_USERNAME --password-stdin
-                            jq --arg QUAY_AUTH "$QUAY_AUTH" '.auths += {"quay.io/rhceph-dev": {"auth":$QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
+                            printf '%s' "$QUAY_PASSWORD" | podman login quay.io -u $QUAY_USERNAME --password-stdin
+                            QUAY_AUTH="$QUAY_AUTH" jq '.auths += {"quay.io/rhceph-dev": {"auth":$ENV.QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
                             mv -f global-pull-secret.json.tmp global-pull-secret.json
                             oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=global-pull-secret.json
                             oc wait mcp master worker --for condition=updated --timeout=20m

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -79,6 +79,28 @@ END
             }
         }
 
+        stage('ODF Registered') {
+            when {
+                expression { env.ODF_CATALOG_IMAGE?.trim() }
+            }
+            steps {
+                script {
+                    withCredentials([string(credentialsId: 'perfci_quay_username', variable: 'QUAY_USERNAME'), string(credentialsId: 'perfci_quay_password', variable: 'QUAY_PASSWORD')]) {
+                        sh '''
+                            oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json
+                            QUAY_AUTH=$(echo -n "${QUAY_USERNAME}:${QUAY_PASSWORD}" | base64 -w 0)
+                            podman login quay.io -u $QUAY_USERNAME -p $QUAY_PASSWORD
+                            jq --arg QUAY_AUTH "$QUAY_AUTH" '.auths += {"quay.io/rhceph-dev": {"auth":$QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
+                            mv -f global-pull-secret.json.tmp global-pull-secret.json
+                            oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=global-pull-secret.json
+                            rm -f global-pull-secret.json
+                            oc wait mcp master worker --for condition=updated --timeout=20m
+                        '''
+                    }
+                }
+            }
+        }
+
         stage('CNV Nightly Registered') {
             steps {
                 script {

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -90,7 +90,7 @@ END
                             trap "rm -f global-pull-secret.json global-pull-secret.json.tmp" EXIT
                             install -m 600 /dev/null global-pull-secret.json
                             oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json
-                            QUAY_AUTH=$(python3 -c "import base64; print(base64.b64encode(b'${QUAY_USERNAME}:${QUAY_PASSWORD}').decode(), end='')")
+                            QUAY_AUTH=$(QUAY_USERNAME="$QUAY_USERNAME" QUAY_PASSWORD="$QUAY_PASSWORD" python3 -c "import base64, os; print(base64.b64encode(f'{os.environ[\"QUAY_USERNAME\"]}:{os.environ[\"QUAY_PASSWORD\"]}'.encode()).decode(), end='')")
                             printf '%s' "$QUAY_PASSWORD" | podman login quay.io -u $QUAY_USERNAME --password-stdin
                             QUAY_AUTH="$QUAY_AUTH" jq '.auths += {"quay.io/rhceph-dev": {"auth":$ENV.QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
                             mv -f global-pull-secret.json.tmp global-pull-secret.json

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -93,7 +93,6 @@ END
                             oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json
                             QUAY_AUTH=$(python3 -c "import base64; print(base64.b64encode(b'${QUAY_USERNAME}:${QUAY_PASSWORD}').decode(), end='')")
                             echo "$QUAY_PASSWORD" | podman login quay.io -u $QUAY_USERNAME --password-stdin
-                            set -x
                             jq --arg QUAY_AUTH "$QUAY_AUTH" '.auths += {"quay.io/rhceph-dev": {"auth":$QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
                             mv -f global-pull-secret.json.tmp global-pull-secret.json
                             oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=global-pull-secret.json

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -88,8 +88,8 @@ END
                     withCredentials([string(credentialsId: 'perfci_quay_username', variable: 'QUAY_USERNAME'), string(credentialsId: 'perfci_quay_password', variable: 'QUAY_PASSWORD')]) {
                         sh '''
                             oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json
-                            QUAY_AUTH=$(echo -n "${QUAY_USERNAME}:${QUAY_PASSWORD}" | base64 -w 0)
-                            podman login quay.io -u $QUAY_USERNAME -p $QUAY_PASSWORD
+                            QUAY_AUTH=$(python3 -c "import base64; print(base64.b64encode(b'${QUAY_USERNAME}:${QUAY_PASSWORD}').decode(), end='')")
+                            echo "$QUAY_PASSWORD" | podman login quay.io -u $QUAY_USERNAME --password-stdin
                             jq --arg QUAY_AUTH "$QUAY_AUTH" '.auths += {"quay.io/rhceph-dev": {"auth":$QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
                             mv -f global-pull-secret.json.tmp global-pull-secret.json
                             oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=global-pull-secret.json

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -87,13 +87,16 @@ END
                 script {
                     withCredentials([string(credentialsId: 'perfci_quay_username', variable: 'QUAY_USERNAME'), string(credentialsId: 'perfci_quay_password', variable: 'QUAY_PASSWORD')]) {
                         sh '''
+                            set +x
+                            trap "rm -f global-pull-secret.json global-pull-secret.json.tmp" EXIT
+                            install -m 600 /dev/null global-pull-secret.json
                             oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json
                             QUAY_AUTH=$(python3 -c "import base64; print(base64.b64encode(b'${QUAY_USERNAME}:${QUAY_PASSWORD}').decode(), end='')")
                             echo "$QUAY_PASSWORD" | podman login quay.io -u $QUAY_USERNAME --password-stdin
+                            set -x
                             jq --arg QUAY_AUTH "$QUAY_AUTH" '.auths += {"quay.io/rhceph-dev": {"auth":$QUAY_AUTH,"email":""}}' global-pull-secret.json > global-pull-secret.json.tmp
                             mv -f global-pull-secret.json.tmp global-pull-secret.json
                             oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=global-pull-secret.json
-                            rm -f global-pull-secret.json
                             oc wait mcp master worker --for condition=updated --timeout=20m
                         '''
                     }

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -87,7 +87,6 @@ END
                 script {
                     withCredentials([string(credentialsId: 'perfci_quay_username', variable: 'QUAY_USERNAME'), string(credentialsId: 'perfci_quay_password', variable: 'QUAY_PASSWORD')]) {
                         sh '''
-                            set +x
                             trap "rm -f global-pull-secret.json global-pull-secret.json.tmp" EXIT
                             install -m 600 /dev/null global-pull-secret.json
                             oc get secret pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > global-pull-secret.json

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         WORKER_DISK_IDS = credentials('perfci_worker_disk_ids')
         CNV_VERSION = credentials('perfci_cnv_version')
         ODF_VERSION = credentials('perfci_odf_version')
+        ODF_CATALOG_IMAGE = credentials('perfci_odf_catalog_image')
         LSO_VERSION = credentials('perfci_lso_version')
         EXPECTED_NODES = credentials('perfci_expected_nodes')
         QUAY_BENCHMARK_RUNNER_REPOSITORY = credentials('perfci_quay_repository')
@@ -125,6 +126,7 @@ END
                                                             -e CNV_VERSION='${CNV_VERSION}' \
                                                             -e LSO_VERSION='${LSO_VERSION}' \
                                                             -e ODF_VERSION='${ODF_VERSION}' \
+                                                            -e ODF_CATALOG_IMAGE='${ODF_CATALOG_IMAGE}' \
                                                             -e NUM_ODF_DISK='${NUM_ODF_DISK}' \
                                                             -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' \
                                                             -e PROVISION_IP='${PROVISION_IP}' \

--- a/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/03_PerfCI_Workloads_Deployment/Jenkinsfile
@@ -107,7 +107,7 @@ END
         stage('WORKLOADS Deployment') {
             steps {
                 script {
-                    def workloads =  ['sysbench_pod', 'sysbench_vm', 'uperf_pod', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb','hammerdb_pod_mariadb_lso', 'hammerdb_vm_mariadb_lso', 'hammerdb_vm_mariadb_scale', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_pod_postgres_lso', 'hammerdb_vm_postgres_lso', 'hammerdb_vm_postgres_scale', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_pod_mssql_lso', 'hammerdb_vm_mssql_lso', 'hammerdb_vm_mssql_scale', 'winmssql_vm', 'winmssql_vm_scale', 'winfio_vm', 'winfio_vm_scale', 'vdbench_pod', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_vm_scale', 'fio_pod', 'fio_vm', 'fio_pod_scale', 'fio_vm_scale', 'bootstorm_vm_scale', 'windows_vm_scale_windows11', 'windows_vm_scale_windows_server_2022' ]
+                    def workloads =  ['sysbench_pod', 'sysbench_vm', 'uperf_pod', 'uperf_vm', 'hammerdb_pod_mariadb', 'hammerdb_vm_mariadb', 'hammerdb_vm_mariadb_scale', 'hammerdb_pod_postgres', 'hammerdb_vm_postgres', 'hammerdb_vm_postgres_scale', 'hammerdb_pod_mssql', 'hammerdb_vm_mssql', 'hammerdb_vm_mssql_scale', 'winmssql_vm', 'winmssql_vm_scale', 'winfio_vm', 'winfio_vm_scale', 'vdbench_pod', 'vdbench_vm', 'vdbench_pod_scale', 'vdbench_vm_scale', 'fio_pod', 'fio_vm', 'fio_pod_scale', 'fio_vm_scale', 'bootstorm_vm_scale', 'windows_vm_scale_windows11', 'windows_vm_scale_windows_server_2022' ]
                     def build_version = sh(script: 'curl -s "https://pypi.org/pypi/benchmark-runner/json" | jq -r .info.version', returnStdout: true).trim()
                     def WINDOWS_URL = ''
                     def SCALE = ''


### PR DESCRIPTION
## Summary
- Add optional `ODF_CATALOG_IMAGE` env var to support custom ODF catalog sources for dev/pre-release ODF versions
- Templates conditionally create and select an `odf-catalog-source` CatalogSource when `ODF_CATALOG_IMAGE` is set; falls back to `redhat-operators` when empty
- Extract `idms.yaml` from catalog image and apply IDMS + wait for MachineConfigPool rollout before proceeding
- Fix ODF health check to accept `HEALTH_OK` output with trailing status text (startswith match)
- Disable LSO workloads in PerfCI pipeline pending OCP 5.0 official LSO release

## Notes
- LSO workloads (`hammerdb *_lso` variants) are temporarily disabled in `03_PerfCI_Workloads_Deployment/Jenkinsfile` until LSO is officially released in OCP 5.0. They will be re-enabled once the official release is available.
- Setting `ODF_CATALOG_IMAGE` to empty installs the standard release ODF version from `redhat-operators` — no custom catalog is created.

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom ODF catalog image during deployment.
  * Added catalog registration, authenticated image access, and readiness checks.
  * ODF resources are now created only when valid, non-empty templates are available.

* **Bug Fixes**
  * Improved ODF health detection to recognize all `HEALTH_OK` responses.
  * Updated subscription selection for custom ODF catalogs.

* **Chores**
  * Removed MariaDB and PostgreSQL LSO workload variants from workload deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->