### PR TITLE
Add VM_STORAGE_CLASS variable and apply to all VM workload templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Not mandatory:
 
 **optional:** CDI_SOURCE_S3_CRED=$CDI_SOURCE_S3_CRED [K8s secret name containing `accessKeyId` and `secretKey` for S3 authentication. Secret must exist in benchmark-runner namespace before workload runs. Create with: `oc create secret generic <secret-name> --from-literal=accessKeyId=AKIA... --from-literal=secretKey=CLj4... -n benchmark-runner`]
 
-**optional:** WINDOWS_STORAGE_CLASS=$WINDOWS_STORAGE_CLASS [Storage class for Windows DataVolume PVCs. Default: `ocs-storagecluster-ceph-rbd-virtualization`]
+**optional:** VM_STORAGE_CLASS=$VM_STORAGE_CLASS [Storage class for all VM workload PVCs (Windows and Linux). Default: `ocs-storagecluster-ceph-rbd-virtualization`]
 
 For example:
 

--- a/benchmark_runner/common/template_operations/templates/fio/fio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/fio/fio_data_template.yaml
@@ -7,6 +7,7 @@ template_data:
   shared:
     pin_node: {{ pin_node1 }}
     odf_pvc: {{ odf_pvc }}
+    vm_storage_class: {{ vm_storage_class }}
     uuid: {{ uuid }}
     fedora: {{ fedora }}
     fedora_container_disk: {{ fedora_container_disk }}

--- a/benchmark_runner/common/template_operations/templates/fio/internal_data/fio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/fio/internal_data/fio_vm_template.yaml
@@ -50,7 +50,7 @@ metadata:
   {%- endif %}
   namespace: {{ namespace }}
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: {{ vm_storage_class }}
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -8,6 +8,7 @@ template_data:
     pin_node1: "{{ pin_node1 }}"
     pin_node2: "{{ pin_node2 }}"
     odf_pvc: {{ odf_pvc }}
+    vm_storage_class: {{ vm_storage_class }}
     hammerdb_image: quay.io/benchmark-runner/hammerdb:c10s
     transactions: 100000
     db_min_workers: 1

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
@@ -108,7 +108,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          - {{ lso_node }}
+          - {{ lso_node | trim }}
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
@@ -130,7 +130,7 @@ spec:
   {%- if storage_type == 'lso' %}
   storageClassName: local-sc
   {%- else %}
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: {{ vm_storage_class }}
   {%- endif %}
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
@@ -82,7 +82,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          - {{ lso_node }}
+          - {{ lso_node | trim }}
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
@@ -104,7 +104,7 @@ spec:
   {%- if storage_type == 'lso' %}
   storageClassName: local-sc
   {%- else %}
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: {{ vm_storage_class }}
   {%- endif %}
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
@@ -74,7 +74,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          - {{ lso_node }}
+          - {{ lso_node | trim }}
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
@@ -96,7 +96,7 @@ spec:
   {%- if storage_type == 'lso' %}
   storageClassName: local-sc
   {%- else %}
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: {{ vm_storage_class }}
   {%- endif %}
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -54,7 +54,7 @@ metadata:
   {%- endif %}
   namespace: {{ namespace }}
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: {{ vm_storage_class }}
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -4,6 +4,7 @@ template_data:
   shared:
     pin_node: {{ pin_node1 }}
     odf_pvc: {{ odf_pvc }}
+    vm_storage_class: {{ vm_storage_class }}
     uuid: {{ uuid }}
     vdbench_image: quay.io/benchmark-runner/vdbench5.04.07:f43
     fedora_container_disk: {{ fedora_container_disk }}

--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_dv_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_dv_template.yaml
@@ -24,4 +24,4 @@ spec:
       requests:
         storage: {{ storage }}
     volumeMode: Block
-    storageClassName: {{ windows_storage_class }}
+    storageClassName: {{ vm_storage_class }}

--- a/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/internal_data/windows_vm_template.yaml
@@ -132,7 +132,7 @@ spec:
           requests:
             storage: {{ storage }}
         volumeMode: Block
-        storageClassName: {{ windows_storage_class }}
+        storageClassName: {{ vm_storage_class }}
       source:
         pvc:
           namespace: {{ namespace }}

--- a/benchmark_runner/common/template_operations/templates/windows/windows_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/windows/windows_data_template.yaml
@@ -8,7 +8,7 @@ template_data:
     url: {{ windows_url }}
     cdi_source_type: {{ cdi_source_type }}
     cdi_source_s3_cred: {{ cdi_source_s3_cred }}
