### PR TITLE
Split Orion configs by vm_os_version to catch OS-specific regressions

### DIFF
--- a/orion-configs/perfci-fio.yaml
+++ b/orion-configs/perfci-fio.yaml
@@ -1,10 +1,11 @@
 tests:
-- name: fio-vm-4k-read
+- name: fio-vm-4k-read-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 4k
     io_operation: read
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -24,12 +25,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-4k-write
+- name: fio-vm-4k-read-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: read
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-4k-write-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 4k
     io_operation: write
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -49,12 +77,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-4k-randread
+- name: fio-vm-4k-write-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: write
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-4k-randread-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 4k
     io_operation: randread
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -74,12 +129,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-4k-randwrite
+- name: fio-vm-4k-randread-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: randread
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-4k-randwrite-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 4k
     io_operation: randwrite
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -99,12 +181,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-8k-read
+- name: fio-vm-4k-randwrite-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 4k
+    io_operation: randwrite
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-8k-read-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 8k
     io_operation: read
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -124,12 +233,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-8k-write
+- name: fio-vm-8k-read-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: read
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-8k-write-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 8k
     io_operation: write
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -149,12 +285,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-8k-randread
+- name: fio-vm-8k-write-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: write
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-8k-randread-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 8k
     io_operation: randread
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -174,12 +337,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-8k-randwrite
+- name: fio-vm-8k-randread-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: randread
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-8k-randwrite-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 8k
     io_operation: randwrite
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -199,12 +389,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-32k-read
+- name: fio-vm-8k-randwrite-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 8k
+    io_operation: randwrite
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-32k-read-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 32k
     io_operation: read
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -224,12 +441,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-32k-write
+- name: fio-vm-32k-read-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: read
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-32k-write-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 32k
     io_operation: write
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -249,12 +493,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-32k-randread
+- name: fio-vm-32k-write-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: write
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-32k-randread-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 32k
     io_operation: randread
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -274,12 +545,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-32k-randwrite
+- name: fio-vm-32k-randread-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: randread
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-32k-randwrite-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 32k
     io_operation: randwrite
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -299,12 +597,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-1M-read
+- name: fio-vm-32k-randwrite-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 32k
+    io_operation: randwrite
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-1M-read-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 1M
     io_operation: read
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -324,12 +649,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-1M-write
+- name: fio-vm-1M-read-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: read
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-1M-write-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 1M
     io_operation: write
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -349,12 +701,39 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-1M-randread
+- name: fio-vm-1M-write-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: write
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-1M-randread-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 1M
     io_operation: randread
+    vm_os_version: centos-stream10
   metrics:
   - name: total-iops
     metric_of_interest: total_iops
@@ -374,12 +753,65 @@ tests:
       agg_type: avg
     threshold: 10
     direction: -1
-- name: fio-vm-1M-randwrite
+- name: fio-vm-1M-randread-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: randread
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-1M-randwrite-centos
   metadata:
     kind: vm
     run_status: complete
     block_size: 1M
     io_operation: randwrite
+    vm_os_version: centos-stream10
+  metrics:
+  - name: total-iops
+    metric_of_interest: total_iops
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+  - name: lat-avg
+    metric_of_interest: lat_avg_usec
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: bandwidth
+    metric_of_interest: total_bw_kbs
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: fio-vm-1M-randwrite-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    block_size: 1M
+    io_operation: randwrite
+    vm_os_version: windows_server_2k25
   metrics:
   - name: total-iops
     metric_of_interest: total_iops

--- a/orion-configs/perfci-hammerdb.yaml
+++ b/orion-configs/perfci-hammerdb.yaml
@@ -1,11 +1,12 @@
 tests:
-  - name: hammerdb-vm-mssql-odf-1vu
+  - name: hammerdb-vm-mssql-odf-1vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
       current_worker: 1
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -13,13 +14,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-odf-2vu
+  - name: hammerdb-vm-mssql-odf-1vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 1
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-odf-2vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
       current_worker: 2
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -27,13 +44,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-odf-4vu
+  - name: hammerdb-vm-mssql-odf-2vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 2
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-odf-4vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
       current_worker: 4
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -41,13 +74,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-odf-8vu
+  - name: hammerdb-vm-mssql-odf-4vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 4
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-odf-8vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
       current_worker: 8
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -55,13 +104,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-odf-16vu
+  - name: hammerdb-vm-mssql-odf-8vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 8
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-odf-16vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
       current_worker: 16
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -69,13 +134,44 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-odf-32vu
+  - name: hammerdb-vm-mssql-odf-16vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 16
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-odf-32vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: odf
       current_worker: 32
