### PR TITLE
Add pytest-rerunfailures to retry flaky integration tests

### DIFF
--- a/.github/workflows/Perf_Env_Build_Test_CI.yml
+++ b/.github/workflows/Perf_Env_Build_Test_CI.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
+        pip install flake8 pytest pytest-cov pytest-rerunfailures
         if [[ -f requirements.txt ]]; then pip install -r requirements.txt; fi
         if [[ -f tests_requirements.txt ]]; then pip install -r tests_requirements.txt; fi
     - name: Lint with flake8
@@ -159,8 +159,8 @@ jobs:
         [[ -z "$KUBEADMIN_PASSWORD" ]] || oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
 
         # run pytest
-        pytest -v tests --cov=benchmark_runner --cov-report=term-missing
-        coverage run -m pytest -v tests
+        pytest -v tests --reruns 2 --reruns-delay 30 --cov=benchmark_runner --cov-report=term-missing
+        coverage run -m pytest -v tests --reruns 2 --reruns-delay 30
         sleep 60
         coverage report -m
     - name: 🎥 Publish to coveralls.io

--- a/.github/workflows/Perf_Env_PR_Test_CI.yml
+++ b/.github/workflows/Perf_Env_PR_Test_CI.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
+        pip install flake8 pytest pytest-cov pytest-rerunfailures
         if [[ -f requirements.txt ]]; then pip install -r requirements.txt; fi
         if [[ -f tests_requirements.txt ]]; then pip install -r tests_requirements.txt; fi
     - name: Lint with flake8
@@ -115,7 +115,7 @@ jobs:
         [[ -z "$KUBEADMIN_PASSWORD" ]] || oc login -u kubeadmin -p "$KUBEADMIN_PASSWORD"
 
         # run pytest
-        pytest
+        pytest --reruns 2 --reruns-delay 30
 
   e2e:
    name: e2e


### PR DESCRIPTION
## Summary

- Add `pytest-rerunfailures` to the integration test dependencies
- Add `--reruns 2 --reruns-delay 30` to pytest commands in both `Perf_Env_Build_Test_CI.yml` and `Perf_Env_PR_Test_CI.yml`

## Problem

Integration tests occasionally fail due to transient cluster issues rather than code bugs. Each run a **different test** fails, confirming the failures are infrastructure-related not code bugs.

Examples of observed failures:
- [run #31693966141](https://github.com/redhat-performance/benchmark-runner/actions/runs/31693966141/job/94427811841): `test_virtctl_vdbench_vm_ephemeral_file_count_scp_and_parse` — `wait_for_vm_completed_by_file_count` timeout
- [run #31927034985](https://github.com/redhat-performance/benchmark-runner/actions/runs/31927034985/job/95116295244): `test_get_long_short_uuid` — `PodNotCreateTimeout: Pod name: app=stressng_workload-test123 does not create`

## Fix

Retry each failed test up to 2 times with a 30-second delay between attempts, as recommended by the [pytest flaky tests documentation](https://docs.pytest.org/en/stable/how-to/flaky.html).

## Test plan
- [ ] Verify next integration test run retries transient failures instead of immediately failing

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by automatically retrying failed tests up to two times.
  * Added a 30-second delay between retry attempts.
  * Applied retry handling to both standard and coverage test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->