### PR TITLE
Fix ODF health check: use startswith instead of exact match

### DIFF
--- a/benchmark_runner/common/oc/oc.py
+++ b/benchmark_runner/common/oc/oc.py
@@ -488,7 +488,7 @@ class OC(SSH):
         health_check = f"{self._cli} -n {namespace} rsh {self._get_pod_name(pod_name=pod_name, namespace=namespace)} ceph health"
 
         while timeout <= 0 or current_wait_time <= timeout:
-            if 'HEALTH_OK' == self.run(health_check).strip():
+            if self.run(health_check).strip().startswith('HEALTH_OK'):
                 return True
 
             # Sleep for a defined interval and update the wait time


### PR DESCRIPTION
## Summary

Fix `wait_for_odf_healthcheck` in `oc.py` to handle muted Ceph warnings.

## Problem

When Ceph warnings are muted, `ceph health` returns:
```
HEALTH_OK
(muted: AUTH_INSECURE_CLIENT_KEY_TYPE AUTH_INSECURE_KEYS_ALLOWED ...)
```

The previous exact equality check `'HEALTH_OK' == output.strip()` fails because `strip()` only removes leading/trailing whitespace — the muted warnings on subsequent lines remain, causing `wait_for_odf_healthcheck` to loop indefinitely even when the cluster is healthy.

## Fix

Changed to `output.strip().startswith('HEALTH_OK')` which correctly handles both:
- `HEALTH_OK` (no warnings)
- `HEALTH_OK\n(muted: ...)` (muted warnings)

## Test plan
- [x] All 26 unit tests pass

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-check handling so systems reporting `HEALTH_OK` with additional status details are recognized as healthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->