+      vm_os_version: centos-stream10
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-odf-32vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: odf
+      current_worker: 32
+      vm_os_version: windows_server_2k25
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -503,13 +599,14 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-lso-1vu
+  - name: hammerdb-vm-mssql-lso-1vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
       current_worker: 1
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -517,13 +614,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-lso-2vu
+  - name: hammerdb-vm-mssql-lso-1vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 1
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-lso-2vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
       current_worker: 2
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -531,13 +644,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-lso-4vu
+  - name: hammerdb-vm-mssql-lso-2vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 2
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-lso-4vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
       current_worker: 4
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -545,13 +674,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-lso-8vu
+  - name: hammerdb-vm-mssql-lso-4vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 4
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-lso-8vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
       current_worker: 8
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -559,13 +704,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-lso-16vu
+  - name: hammerdb-vm-mssql-lso-8vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 8
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-lso-16vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
       current_worker: 16
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -573,13 +734,44 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-lso-32vu
+  - name: hammerdb-vm-mssql-lso-16vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 16
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-lso-32vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: lso
       current_worker: 32
+      vm_os_version: centos-stream10
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-lso-32vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: lso
+      current_worker: 32
+      vm_os_version: windows_server_2k25
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -1007,13 +1199,14 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-scale-1vu
+  - name: hammerdb-vm-mssql-scale-1vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
       current_worker: 1
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -1021,13 +1214,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-scale-2vu
+  - name: hammerdb-vm-mssql-scale-1vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 1
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-scale-2vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
       current_worker: 2
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -1035,13 +1244,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-scale-4vu
+  - name: hammerdb-vm-mssql-scale-2vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 2
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-scale-4vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
       current_worker: 4
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -1049,13 +1274,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-scale-8vu
+  - name: hammerdb-vm-mssql-scale-4vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 4
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-scale-8vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
       current_worker: 8
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -1063,13 +1304,29 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-scale-16vu
+  - name: hammerdb-vm-mssql-scale-8vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 8
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-scale-16vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
       current_worker: 16
+      vm_os_version: centos-stream10
     metrics:
       - name: tpm
         metric_of_interest: tpm
@@ -1077,13 +1334,44 @@ tests:
           agg_type: avg
         threshold: 10
         direction: -1
-  - name: hammerdb-vm-mssql-scale-32vu
+  - name: hammerdb-vm-mssql-scale-16vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 16
+      vm_os_version: windows_server_2k25
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-scale-32vu-centos
     metadata:
       kind: vm
       run_status: complete
       db_type: mssql
       storage_type: scale
       current_worker: 32
+      vm_os_version: centos-stream10
+    metrics:
+      - name: tpm
+        metric_of_interest: tpm
+        agg:
+          agg_type: avg
+        threshold: 10
+        direction: -1
+  - name: hammerdb-vm-mssql-scale-32vu-win2k25
+    metadata:
+      kind: vm
+      run_status: complete
+      db_type: mssql
+      storage_type: scale
+      current_worker: 32
+      vm_os_version: windows_server_2k25
     metrics:
       - name: tpm
         metric_of_interest: tpm

--- a/orion-configs/perfci-winfio.yaml
+++ b/orion-configs/perfci-winfio.yaml
@@ -3,6 +3,7 @@ tests:
     metadata:
       kind: vm
       run_status: complete
+      vm_os_version: windows_server_2k25
     metrics:
       - name: total-iops
         metric_of_interest: total_iops

--- a/orion-configs/perfci-winmssql.yaml
+++ b/orion-configs/perfci-winmssql.yaml
@@ -3,6 +3,7 @@ tests:
     metadata:
       kind: vm
       run_status: complete
+      vm_os_version: windows_server_2k25
     metrics:
       - name: tpm
         metric_of_interest: tpm


### PR DESCRIPTION
Adds vm_os_version filter to fio, hammerdb, winfio, and winmssql 
  Orion configs so OS-specific regressions (e.g., winfio degradation on win2k25) are not diluted by averaging with centos results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded VM FIO performance testing across 4K, 8K, 32K, and 1M workloads, covering read, write, random read, and random write scenarios.
  * Added dedicated test coverage for CentOS Stream 10 and Windows Server 2025.
  * Expanded HammerDB MSSQL VM testing across supported storage configurations and both operating systems.
* **Improvements**
  * Added explicit operating system version details to Windows FIO and MSSQL performance tests.
  * Preserved existing performance metric evaluation and validation thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->