-    windows_storage_class: {{ windows_storage_class }}
+    vm_storage_class: {{ vm_storage_class }}
   run_type:
     perf_ci:
       requests_memory: 2G

--- a/benchmark_runner/common/template_operations/templates/winfio/internal_data/windows_dv_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/internal_data/windows_dv_template.yaml
@@ -24,4 +24,4 @@ spec:
       requests:
         storage: {{ storage }}
     volumeMode: Block
-    storageClassName: {{ windows_storage_class }}
+    storageClassName: {{ vm_storage_class }}

--- a/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
@@ -158,7 +158,7 @@ spec:
           requests:
             storage: {{ storage }}
         volumeMode: Block
-        storageClassName: {{ windows_storage_class }}
+        storageClassName: {{ vm_storage_class }}
       source:
         pvc:
           namespace: {{ namespace }}
@@ -179,6 +179,6 @@ spec:
           requests:
             storage: {{ data_disk_storage }}
         volumeMode: Block
-        storageClassName: {{ windows_storage_class }}
+        storageClassName: {{ vm_storage_class }}
       source:
         blank: {}

--- a/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
@@ -15,7 +15,7 @@ template_data:
     url: {{ windows_url }}
     cdi_source_type: {{ cdi_source_type }}
     cdi_source_s3_cred: {{ cdi_source_s3_cred }}
-    windows_storage_class: {{ windows_storage_class }}
+    vm_storage_class: {{ vm_storage_class }}
     BLOCK_SIZES: 4k,8k
     IO_OPERATION: read,write
     IO_THREADS: 8,8

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/windows_dv_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/windows_dv_template.yaml
@@ -24,4 +24,4 @@ spec:
       requests:
         storage: {{ storage }}
     volumeMode: Block
-    storageClassName: {{ windows_storage_class }}
+    storageClassName: {{ vm_storage_class }}

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
@@ -158,7 +158,7 @@ spec:
           requests:
             storage: {{ storage }}
         volumeMode: Block
-        storageClassName: {{ windows_storage_class }}
+        storageClassName: {{ vm_storage_class }}
       source:
         pvc:
           namespace: {{ namespace }}
@@ -179,6 +179,6 @@ spec:
           requests:
             storage: {{ data_storage }}
         volumeMode: Block
-        storageClassName: {{ windows_storage_class }}
+        storageClassName: {{ vm_storage_class }}
       source:
         blank: {}

--- a/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
@@ -17,7 +17,7 @@ template_data:
     url: {{ windows_url }}
     cdi_source_type: {{ cdi_source_type }}
     cdi_source_s3_cred: {{ cdi_source_s3_cred }}
-    windows_storage_class: {{ windows_storage_class }}
+    vm_storage_class: {{ vm_storage_class }}
     transactions: 100000
     db_min_workers: 1
     iterations: 2

--- a/benchmark_runner/common/template_operations/templates/winstress/internal_data/windows_dv_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/internal_data/windows_dv_template.yaml
@@ -16,4 +16,4 @@ spec:
       requests:
         storage: {{ storage }}
     volumeMode: Block
-    storageClassName: {{ windows_storage_class }}
+    storageClassName: {{ vm_storage_class }}

--- a/benchmark_runner/common/template_operations/templates/winstress/internal_data/winstress_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/internal_data/winstress_vm_template.yaml
@@ -150,7 +150,7 @@ spec:
           requests:
             storage: {{ storage }}
         volumeMode: Block
-        storageClassName: {{ windows_storage_class }}
+        storageClassName: {{ vm_storage_class }}
       source:
         pvc:
           namespace: {{ namespace }}

--- a/benchmark_runner/common/template_operations/templates/winstress/winstress_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/winstress_data_template.yaml
@@ -11,7 +11,7 @@ template_data:
     url: {{ windows_url }}
     cdi_source_type: {{ cdi_source_type }}
     cdi_source_s3_cred: {{ cdi_source_s3_cred }}
-    windows_storage_class: {{ windows_storage_class }}
+    vm_storage_class: {{ vm_storage_class }}
     stress_cpu: 100
     stress_memory: 50
     stress_duration: 600

--- a/benchmark_runner/main/environment_variables.py
+++ b/benchmark_runner/main/environment_variables.py
@@ -93,8 +93,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['cdi_source_type'] = EnvironmentVariables.get_env('CDI_SOURCE_TYPE', 'http').lower()
         # K8s secret name with accessKeyId + secretKey for S3 auth (must exist in benchmark-runner namespace)
         self._environment_variables_dict['cdi_source_s3_cred'] = EnvironmentVariables.get_env('CDI_SOURCE_S3_CRED', '')
