### PR TITLE
Add oc login before integration tests to prevent token expiry

### DIFF
--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -114,6 +114,7 @@ jobs:
           mkdir -p "$RUNNER_PATH/.kube/"
           echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
+          echo "KUBECONFIG=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: 📃 Integration test with pytest
       env:
@@ -155,7 +156,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
 
         # refresh oc token before running tests to prevent mid-test expiry
-        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --kubeconfig="$KUBECONFIG_PATH"
+        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
 
         # run pytest
         pytest -v tests --cov=benchmark_runner --cov-report=term-missing

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -114,7 +114,6 @@ jobs:
           mkdir -p "$RUNNER_PATH/.kube/"
           echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
-          echo "KUBECONFIG=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: 📃 Integration test with pytest
       env:

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -154,6 +154,9 @@ jobs:
         cp $RUNNER_PATH/virtctl /usr/local/bin/virtctl
         rm -rf $RUNNER_PATH/virtctl
 
+        # refresh oc token before running tests to prevent mid-test expiry
+        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --insecure-skip-tls-verify=true
+
         # run pytest
         pytest -v tests --cov=benchmark_runner --cov-report=term-missing
         coverage run -m pytest -v tests

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -156,7 +156,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
 
         # refresh oc token before running tests to prevent mid-test expiry
-        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
+        [[ -z "$KUBEADMIN_PASSWORD" ]] || oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
 
         # run pytest
         pytest -v tests --cov=benchmark_runner --cov-report=term-missing

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -114,6 +114,7 @@ jobs:
           mkdir -p "$RUNNER_PATH/.kube/"
           echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
+          echo "KUBECONFIG=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: 📃 Integration test with pytest
       env:

--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -155,7 +155,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
 
         # refresh oc token before running tests to prevent mid-test expiry
-        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --insecure-skip-tls-verify=true
+        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --kubeconfig="$KUBECONFIG_PATH"
 
         # run pytest
         pytest -v tests --cov=benchmark_runner --cov-report=term-missing

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -110,6 +110,9 @@ jobs:
         cp $RUNNER_PATH/virtctl /usr/local/bin/virtctl
         rm -rf $RUNNER_PATH/virtctl
 
+        # refresh oc token before running tests to prevent mid-test expiry
+        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --insecure-skip-tls-verify=true
+
         # run pytest
         pytest
 

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -112,7 +112,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
 
         # refresh oc token before running tests to prevent mid-test expiry
-        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
+        [[ -z "$KUBEADMIN_PASSWORD" ]] || oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
 
         # run pytest
         pytest

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -72,6 +72,7 @@ jobs:
           mkdir -p "$RUNNER_PATH/.kube/"
           echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
+          echo "KUBECONFIG=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: 📃 Integration test with pytest
       env:

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -111,7 +111,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
 
         # refresh oc token before running tests to prevent mid-test expiry
-        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --insecure-skip-tls-verify=true
+        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --kubeconfig="$KUBECONFIG_PATH"
 
         # run pytest
         pytest

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -72,7 +72,6 @@ jobs:
           mkdir -p "$RUNNER_PATH/.kube/"
           echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
-          echo "KUBECONFIG=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: 📃 Integration test with pytest
       env:

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -72,6 +72,7 @@ jobs:
           mkdir -p "$RUNNER_PATH/.kube/"
           echo "$KUBECONFIG_CONTENTS" > "$RUNNER_PATH/.kube/config"
           echo "KUBECONFIG_PATH=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
+          echo "KUBECONFIG=$RUNNER_PATH/.kube/config" >> "$GITHUB_ENV"
           sudo tee -a /etc/hosts <<< "$OCP_HOSTS" > /dev/null
     - name: 📃 Integration test with pytest
       env:
@@ -111,7 +112,7 @@ jobs:
         rm -rf $RUNNER_PATH/virtctl
 
         # refresh oc token before running tests to prevent mid-test expiry
-        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD" --kubeconfig="$KUBECONFIG_PATH"
+        oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
 
         # run pytest
         pytest


### PR DESCRIPTION
## Summary

- Add `oc login` step before running pytest in both `Perf_Env_Build_Test_CI.yml` and `Perf_Env_PR_Test_CI.yml`

## Problem

Observed in run [#31389876520](https://github.com/redhat-performance/benchmark-runner/actions/runs/31389876520/job/93459326747) — the integration test was stuck for over 1 hour in the pytest step.

Root cause: the OC token expired mid-test causing all `oc` commands to fail with:
```
E couldn't get current server API group list: the server has asked for the client to provide credentials
error: You must be logged in to the server (the server has asked for the client to provide credentials)
```
The test then hangs indefinitely waiting for pods/VMs that were never created because all `oc` commands were failing silently after token expiry.

## Fix

Refresh the token with `oc login -u kubeadmin -p $KUBEADMIN_PASSWORD` immediately before running pytest so the session is valid for the full duration of the integration tests.

## Test plan
- [ ] Verify next integration test run completes without token expiry errors

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved integration test workflows by refreshing authentication immediately before test execution.
  - Increased the reliability of automated validation in performance and pull request environments.
  - Improved access to cluster configuration during automated test runs.

- **Chores**
  - Updated continuous integration checks to use current access credentials automatically.
  - Reduced failures caused by expired authentication sessions and improved consistency across test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->