### PR TITLE
Fix inverted Orion direction values across all perfci configs

### DIFF
--- a/orion-configs/perfci-bootstorm.yaml
+++ b/orion-configs/perfci-bootstorm.yaml
@@ -9,10 +9,10 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
       - name: total-run-time
         metric_of_interest: total_run_time
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1

--- a/orion-configs/perfci-fio.yaml
+++ b/orion-configs/perfci-fio.yaml
@@ -11,19 +11,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-4k-write
   metadata:
     kind: vm
@@ -36,19 +36,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-4k-randread
   metadata:
     kind: vm
@@ -61,19 +61,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-4k-randwrite
   metadata:
     kind: vm
@@ -86,19 +86,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-8k-read
   metadata:
     kind: vm
@@ -111,19 +111,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-8k-write
   metadata:
     kind: vm
@@ -136,19 +136,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-8k-randread
   metadata:
     kind: vm
@@ -161,19 +161,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-8k-randwrite
   metadata:
     kind: vm
@@ -186,19 +186,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-32k-read
   metadata:
     kind: vm
@@ -211,19 +211,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-32k-write
   metadata:
     kind: vm
@@ -236,19 +236,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-32k-randread
   metadata:
     kind: vm
@@ -261,19 +261,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-32k-randwrite
   metadata:
     kind: vm
@@ -286,19 +286,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-1M-read
   metadata:
     kind: vm
@@ -311,19 +311,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-1M-write
   metadata:
     kind: vm
@@ -336,19 +336,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-1M-randread
   metadata:
     kind: vm
@@ -361,19 +361,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-vm-1M-randwrite
   metadata:
     kind: vm
@@ -386,19 +386,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-4k-read
   metadata:
     kind: pod
@@ -411,19 +411,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-4k-write
   metadata:
     kind: pod
@@ -436,19 +436,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-4k-randread
   metadata:
     kind: pod
@@ -461,19 +461,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-4k-randwrite
   metadata:
     kind: pod
@@ -486,19 +486,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-8k-read
   metadata:
     kind: pod
@@ -511,19 +511,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-8k-write
   metadata:
     kind: pod
@@ -536,19 +536,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-8k-randread
   metadata:
     kind: pod
@@ -561,19 +561,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-8k-randwrite
   metadata:
     kind: pod
@@ -586,19 +586,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-32k-read
   metadata:
     kind: pod
@@ -611,19 +611,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-32k-write
   metadata:
     kind: pod
@@ -636,19 +636,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-32k-randread
   metadata:
     kind: pod
@@ -661,19 +661,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-32k-randwrite
   metadata:
     kind: pod
@@ -686,19 +686,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-1M-read
   metadata:
     kind: pod
@@ -711,19 +711,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-1M-write
   metadata:
     kind: pod
@@ -736,19 +736,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-1M-randread
   metadata:
     kind: pod
@@ -761,19 +761,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: fio-pod-1M-randwrite
   metadata:
     kind: pod
@@ -786,16 +786,16 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: lat-avg
     metric_of_interest: lat_avg_usec
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: bandwidth
     metric_of_interest: total_bw_kbs
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1

--- a/orion-configs/perfci-hammerdb.yaml
+++ b/orion-configs/perfci-hammerdb.yaml
@@ -12,7 +12,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-odf-2vu
     metadata:
       kind: vm
@@ -26,7 +26,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-odf-4vu
     metadata:
       kind: vm
@@ -40,7 +40,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-odf-8vu
     metadata:
       kind: vm
@@ -54,7 +54,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-odf-16vu
     metadata:
       kind: vm
@@ -68,7 +68,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-odf-32vu
     metadata:
       kind: vm
@@ -82,7 +82,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-odf-1vu
     metadata:
       kind: vm
@@ -96,7 +96,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-odf-2vu
     metadata:
       kind: vm
@@ -110,7 +110,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-odf-4vu
     metadata:
       kind: vm
@@ -124,7 +124,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-odf-8vu
     metadata:
       kind: vm
@@ -138,7 +138,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-odf-16vu
     metadata:
       kind: vm
@@ -152,7 +152,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-odf-32vu
     metadata:
       kind: vm
@@ -166,7 +166,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-odf-1vu
     metadata:
       kind: vm
@@ -180,7 +180,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-odf-2vu
     metadata:
       kind: vm
@@ -194,7 +194,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-odf-4vu
     metadata:
       kind: vm
@@ -208,7 +208,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-odf-8vu
     metadata:
       kind: vm
@@ -222,7 +222,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-odf-16vu
     metadata:
       kind: vm
