### PR TITLE
Fix uperf pod server readiness race: add TCP readiness probe

### DIFF
--- a/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/uperf/internal_data/uperf_pod_server_template.yaml
@@ -190,6 +190,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   {%- if pin == 'true' or pin == true %}
   nodeSelector:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -309,6 +309,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -309,6 +309,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -309,6 +309,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -309,6 +309,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_pod_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_False/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_uperf_vm_ODF_PVC_True/uperf_pod_server.yaml
@@ -138,6 +138,12 @@ spec:
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["dnf install -y uperf > /dev/null && uperf -s -v -P 30000"]
+    readinessProbe:
+      tcpSocket:
+        port: 30000
+      initialDelaySeconds: 5
+      periodSeconds: 3
+      failureThreshold: 10
   restartPolicy: Never
   nodeSelector:
     kubernetes.io/hostname: 'pin-node-1'


### PR DESCRIPTION
## Summary

- Add a `tcpSocket` readiness probe on port 30000 to the uperf server pod template
- Without this probe, Kubernetes marks the pod Ready as soon as the container starts, but the uperf process may not yet be listening — the client connects immediately and gets `Connection refused`, causing all 12 benchmark scenarios to report 0 bytes/ops
- With the probe, `wait_for_ready` blocks until uperf is actually accepting connections, eliminating the race

## Root cause

Observed in a failed run where `wait_for_pod_completed` returned in 15 seconds (vs ~13 minutes for a healthy run), and the client log showed:
```
Error connecting to <server_ip>
** TCP: Cannot connect to <server_ip>:30000 Connection refused
```

## Test plan
- [ ] Golden file tests pass (`make test_golden_files`)
- [ ] All unit tests pass (`PYTHONPATH=. python3 -m pytest -v tests/unittest/`)
- [ ] Verify next uperf pod CI run completes with non-zero results

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TCP readiness check for the uperf server on port 30000.
  * The check starts after 5 seconds, runs every 3 seconds, and allows up to 10 consecutive failures.

* **Tests**
  * Updated expected deployment configurations to include the new readiness check across supported test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->