### PR TITLE
Improve CPU stress benchmark: replace 2**32 loop with deterministic cpu_work and perf_counter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,9 @@ python -m benchmark_runner.main.main
 
 Always run these two steps before pushing any commit:
 
-1. **Rebase onto main** to stay up to date and avoid conflicts:
+1. **Sync with upstream** to stay up to date and avoid conflicts:
    ```bash
-   git fetch origin main && git rebase origin/main
+   git fetch upstream && git merge upstream/main
    ```
 
 2. **Run all unit tests** to ensure nothing is broken:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,9 @@ python -m benchmark_runner.main.main
 
 Always run these two steps before pushing any commit:
 
-1. **Sync with upstream** to stay up to date and avoid conflicts:
+1. **Rebase onto main** to stay up to date and avoid conflicts:
    ```bash
-   git fetch upstream && git merge upstream/main
+   git fetch origin main && git rebase origin/main
    ```
 
 2. **Run all unit tests** to ensure nothing is broken:

--- a/benchmark_runner/common/template_operations/templates/linstress/internal_data/linstress_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/linstress/internal_data/linstress_vm_template.yaml
@@ -54,7 +54,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -66,7 +66,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs ({{ stress_cpu }}%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -82,23 +82,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -121,7 +121,8 @@ stringData:
                       'stress_cpu_percent': {{ stress_cpu }},
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/benchmark_runner/common/template_operations/templates/linstress/internal_data/linstress_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/linstress/internal_data/linstress_vm_template.yaml
@@ -22,14 +22,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/benchmark_runner/common/template_operations/templates/winstress/internal_data/01_run_stress_template.ps1
+++ b/benchmark_runner/common/template_operations/templates/winstress/internal_data/01_run_stress_template.ps1
@@ -10,14 +10,21 @@ New-Item -ItemType Directory -Force -Path $stressDir | Out-Null
 $scriptContent = @"
 import multiprocessing, time, psutil, json
 
-def burn_cpu(d, result_dict, idx):
-    ops = 0
-    start = time.time()
+def cpu_work():
+    x = 1
+    for _ in range(100):
+        x = x * 1000003 % 999999937
+    return x
+
+def burn_cpu(d, result_dict, idx, batch=10000):
+    start = time.perf_counter()
     end = start + d
-    while time.time() < end:
-        _ = 2**32
-        ops += 1
-    elapsed = time.time() - start
+    ops = 0
+    while time.perf_counter() < end:
+        for _ in range(batch):
+            cpu_work()
+        ops += batch
+    elapsed = time.perf_counter() - start
     result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
 def burn_memory(target_percent, duration):

--- a/benchmark_runner/common/template_operations/templates/winstress/internal_data/01_run_stress_template.ps1
+++ b/benchmark_runner/common/template_operations/templates/winstress/internal_data/01_run_stress_template.ps1
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     print(f'CPU count: {cpu_total}')
     print(f'Stressing {cpu_count} CPUs ({{"{{ stress_cpu }}"}}%) and {mem_target}% memory for {duration}s')
-    print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GB')
+    print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
     print(f'Memory before: {psutil.virtual_memory().percent}%')
     print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -70,23 +70,23 @@ if __name__ == '__main__':
     cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
     [p.start() for p in cpu_procs]
 
+    intervals = max(1, duration // 30)
     samples = []
-    elapsed_total = 0
-    while elapsed_total < duration:
-        step = min(30, duration - elapsed_total)
-        time.sleep(step)
-        elapsed_total += step
+    for i in range(intervals):
+        time.sleep(30)
         mem = psutil.virtual_memory()
         cpu_pct = psutil.cpu_percent(interval=1)
         sample = {
-            'time_sec': elapsed_total,
+            'time_sec': (i+1)*30,
             'cpu_percent': cpu_pct,
             'mem_percent': mem.percent,
+            'mem_used_mb': round(mem.used / (1024**2), 1),
+            'mem_total_mb': round(mem.total / (1024**2), 1),
             'mem_used_gb': round(mem.used / (1024**3), 1),
             'mem_total_gb': round(mem.total / (1024**3), 1)
         }
         samples.append(sample)
-        print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+        print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
     [p.join() for p in cpu_procs]
     if mem_proc:
@@ -109,7 +109,8 @@ if __name__ == '__main__':
             'stress_cpu_percent': {{ stress_cpu }},
             'stress_memory_percent': mem_target,
             'duration_sec': duration,
-            'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+            'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+            'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
         },
         'throughput': {
             'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_False/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -50,7 +50,7 @@ stringData:
                   size = min(chunk_size, alloc_bytes - allocated)
                   blocks.append(bytearray(size))
                   allocated += size
-                  print(f'Allocated {allocated // (1024*1024)}MiB / {alloc_bytes // (1024*1024)}MiB ({psutil.virtual_memory().percent}%)')
+                  print(f'Allocated {allocated // (1024*1024)}MB / {alloc_bytes // (1024*1024)}MB ({psutil.virtual_memory().percent}%)')
               print(f'Memory at {psutil.virtual_memory().percent}%, holding for {duration}s...')
               time.sleep(duration)
 
@@ -62,7 +62,7 @@ stringData:
 
               print(f'CPU count: {cpu_total}')
               print(f'Stressing {cpu_count} CPUs (100%) and {mem_target}% memory for {duration}s')
-              print(f'Total memory: {psutil.virtual_memory().total // (1024**3)}GiB')
+              print(f'Total memory: {psutil.virtual_memory().total // (1024**2)}MB')
               print(f'Memory before: {psutil.virtual_memory().percent}%')
               print(f'CPU before: {psutil.cpu_percent(interval=1)}%')
 
@@ -78,23 +78,23 @@ stringData:
               cpu_procs = [multiprocessing.Process(target=burn_cpu, args=(duration, result_dict, i)) for i in range(cpu_count)]
               [p.start() for p in cpu_procs]
 
+              intervals = max(1, duration // 30)
               samples = []
-              elapsed_total = 0
-              while elapsed_total < duration:
-                  step = min(30, duration - elapsed_total)
-                  time.sleep(step)
-                  elapsed_total += step
+              for i in range(intervals):
+                  time.sleep(30)
                   mem = psutil.virtual_memory()
                   cpu_pct = psutil.cpu_percent(interval=1)
                   sample = {
-                      'time_sec': elapsed_total,
+                      'time_sec': (i+1)*30,
                       'cpu_percent': cpu_pct,
                       'mem_percent': mem.percent,
+                      'mem_used_mb': round(mem.used / (1024**2), 1),
+                      'mem_total_mb': round(mem.total / (1024**2), 1),
                       'mem_used_gb': round(mem.used / (1024**3), 1),
                       'mem_total_gb': round(mem.total / (1024**3), 1)
                   }
                   samples.append(sample)
-                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_gb']}GiB/{sample['mem_total_gb']}GiB)")
+                  print(f"At {sample['time_sec']}s: CPU={cpu_pct}% MEM={mem.percent}% ({sample['mem_used_mb']}MB/{sample['mem_total_mb']}MB)")
 
               [p.join() for p in cpu_procs]
               if mem_proc:
@@ -117,7 +117,8 @@ stringData:
                       'stress_cpu_percent': 100,
                       'stress_memory_percent': mem_target,
                       'duration_sec': duration,
-                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1)
+                      'total_memory_gb': round(psutil.virtual_memory().total / (1024**3), 1),
+                      'total_memory_mb': round(psutil.virtual_memory().total / (1024**2), 1)
                   },
                   'throughput': {
                       'total_ops': total_ops,

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_linstress_vm_ODF_PVC_True/linstress_vm.yaml
@@ -18,14 +18,21 @@ stringData:
         content: |
           import multiprocessing, time, psutil, json
 
-          def burn_cpu(d, result_dict, idx):
-              ops = 0
-              start = time.time()
+          def cpu_work():
+              x = 1
+              for _ in range(100):
+                  x = x * 1000003 % 999999937
+              return x
+
+          def burn_cpu(d, result_dict, idx, batch=10000):
+              start = time.perf_counter()
               end = start + d
-              while time.time() < end:
-                  _ = 2**32
-                  ops += 1
-              elapsed = time.time() - start
+              ops = 0
+              while time.perf_counter() < end:
+                  for _ in range(batch):
+                      cpu_work()
+                  ops += batch
+              elapsed = time.perf_counter() - start
               result_dict[idx] = {'ops': ops, 'elapsed': elapsed, 'ops_per_sec': ops / elapsed}
 
           def burn_memory(target_percent, duration):


### PR DESCRIPTION
## Summary
- Replace the `2**32` CPU burn loop with a deterministic integer math loop (`x * 1000003 % 999999937`) for consistent and comparable throughput measurement across platforms
- Replace `time.time()` with `time.perf_counter()` for higher resolution, monotonic timing
- Apply to both `linstress` (Linux) and `winstress` (Windows) stress scripts

## Why
- `2**32` is Python-optimized and not representative of real CPU work
- `time.time()` has lower resolution and is not monotonic
- The new `cpu_work()` function produces consistent, comparable results between Linux and Windows

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated CPU stress workloads to perform repeated modular arithmetic in configurable batches.
  * Improved CPU timing precision and operation-count accuracy.
  * Added MB values alongside GB values in memory reporting and samples.
  * Standardized memory sampling to fixed 30-second intervals.
  * Reports now include total memory in MB.

* **Tests**
  * Updated expected stress-test outputs across supported VM and execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->