@@ -236,7 +236,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-odf-32vu
     metadata:
       kind: vm
@@ -250,7 +250,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-odf-1vu
     metadata:
       kind: pod
@@ -264,7 +264,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-odf-2vu
     metadata:
       kind: pod
@@ -278,7 +278,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-odf-4vu
     metadata:
       kind: pod
@@ -292,7 +292,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-odf-8vu
     metadata:
       kind: pod
@@ -306,7 +306,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-odf-16vu
     metadata:
       kind: pod
@@ -320,7 +320,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-odf-32vu
     metadata:
       kind: pod
@@ -334,7 +334,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-odf-1vu
     metadata:
       kind: pod
@@ -348,7 +348,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-odf-2vu
     metadata:
       kind: pod
@@ -362,7 +362,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-odf-4vu
     metadata:
       kind: pod
@@ -376,7 +376,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-odf-8vu
     metadata:
       kind: pod
@@ -390,7 +390,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-odf-16vu
     metadata:
       kind: pod
@@ -404,7 +404,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-odf-32vu
     metadata:
       kind: pod
@@ -418,7 +418,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-odf-1vu
     metadata:
       kind: pod
@@ -432,7 +432,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-odf-2vu
     metadata:
       kind: pod
@@ -446,7 +446,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-odf-4vu
     metadata:
       kind: pod
@@ -460,7 +460,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-odf-8vu
     metadata:
       kind: pod
@@ -474,7 +474,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-odf-16vu
     metadata:
       kind: pod
@@ -488,7 +488,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-odf-32vu
     metadata:
       kind: pod
@@ -502,7 +502,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-lso-1vu
     metadata:
       kind: vm
@@ -516,7 +516,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-lso-2vu
     metadata:
       kind: vm
@@ -530,7 +530,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-lso-4vu
     metadata:
       kind: vm
@@ -544,7 +544,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-lso-8vu
     metadata:
       kind: vm
@@ -558,7 +558,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-lso-16vu
     metadata:
       kind: vm
@@ -572,7 +572,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-lso-32vu
     metadata:
       kind: vm
@@ -586,7 +586,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-lso-1vu
     metadata:
       kind: vm
@@ -600,7 +600,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-lso-2vu
     metadata:
       kind: vm
@@ -614,7 +614,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-lso-4vu
     metadata:
       kind: vm
@@ -628,7 +628,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-lso-8vu
     metadata:
       kind: vm
@@ -642,7 +642,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-lso-16vu
     metadata:
       kind: vm
@@ -656,7 +656,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mariadb-lso-32vu
     metadata:
       kind: vm
@@ -670,7 +670,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-lso-1vu
     metadata:
       kind: vm
@@ -684,7 +684,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-lso-2vu
     metadata:
       kind: vm
@@ -698,7 +698,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-lso-4vu
     metadata:
       kind: vm
@@ -712,7 +712,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-lso-8vu
     metadata:
       kind: vm
@@ -726,7 +726,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-lso-16vu
     metadata:
       kind: vm
@@ -740,7 +740,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-pg-lso-32vu
     metadata:
       kind: vm
@@ -754,7 +754,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-lso-1vu
     metadata:
       kind: pod
@@ -768,7 +768,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-lso-2vu
     metadata:
       kind: pod
@@ -782,7 +782,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-lso-4vu
     metadata:
       kind: pod
@@ -796,7 +796,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-lso-8vu
     metadata:
       kind: pod
@@ -810,7 +810,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-lso-16vu
     metadata:
       kind: pod
@@ -824,7 +824,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mssql-lso-32vu
     metadata:
       kind: pod
@@ -838,7 +838,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-lso-1vu
     metadata:
       kind: pod
@@ -852,7 +852,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-lso-2vu
     metadata:
       kind: pod
@@ -866,7 +866,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-lso-4vu
     metadata:
       kind: pod
@@ -880,7 +880,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-lso-8vu
     metadata:
       kind: pod
@@ -894,7 +894,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-lso-16vu
     metadata:
       kind: pod
@@ -908,7 +908,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-mariadb-lso-32vu
     metadata:
       kind: pod
@@ -922,7 +922,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-lso-1vu
     metadata:
       kind: pod
@@ -936,7 +936,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-lso-2vu
     metadata:
       kind: pod
@@ -950,7 +950,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-lso-4vu
     metadata:
       kind: pod
@@ -964,7 +964,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-lso-8vu
     metadata:
       kind: pod
@@ -978,7 +978,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-lso-16vu
     metadata:
       kind: pod
@@ -992,7 +992,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-pod-pg-lso-32vu
     metadata:
       kind: pod
