### PR TITLE
Remove Orion tests with no matching ES data

### DIFF
--- a/orion-configs/perfci-hammerdb.yaml
+++ b/orion-configs/perfci-hammerdb.yaml
@@ -1,1381 +1,1111 @@
 tests:
-  - name: hammerdb-vm-mssql-odf-1vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 1
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-1vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 1
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-2vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 2
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-2vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 2
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-4vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 4
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-4vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 4
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-8vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 8
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-8vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 8
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-16vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 16
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-16vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 16
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-32vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 32
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-odf-32vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 32
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-odf-1vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-odf-2vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-odf-4vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-odf-8vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-odf-16vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-odf-32vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-odf-1vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-odf-2vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-odf-4vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-odf-8vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-odf-16vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-odf-32vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-odf-1vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-odf-2vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-odf-4vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-odf-8vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-odf-16vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-odf-32vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: odf
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-odf-1vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-odf-2vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-odf-4vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-odf-8vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-odf-16vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-odf-32vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: odf
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-odf-1vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-odf-2vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-odf-4vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-odf-8vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-odf-16vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-odf-32vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: odf
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-1vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 1
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-1vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 1
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-2vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 2
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-2vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 2
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-4vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 4
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-4vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 4
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-8vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 8
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-8vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 8
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-16vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 16
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-16vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 16
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-32vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 32
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-lso-32vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 32
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-lso-1vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-lso-2vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-lso-4vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-lso-8vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-lso-16vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mariadb-lso-32vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-lso-1vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-lso-2vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-lso-4vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-lso-8vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-lso-16vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-pg-lso-32vu
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-lso-1vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-lso-2vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-lso-4vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-lso-8vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-lso-16vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mssql-lso-32vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mssql
-      storage_type: lso
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-lso-1vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-lso-2vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-lso-4vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-lso-8vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-lso-16vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-mariadb-lso-32vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: mariadb
-      storage_type: lso
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-lso-1vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 1
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-lso-2vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 2
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-lso-4vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 4
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-lso-8vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 8
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-lso-16vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 16
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-pod-pg-lso-32vu
-    metadata:
-      kind: pod
-      run_status: complete
-      db_type: pg
-      storage_type: lso
-      current_worker: 32
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-1vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 1
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-1vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 1
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-2vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 2
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-2vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 2
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-4vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 4
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-4vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 4
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-8vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 8
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-8vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 8
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-16vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 16
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-16vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 16
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-32vu-centos
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 32
-      vm_os_version: centos-stream10
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
-  - name: hammerdb-vm-mssql-scale-32vu-win2k25
-    metadata:
-      kind: vm
-      run_status: complete
-      db_type: mssql
-      storage_type: scale
-      current_worker: 32
-      vm_os_version: windows_server_2k25
-    metrics:
-      - name: tpm
-        metric_of_interest: tpm
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: -1
+- name: hammerdb-vm-mssql-odf-1vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 1
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-1vu-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 1
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-2vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 2
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-2vu-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 2
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-4vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 4
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-4vu-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 4
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-8vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 8
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-8vu-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 8
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-16vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 16
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-16vu-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 16
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-32vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 32
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-odf-32vu-win2k25
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 32
+    vm_os_version: windows_server_2k25
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-odf-1vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-odf-2vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-odf-4vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-odf-8vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-odf-16vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-odf-32vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-odf-1vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-odf-2vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-odf-4vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-odf-8vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-odf-16vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-odf-32vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-odf-1vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-odf-2vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-odf-4vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-odf-8vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-odf-16vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-odf-32vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: odf
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-odf-1vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-odf-2vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-odf-4vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-odf-8vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-odf-16vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-odf-32vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: odf
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-odf-1vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-odf-2vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-odf-4vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-odf-8vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-odf-16vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-odf-32vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: odf
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-lso-1vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 1
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-lso-2vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 2
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-lso-4vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 4
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-lso-8vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 8
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-lso-16vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 16
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mssql-lso-32vu-centos
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 32
+    vm_os_version: centos-stream10
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-lso-1vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-lso-2vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-lso-4vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-lso-8vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-lso-16vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-mariadb-lso-32vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-lso-1vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-lso-2vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-lso-4vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-lso-8vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-lso-16vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-vm-pg-lso-32vu
+  metadata:
+    kind: vm
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-lso-1vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-lso-2vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-lso-4vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-lso-8vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-lso-16vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mssql-lso-32vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mssql
+    storage_type: lso
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-lso-1vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-lso-2vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-lso-4vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-lso-8vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-lso-16vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-mariadb-lso-32vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: mariadb
+    storage_type: lso
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-lso-1vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 1
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-lso-2vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 2
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-lso-4vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 4
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-lso-8vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 8
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-lso-16vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 16
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1
+- name: hammerdb-pod-pg-lso-32vu
+  metadata:
+    kind: pod
+    run_status: complete
+    db_type: pg
+    storage_type: lso
+    current_worker: 32
+  metrics:
+  - name: tpm
+    metric_of_interest: tpm
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: -1