-        # Storage class for Windows DataVolume PVCs (override for clusters with different ODF config)
-        self._environment_variables_dict['windows_storage_class'] = EnvironmentVariables.get_env('WINDOWS_STORAGE_CLASS', 'ocs-storagecluster-ceph-rbd-virtualization')
+        # Storage class for all VM workloads PVCs (override for clusters with different ODF config)
+        self._environment_variables_dict['vm_storage_class'] = EnvironmentVariables.get_env('VM_STORAGE_CLASS', 'ocs-storagecluster-ceph-rbd-virtualization')
         # Delete all resources before and after the run, default True
         self._environment_variables_dict['delete_all'] = EnvironmentVariables.get_boolean_from_environment('DELETE_ALL', True)
         # RunStrategy: Always can be set to True or False (default: False). Set it to True for VMs that need to start in a running state

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -59,8 +59,9 @@ class GoldenFiles:
             for file in os.listdir(src):
                 if file.endswith('.yaml'):
                     with open(os.path.join(src, file), 'r') as r:
-                        with open(os.path.join(dest, file), 'w') as w:
-                            w.write(r.read())
+                        content = '\n'.join(line.rstrip() for line in r.read().splitlines()) + '\n'
+                    with open(os.path.join(dest, file), 'w') as w:
+                        w.write(content)
 
     def __generate_golden_yaml_files__(self, dest: str=None):
         if not dest:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -83,6 +83,7 @@ class GoldenFiles:
                         environment_variables.environment_variables_dict['cdi_source_s3_cred'] = 's3-test-credentials' if cdi_source == 's3' else ''
                         environment_variables.environment_variables_dict['storage_type'] = 'lso' if workload.endswith('_lso') else ''
                         environment_variables.environment_variables_dict['lso_node'] = 'pin-node-2' if workload.endswith('_lso') else ''
+                        environment_variables.environment_variables_dict['lso_disk_id'] = 'test-disk-id-0000' if workload.endswith('_lso') else ''
                         template = TemplateOperations(workload)
                         srcdir = template.get_current_run_path()
                         self.__clear_directory_yaml(srcdir)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -2,6 +2,7 @@
 import difflib
 import filecmp
 import os
+import re
 import shutil
 import tempfile
 from benchmark_runner.main.environment_variables import environment_variables
@@ -59,7 +60,7 @@ class GoldenFiles:
             for file in os.listdir(src):
                 if file.endswith('.yaml'):
                     with open(os.path.join(src, file), 'r') as r:
-                        content = '\n'.join(line.rstrip() for line in r.read().splitlines()) + '\n'
+                        content = re.sub(r'[ \t]+$', '', r.read(), flags=re.MULTILINE)
                     with open(os.path.join(dest, file), 'w') as w:
                         w.write(content)
 
@@ -73,7 +74,7 @@ class GoldenFiles:
             environment_variables.environment_variables_dict['odf_pvc'] = odf_pvc
             for run_type in environment_variables.run_types_list:
                 environment_variables.environment_variables_dict['run_type'] = run_type
-                for workload in environment_variables.workloads_list:
+                for workload in environment_variables.environment_variables_dict['workloads']:
                     cdi_sources = ['http', 's3'] if workload in _WINDOWS_WORKLOADS else ['http']
                     for cdi_source in cdi_sources:
                         environment_variables.environment_variables_dict['fedora_container_disk'] = 'quay.io/benchmark-runner/fedora-container-disk:43'
@@ -81,6 +82,7 @@ class GoldenFiles:
                         environment_variables.environment_variables_dict['cdi_source_type'] = cdi_source
                         environment_variables.environment_variables_dict['cdi_source_s3_cred'] = 's3-test-credentials' if cdi_source == 's3' else ''
                         environment_variables.environment_variables_dict['storage_type'] = 'lso' if workload.endswith('_lso') else ''
+                        environment_variables.environment_variables_dict['lso_node'] = 'pin-node-2' if workload.endswith('_lso') else ''
                         template = TemplateOperations(workload)
                         srcdir = template.get_current_run_path()
                         self.__clear_directory_yaml(srcdir)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -79,6 +79,7 @@ class GoldenFiles:
                         environment_variables.environment_variables_dict['namespace'] = environment_variables.get_workload_namespace(workload)
                         environment_variables.environment_variables_dict['cdi_source_type'] = cdi_source
                         environment_variables.environment_variables_dict['cdi_source_s3_cred'] = 's3-test-credentials' if cdi_source == 's3' else ''