@@ -1006,7 +1006,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-scale-1vu
     metadata:
       kind: vm
@@ -1020,7 +1020,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-scale-2vu
     metadata:
       kind: vm
@@ -1034,7 +1034,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-scale-4vu
     metadata:
       kind: vm
@@ -1048,7 +1048,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-scale-8vu
     metadata:
       kind: vm
@@ -1062,7 +1062,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-scale-16vu
     metadata:
       kind: vm
@@ -1076,7 +1076,7 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
   - name: hammerdb-vm-mssql-scale-32vu
     metadata:
       kind: vm
@@ -1090,4 +1090,4 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1

--- a/orion-configs/perfci-sysbench.yaml
+++ b/orion-configs/perfci-sysbench.yaml
@@ -9,13 +9,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: cpu-latency-p95
     metric_of_interest: cpu_latency_95th
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: sysbench-vm-memory
   metadata:
     kind: vm
@@ -26,13 +26,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: memory-latency-p95
     metric_of_interest: memory_latency_95th
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: sysbench-pod-cpu
   metadata:
     kind: pod
@@ -43,13 +43,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: cpu-latency-p95
     metric_of_interest: cpu_latency_95th
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: sysbench-pod-memory
   metadata:
     kind: pod
@@ -60,10 +60,10 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: memory-latency-p95
     metric_of_interest: memory_latency_95th
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1

--- a/orion-configs/perfci-uperf.yaml
+++ b/orion-configs/perfci-uperf.yaml
@@ -12,19 +12,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-stream-1thr-1024b
   metadata:
     kind: vm
@@ -38,19 +38,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-stream-1thr-8192b
   metadata:
     kind: vm
@@ -64,19 +64,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-stream-8thr-64b
   metadata:
     kind: vm
@@ -90,19 +90,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-stream-8thr-1024b
   metadata:
     kind: vm
@@ -116,19 +116,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-stream-8thr-8192b
   metadata:
     kind: vm
@@ -142,19 +142,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-rr-1thr-64b
   metadata:
     kind: vm
@@ -168,19 +168,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-rr-1thr-1024b
   metadata:
     kind: vm
@@ -194,19 +194,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-rr-1thr-8192b
   metadata:
     kind: vm
@@ -220,19 +220,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-rr-8thr-64b
   metadata:
     kind: vm
@@ -246,19 +246,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-rr-8thr-1024b
   metadata:
     kind: vm
@@ -272,19 +272,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-vm-rr-8thr-8192b
   metadata:
     kind: vm
@@ -298,19 +298,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-stream-1thr-64b
   metadata:
     kind: pod
@@ -324,19 +324,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-stream-1thr-1024b
   metadata:
     kind: pod
@@ -350,19 +350,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-stream-1thr-8192b
   metadata:
     kind: pod
@@ -376,19 +376,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-stream-8thr-64b
   metadata:
     kind: pod
@@ -402,19 +402,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-stream-8thr-1024b
   metadata:
     kind: pod
@@ -428,19 +428,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-stream-8thr-8192b
   metadata:
     kind: pod
@@ -454,19 +454,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-rr-1thr-64b
   metadata:
     kind: pod
@@ -480,19 +480,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-rr-1thr-1024b
   metadata:
     kind: pod
@@ -506,19 +506,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-rr-1thr-8192b
   metadata:
     kind: pod
@@ -532,19 +532,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-rr-8thr-64b
   metadata:
     kind: pod
@@ -558,19 +558,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-rr-8thr-1024b
   metadata:
     kind: pod
@@ -584,19 +584,19 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
 - name: uperf-pod-rr-8thr-8192b
   metadata:
     kind: pod
@@ -610,16 +610,16 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: norm_ltcy
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
   - name: operations
     metric_of_interest: norm_ops
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1

--- a/orion-configs/perfci-vdbench.yaml
+++ b/orion-configs/perfci-vdbench.yaml
@@ -10,13 +10,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-oltp1
   metadata:
     kind: vm
@@ -28,13 +28,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-oltp2
   metadata:
     kind: vm
@@ -46,13 +46,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-oltphw
   metadata:
     kind: vm
@@ -64,13 +64,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-odss2
   metadata:
     kind: vm
@@ -82,13 +82,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-odss128
   metadata:
     kind: vm
@@ -100,13 +100,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-4kb_cache_read_32threads
   metadata:
     kind: vm
@@ -118,13 +118,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-4kb_cache_write_32threads
   metadata:
     kind: vm
@@ -136,13 +136,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-4kb_read_16threads
   metadata:
     kind: vm
