### PR TITLE
Add CLEAR_CACHE flag to support scale env.

### DIFF
--- a/benchmark_runner/clusterbuster/clusterbuster_workloads.py
+++ b/benchmark_runner/clusterbuster/clusterbuster_workloads.py
@@ -66,7 +66,8 @@ class ClusterBusterWorkloads(WorkloadsOperations):
         :return:
         """
         self.delete_all()
-        self.clear_nodes_cache()
+        if self._clear_cache:
+            self.clear_nodes_cache()
         if self._enable_prometheus_snapshot:
             self.start_prometheus()
 

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -97,6 +97,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['windows_storage_class'] = EnvironmentVariables.get_env('WINDOWS_STORAGE_CLASS', 'ocs-storagecluster-ceph-rbd-virtualization')
         # Delete all resources before and after the run, default True
         self._environment_variables_dict['delete_all'] = EnvironmentVariables.get_boolean_from_environment('DELETE_ALL', True)
+        # Clear nodes cache before running workload, default True
+        self._environment_variables_dict['clear_cache'] = EnvironmentVariables.get_boolean_from_environment('CLEAR_CACHE', True)
         # RunStrategy: Always can be set to True or False (default: False). Set it to True for VMs that need to start in a running state
         self._environment_variables_dict['run_strategy'] = EnvironmentVariables.get_boolean_from_environment('RUN_STRATEGY', False)
         # Creating VMs only, default False (when True: configure RUN_STRATEGY: True/ DELETE_ALL: False)

--- a/benchmark_runner/workloads/workloads_operations.py
+++ b/benchmark_runner/workloads/workloads_operations.py
@@ -126,6 +126,7 @@ class WorkloadsOperations:
         self._windows_url = self._environment_variables_dict.get('windows_url', '')
         self._create_vms_only = self._environment_variables_dict.get('create_vms_only', '')
         self._delete_all = self._environment_variables_dict.get('delete_all', '')
+        self._clear_cache = self._environment_variables_dict.get('clear_cache', True)
         self._verification_only = self._environment_variables_dict.get('verification_only', '')
         self._must_gather_log = self._environment_variables_dict.get('must_gather_log', '')
         self._test_name = self._environment_variables_dict.get('test_name', '')
@@ -625,6 +626,7 @@ class WorkloadsOperations:
             raise KataNotInstalled(workload=self._workload)
         if self._delete_all:
             self.delete_all()
+        if self._clear_cache:
             self.clear_nodes_cache()
         if self._odf_pvc:
             self.odf_workload_verification()


### PR DESCRIPTION
## Summary

- Add \`CLEAR_CACHE\` environment variable (default: \`True\`) to support scale environments
- Decouple \`clear_nodes_cache()\` from \`DELETE_ALL\` in \`workloads_operations.py\` and \`clusterbuster_workloads.py\` so each can be controlled independently

## Motivation

Previously \`clear_nodes_cache()\` was always called together with \`delete_all()\` — it was not possible to skip cache clearing without also skipping resource deletion. This adds flexibility for re-running workloads on an already-prepared cluster to save time.

This improvement is particularly useful **for support scale env.** — in large-scale runs where many VMs/pods are deployed across multiple nodes, clearing the cache on every node adds significant overhead. Setting \`CLEAR_CACHE=False\` allows scale workloads to skip this step and reduce total run time.

## Usage

\`\`\`bash
# Skip cache clearing (default is True)
CLEAR_CACHE=False python -m benchmark_runner.main.main
\`\`\`

## Test plan
- [x] All 26 unit tests pass
- [x] Applied to both \`workloads_operations.py\` and \`clusterbuster_workloads.py\`

🤖 Assisted-by: Claude Code