### PR TITLE
Update winfio perf_ci CPU to match ioThreads configuration

### DIFF
--- a/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
@@ -33,8 +33,8 @@ template_data:
       PAUSE: 15
       SIZE: 4G
       requests_memory: 4G
-      requests_cpu: 1
-      cores: 2
+      requests_cpu: 8
+      cores: 8
       storage: 76Gi
       data_disk_storage: 64Gi
     default:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False/winfio_vm.yaml
@@ -24,7 +24,7 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
+          cores: 8
           sockets: 1
           threads: 1
         devices:
@@ -81,7 +81,7 @@ spec:
           type: q35
         resources:
           requests:
-            cpu: 1
+            cpu: 8
             memory: 4G
       evictionStrategy: LiveMigrate
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_False_CDI_s3/winfio_vm.yaml
@@ -24,7 +24,7 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
+          cores: 8
           sockets: 1
           threads: 1
         devices:
@@ -81,7 +81,7 @@ spec:
           type: q35
         resources:
           requests:
-            cpu: 1
+            cpu: 8
             memory: 4G
       evictionStrategy: LiveMigrate
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True/winfio_vm.yaml
@@ -24,7 +24,7 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
+          cores: 8
           sockets: 1
           threads: 1
         devices:
@@ -81,7 +81,7 @@ spec:
           type: q35
         resources:
           requests:
-            cpu: 1
+            cpu: 8
             memory: 4G
       evictionStrategy: LiveMigrate
       networks:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_winfio_vm_ODF_PVC_True_CDI_s3/winfio_vm.yaml
@@ -24,7 +24,7 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
+          cores: 8
           sockets: 1
           threads: 1
         devices:
@@ -81,7 +81,7 @@ spec:
           type: q35
         resources:
           requests:
-            cpu: 1
+            cpu: 8
             memory: 4G
       evictionStrategy: LiveMigrate
       networks:


### PR DESCRIPTION
## Summary

Update `winfio` `perf_ci` run type CPU configuration:
- `requests_cpu`: 1 → 8
- `cores`: 2 → 8

This aligns the VM CPU allocation with the 8 FIO IO threads (`IO_THREADS: 8,8,8,8`) used in the benchmark and the `supplementalPoolThreadCount: 8` ioThreads configured in the VM template.

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased CPU resources for WinFIO performance test environments from 1 requestable CPU and 2 cores to 8 CPUs and 8 cores.
  * Applied the updated allocation consistently across supported VM and storage configurations.

* **Tests**
  * Updated expected configuration outputs to reflect the increased CPU allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->