@@ -154,13 +154,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-4kb_write_16threads
   metadata:
     kind: vm
@@ -172,13 +172,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-64kb_cache_read_4threads
   metadata:
     kind: vm
@@ -190,13 +190,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-64kb_cache_write_4threads
   metadata:
     kind: vm
@@ -208,13 +208,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-64kb_read_4threads
   metadata:
     kind: vm
@@ -226,13 +226,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-vm-64kb_write_4threads
   metadata:
     kind: vm
@@ -244,13 +244,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-fillup
   metadata:
     kind: pod
@@ -262,13 +262,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-oltp1
   metadata:
     kind: pod
@@ -280,13 +280,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-oltp2
   metadata:
     kind: pod
@@ -298,13 +298,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-oltphw
   metadata:
     kind: pod
@@ -316,13 +316,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-odss2
   metadata:
     kind: pod
@@ -334,13 +334,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-odss128
   metadata:
     kind: pod
@@ -352,13 +352,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-4kb_cache_read_32threads
   metadata:
     kind: pod
@@ -370,13 +370,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-4kb_cache_write_32threads
   metadata:
     kind: pod
@@ -388,13 +388,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-4kb_read_16threads
   metadata:
     kind: pod
@@ -406,13 +406,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-4kb_write_16threads
   metadata:
     kind: pod
@@ -424,13 +424,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-64kb_cache_read_4threads
   metadata:
     kind: pod
@@ -442,13 +442,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-64kb_cache_write_4threads
   metadata:
     kind: pod
@@ -460,13 +460,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-64kb_read_4threads
   metadata:
     kind: pod
@@ -478,13 +478,13 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
-    direction: -1
+    direction: 1
 - name: vdbench-pod-64kb_write_4threads
   metadata:
     kind: pod
@@ -496,10 +496,46 @@ tests:
     agg:
       agg_type: avg
     threshold: 10
-    direction: 1
+    direction: -1
   - name: latency
     metric_of_interest: Resp
     agg:
       agg_type: avg
     threshold: 10
+    direction: 1
+- name: vdbench-vm-64kb_write_16threads
+  metadata:
+    kind: vm
+    run_status: complete
+    Run: 64kb_write_16threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
     direction: -1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: vdbench-pod-64kb_write_16threads
+  metadata:
+    kind: pod
+    run_status: complete
+    Run: 64kb_write_16threads
+  metrics:
+  - name: iops
+    metric_of_interest: Rate
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: latency
+    metric_of_interest: Resp
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1

--- a/orion-configs/perfci-windows-bootstorm.yaml
+++ b/orion-configs/perfci-windows-bootstorm.yaml
@@ -10,13 +10,13 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
       - name: total-run-time
         metric_of_interest: total_run_time
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
   - name: windows-bootstorm-server2022
     metadata:
       kind: vm
@@ -28,13 +28,13 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
       - name: total-run-time
         metric_of_interest: total_run_time
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
   - name: windows-bootstorm-server2025
     metadata:
       kind: vm
@@ -46,10 +46,10 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
       - name: total-run-time
         metric_of_interest: total_run_time
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1

--- a/orion-configs/perfci-winfio.yaml
+++ b/orion-configs/perfci-winfio.yaml
@@ -9,16 +9,16 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1
       - name: lat-avg
         metric_of_interest: lat_avg_usec
         agg:
           agg_type: avg
         threshold: 10
-        direction: -1
+        direction: 1
       - name: bandwidth
         metric_of_interest: total_bw_kbs
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1

--- a/orion-configs/perfci-winmssql.yaml
+++ b/orion-configs/perfci-winmssql.yaml
@@ -9,4 +9,4 @@ tests:
         agg:
           agg_type: avg
         threshold: 10
-        direction: 1
+        direction: -1


### PR DESCRIPTION
All perfci Orion configs had direction values inverted so throughput/IOPS/tpm were flagging increases as regressions and latency/time were flagging decreases as regressions.

- `direction: 1` → increase is regression (latency, boot time, CPU)
- `direction: -1` → decrease is regression (throughput, IOPS, tpm, bandwidth)

Also adds missing vdbench variant `64kb_write_16threads` (vm + pod).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected performance threshold evaluation across boot, database, storage, CPU, memory, and networking benchmarks.
  - Throughput, IOPS, bandwidth, and operations metrics now use the appropriate comparison direction, while latency metrics are evaluated correctly.
  - Updated performance checks across Linux and Windows environments, including Windows 11, Server 2022, and Server 2025.

- **New Features**
  - Added 64 KB write testing with 16 threads to Vdbench performance coverage for both virtual machines and pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->