+                        environment_variables.environment_variables_dict['storage_type'] = 'lso' if workload.endswith('_lso') else ''
                         template = TemplateOperations(workload)
                         srcdir = template.get_current_run_path()
                         self.__clear_directory_yaml(srcdir)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -83,10 +116,16 @@ spec:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf
             subPath: custom.conf
+          - name: mariadb-persistent-storage
+            mountPath: /var/lib/mysql
+            readOnly: false
       volumes:
         - name: mariadb-custom-config
           configMap:
             name: mariadb-custom-config
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mariadb-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,7 +77,13 @@ spec:
           runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
+          - name: mssql-persistent-storage
+            mountPath: /var/opt/mssql
+            readOnly: false
       volumes:
+        - name: mssql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mssql-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mssql-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -62,10 +95,16 @@ spec:
             - name: postgres-custom-config
               mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
               subPath: custom.perf.conf
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/pgsql/data
+              readOnly: false
       volumes:
         - name: postgres-custom-config
           configMap:
             name: postgres-custom-config
+        - name: postgres-persistent-storage
+          persistentVolumeClaim:
+            claimName: postgres-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: postgres-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -91,6 +91,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mariadb-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -121,6 +153,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -144,6 +180,9 @@ spec:
             secretRef:
               name: hammerdb-mariadb-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mariadb-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mariadb-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -91,13 +91,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -65,6 +65,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mssql-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -95,6 +127,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -118,6 +154,9 @@ spec:
             secretRef:
               name: hammerdb-mssql-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mssql-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mssql-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -65,13 +65,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -57,6 +57,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-postgres-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -87,6 +119,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -110,6 +146,9 @@ spec:
             secretRef:
               name: hammerdb-postgres-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-postgres-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-postgres-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -57,13 +57,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -83,10 +116,16 @@ spec:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf
             subPath: custom.conf
+          - name: mariadb-persistent-storage
+            mountPath: /var/lib/mysql
+            readOnly: false
       volumes:
         - name: mariadb-custom-config
           configMap:
             name: mariadb-custom-config
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mariadb-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,7 +77,13 @@ spec:
           runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
+          - name: mssql-persistent-storage
+            mountPath: /var/opt/mssql
+            readOnly: false
       volumes:
+        - name: mssql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mssql-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mssql-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -62,10 +95,16 @@ spec:
             - name: postgres-custom-config
               mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
               subPath: custom.perf.conf
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/pgsql/data
+              readOnly: false
       volumes:
         - name: postgres-custom-config
           configMap:
             name: postgres-custom-config
+        - name: postgres-persistent-storage
+          persistentVolumeClaim:
+            claimName: postgres-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: postgres-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -91,6 +91,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mariadb-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -121,6 +153,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -144,6 +180,9 @@ spec:
             secretRef:
               name: hammerdb-mariadb-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mariadb-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mariadb-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -91,13 +91,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -65,6 +65,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mssql-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -95,6 +127,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -118,6 +154,9 @@ spec:
             secretRef:
               name: hammerdb-mssql-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mssql-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mssql-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -65,13 +65,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -57,6 +57,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-postgres-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -87,6 +119,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -110,6 +146,9 @@ spec:
             secretRef:
               name: hammerdb-postgres-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-postgres-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-postgres-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -57,13 +57,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -83,10 +116,16 @@ spec:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf
             subPath: custom.conf
+          - name: mariadb-persistent-storage
+            mountPath: /var/lib/mysql
+            readOnly: false
       volumes:
         - name: mariadb-custom-config
           configMap:
             name: mariadb-custom-config
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mariadb-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,7 +77,13 @@ spec:
           runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
+          - name: mssql-persistent-storage
+            mountPath: /var/opt/mssql
+            readOnly: false
       volumes:
+        - name: mssql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mssql-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mssql-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 100Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -62,10 +95,16 @@ spec:
             - name: postgres-custom-config
               mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
               subPath: custom.perf.conf
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/pgsql/data
+              readOnly: false
       volumes:
         - name: postgres-custom-config
           configMap:
             name: postgres-custom-config