--- a/orion-configs/perfci-vdbench.yaml
+++ b/orion-configs/perfci-vdbench.yaml
@@ -503,39 +503,3 @@ tests:
       agg_type: avg
     threshold: 10
     direction: 1
-- name: vdbench-vm-64kb_write_16threads
-  metadata:
-    kind: vm
-    run_status: complete
-    Run: 64kb_write_16threads
-  metrics:
-  - name: iops
-    metric_of_interest: Rate
-    agg:
-      agg_type: avg
-    threshold: 10
-    direction: -1
-  - name: latency
-    metric_of_interest: Resp
-    agg:
-      agg_type: avg
-    threshold: 10
-    direction: 1
-- name: vdbench-pod-64kb_write_16threads
-  metadata:
-    kind: pod
-    run_status: complete
-    Run: 64kb_write_16threads
-  metrics:
-  - name: iops
-    metric_of_interest: Rate
-    agg:
-      agg_type: avg
-    threshold: 10
-    direction: -1
-  - name: latency
-    metric_of_interest: Resp
-    agg:
-      agg_type: avg
-    threshold: 10
-    direction: 1

--- a/orion-configs/perfci-windows-bootstorm.yaml
+++ b/orion-configs/perfci-windows-bootstorm.yaml
@@ -1,55 +1,37 @@
 tests:
-  - name: windows-bootstorm-windows11
-    metadata:
-      kind: vm
-      run_status: complete
-      vm_os_version: windows11
-    metrics:
-      - name: bootstorm-time
-        metric_of_interest: bootstorm_time
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: total-run-time
-        metric_of_interest: total_run_time
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-  - name: windows-bootstorm-server2022
-    metadata:
-      kind: vm
-      run_status: complete
-      vm_os_version: windows_server_2022
-    metrics:
-      - name: bootstorm-time
-        metric_of_interest: bootstorm_time
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: total-run-time
-        metric_of_interest: total_run_time
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-  - name: windows-bootstorm-server2025
-    metadata:
-      kind: vm
-      run_status: complete
-      vm_os_version: windows_server_2025
-    metrics:
-      - name: bootstorm-time
-        metric_of_interest: bootstorm_time
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
-      - name: total-run-time
-        metric_of_interest: total_run_time
-        agg:
-          agg_type: avg
-        threshold: 10
-        direction: 1
+- name: windows-bootstorm-windows11
+  metadata:
+    kind: vm
+    run_status: complete
+    vm_os_version: windows11
+  metrics:
+  - name: bootstorm-time
+    metric_of_interest: bootstorm_time
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: total-run-time
+    metric_of_interest: total_run_time
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+- name: windows-bootstorm-server2022
+  metadata:
+    kind: vm
+    run_status: complete
+    vm_os_version: windows_server_2022
+  metrics:
+  - name: bootstorm-time
+    metric_of_interest: bootstorm_time
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1
+  - name: total-run-time
+    metric_of_interest: total_run_time
+    agg:
+      agg_type: avg
+    threshold: 10
+    direction: 1


### PR DESCRIPTION
## Summary
- Remove Orion config tests that reference metadata combinations with no data in Elasticsearch
- When any test has no matching UUID, Orion calls `sys.exit(3)` and discards ALL results for the entire workload — including tests that passed
- Root cause of CloudSensei workload count dropping from 170 → 82

### Changes
| Config | Before | After | Removed |
|---|---|---|---|
| perfci-hammerdb.yaml | 96 | 78 | 12 win2k25 + 6 scale (no ES data) |
| perfci-vdbench.yaml | 30 | 28 | 2 `64kb_write_16threads` (no ES data) |
| perfci-windows-bootstorm.yaml | 3 | 2 | 1 `windows_server_2025` (workload removed) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test Configuration Updates**
  * Updated HammerDB performance scenarios for VM and pod deployments across MSSQL, MariaDB, and PostgreSQL.
  * Added CentOS Stream 10 and Windows Server 2025 metadata to selected MSSQL VM scenarios.
  * Removed outdated scale-storage MSSQL scenarios and two Vdbench workload tests.
  * Updated Windows bootstorm coverage for Windows 11 and Windows Server 2022.
  * Removed the Windows Server 2025 bootstorm configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->