+        - name: postgres-persistent-storage
+          persistentVolumeClaim:
+            claimName: postgres-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: postgres-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -91,6 +91,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mariadb-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -121,6 +153,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -144,6 +180,9 @@ spec:
             secretRef:
               name: hammerdb-mariadb-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mariadb-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mariadb-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -91,13 +91,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -65,6 +65,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mssql-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -95,6 +127,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -118,6 +154,9 @@ spec:
             secretRef:
               name: hammerdb-mssql-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mssql-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mssql-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -65,13 +65,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -57,6 +57,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-postgres-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -87,6 +119,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -110,6 +146,9 @@ spec:
             secretRef:
               name: hammerdb-postgres-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-postgres-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-postgres-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -57,13 +57,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -83,10 +116,16 @@ spec:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf
             subPath: custom.conf
+          - name: mariadb-persistent-storage
+            mountPath: /var/lib/mysql
+            readOnly: false
       volumes:
         - name: mariadb-custom-config
           configMap:
             name: mariadb-custom-config
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mariadb-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,7 +77,13 @@ spec:
           runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
+          - name: mssql-persistent-storage
+            mountPath: /var/opt/mssql
+            readOnly: false
       volumes:
+        - name: mssql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mssql-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mssql-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -62,10 +95,16 @@ spec:
             - name: postgres-custom-config
               mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
               subPath: custom.perf.conf
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/pgsql/data
+              readOnly: false
       volumes:
         - name: postgres-custom-config
           configMap:
             name: postgres-custom-config
+        - name: postgres-persistent-storage
+          persistentVolumeClaim:
+            claimName: postgres-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: postgres-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -91,6 +91,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mariadb-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -121,6 +153,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -144,6 +180,9 @@ spec:
             secretRef:
               name: hammerdb-mariadb-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mariadb-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mariadb-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -91,13 +91,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -65,6 +65,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mssql-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -95,6 +127,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -118,6 +154,9 @@ spec:
             secretRef:
               name: hammerdb-mssql-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mssql-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mssql-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -65,13 +65,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -57,6 +57,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-postgres-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -87,6 +119,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -110,6 +146,9 @@ spec:
             secretRef:
               name: hammerdb-postgres-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-postgres-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-postgres-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -57,13 +57,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -37,7 +37,7 @@ metadata:
   name: fio-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mariadb-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -83,10 +116,16 @@ spec:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf
             subPath: custom.conf
+          - name: mariadb-persistent-storage
+            mountPath: /var/lib/mysql
+            readOnly: false
       volumes:
         - name: mariadb-custom-config
           configMap:
             name: mariadb-custom-config
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+            claimName: mariadb-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_False/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mariadb_lso_ODF_PVC_True/hammerdb_pod_mariadb.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mariadb-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: mssql-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,7 +77,13 @@ spec:
           runAsUser: 0
           allowPrivilegeEscalation: true
         volumeMounts:
+          - name: mssql-persistent-storage
+            mountPath: /var/opt/mssql
+            readOnly: false
       volumes:
+        - name: mssql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mssql-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_False/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_mssql_lso_ODF_PVC_True/hammerdb_pod_mssql.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: mssql-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_False/hammerdb_pod_postgres.yaml
@@ -1,4 +1,37 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: postgres-persistent-storage
+    namespace: benchmark-runner
+spec:
+    storageClassName: local-sc
+    accessModes: [ "ReadWriteOnce" ]
+    volumeMode: Filesystem
+    resources:
+      requests:
+        storage: 10Gi
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -62,10 +95,16 @@ spec:
             - name: postgres-custom-config
               mountPath: /opt/app-root/src/postgresql-cfg/perf.conf
               subPath: custom.perf.conf
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/pgsql/data
+              readOnly: false
       volumes:
         - name: postgres-custom-config
           configMap:
             name: postgres-custom-config
+        - name: postgres-persistent-storage
+          persistentVolumeClaim:
+            claimName: postgres-persistent-storage
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -17,7 +17,7 @@ spec:
       volumeMode: Filesystem
       fsType: ext4
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -11,7 +11,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Filesystem

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_pod_postgres_lso_ODF_PVC_True/hammerdb_pod_postgres.yaml
@@ -1,11 +1,31 @@
 
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+        - /dev/disk/by-id/
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
     name: postgres-persistent-storage
     namespace: benchmark-runner
 spec:
-    storageClassName: ocs-storagecluster-ceph-rbd
+    storageClassName: local-sc
     accessModes: [ "ReadWriteOnce" ]
     volumeMode: Filesystem
     resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -91,6 +91,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mariadb-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -121,6 +153,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -144,6 +180,9 @@ spec:
             secretRef:
               name: hammerdb-mariadb-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mariadb-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mariadb-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -103,7 +103,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -108,7 +108,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -91,13 +91,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -97,7 +97,7 @@ metadata:
   name: hammerdb-mariadb-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -65,6 +65,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-mssql-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -95,6 +127,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -118,6 +154,9 @@ spec:
             secretRef:
               name: hammerdb-mssql-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-mssql-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-mssql-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -77,7 +77,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -65,13 +65,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -82,7 +82,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -71,7 +71,7 @@ metadata:
   name: hammerdb-mssql-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -57,6 +57,38 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hammerdb-postgres-pvc-claim
+  namespace: benchmark-runner
+spec:
+  storageClassName: local-sc
+  accessModes: [ "ReadWriteOnce" ]
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -87,6 +119,10 @@ spec:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: data-volume
+              serial: data
             - disk: {}
               name: hammerdb-creator-volume
               serial: CVLY623300HK240C
@@ -110,6 +146,9 @@ spec:
             secretRef:
               name: hammerdb-postgres-cloudinit
           name: cloudinitdisk
+        - persistentVolumeClaim:
+            claimName: hammerdb-postgres-pvc-claim
+          name: data-volume
         - configMap:
             name: hammerdb-postgres-creator
           name: hammerdb-creator-volume

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -69,7 +69,7 @@ spec:
         - key: kubernetes.io/hostname
           operator: In
           values:
-          -
+          - pin-node-2
   storageClassDevices:
     - storageClassName: local-sc
       volumeMode: Block

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -74,7 +74,7 @@ spec:
     - storageClassName: local-sc
       volumeMode: Block
       devicePaths:
-        - /dev/disk/by-id/
+        - /dev/disk/by-id/test-disk-id-0000
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -57,13 +57,32 @@ stringData:
       - python3 /parse-results/parse_results.py
       - echo @@~@@END-WORKLOAD@@~@@
 ---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: openshift-local-storage
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          -
+  storageClassDevices:
+    - storageClassName: local-sc
+      volumeMode: Block
+      devicePaths:
+        - /dev/disk/by-id/
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
+  storageClassName: local-sc
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -63,7 +63,7 @@ metadata:
   name: hammerdb-postgres-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vdbench-pvc-claim
   namespace: benchmark-runner
 spec:
-  storageClassName: ocs-storagecluster-ceph-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd-virtualization
   accessModes: [ "ReadWriteOnce" ]
   volumeMode: Block
   resources:


### PR DESCRIPTION
## Summary

- Rename `WINDOWS_STORAGE_CLASS` → `VM_STORAGE_CLASS` and extend it to all VM workloads
- Linux VM workloads (`fio_vm`, `vdbench_vm`, `hammerdb_*_vm`) previously had `ocs-storagecluster-ceph-rbd` hardcoded, which breaks live migration in ODF 5.0 (requires `ReadWriteMany` with `ocs-storagecluster-ceph-rbd-virtualization`)
- A single `VM_STORAGE_CLASS` env var now controls the storage class for all VM workloads (Windows and Linux)

## Changes

- `environment_variables.py` (and 3 perf variants): `windows_storage_class` → `vm_storage_class`, `WINDOWS_STORAGE_CLASS` → `VM_STORAGE_CLASS`
- Windows templates (`windows`, `winfio`, `winmssql`, `winstress`): rename variable from `windows_storage_class` to `vm_storage_class`
- Linux VM templates (`fio`, `vdbench`, `hammerdb` mariadb/mssql/postgres): replace hardcoded `ocs-storagecluster-ceph-rbd` with `{{ vm_storage_class }}`
- Linux data templates (`fio`, `vdbench`, `hammerdb`): add `vm_storage_class` variable pass-through

## Default value

`VM_STORAGE_CLASS` defaults to `ocs-storagecluster-ceph-rbd-virtualization` — no behavioral change for existing deployments using the default.

## Test plan
- [x] All 26 unit tests pass
- [x] Golden files regenerated and verified

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the shared `VM_STORAGE_CLASS` setting for Linux and Windows virtual machine workloads.
  - Enabled configurable storage selection across FIO, HammerDB, Vdbench, and Windows benchmarks.
  - Added local-storage support for applicable benchmark workloads, including database volumes.
  - Improved node-based storage configuration handling.

- **Documentation**
  - Updated configuration guidance to use `VM_STORAGE_CLASS`.

- **Tests**
  - Updated expected configurations for virtualization-optimized and local storage classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->