### PR TITLE
Fix golden file generator: clear all file types between workloads

### DIFF
--- a/tests/unittest/benchmark_runner/common/template_operations/conftest.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/conftest.py
@@ -3,9 +3,3 @@ import tempfile
 from benchmark_runner.main.environment_variables import environment_variables
 
 environment_variables.environment_variables_dict['run_artifacts_path'] = tempfile.mkdtemp()
-
-from tests.unittest.benchmark_runner.common.template_operations.golden_files import GoldenFiles
-
-
-file_generator = GoldenFiles()
-file_generator.generate_golden_files()

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -42,9 +42,8 @@ class GoldenFiles:
     def __clear_directory_yaml(self, dir):
         if os.path.isdir(dir):
             for file in os.listdir(dir):
-                file_path = os.path.join(dir, file)
-                if os.path.isfile(file_path):
-                    os.remove(file_path)
+                if file.endswith('.yaml'):
+                    os.remove(os.path.join(dir, file))
 
     def __generate_yaml_dir_name(self, run_type: str, workload: str, odf_pvc: str, cdi_source: str='http', dest: str=None):
         if dest is None:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -42,8 +42,9 @@ class GoldenFiles:
     def __clear_directory_yaml(self, dir):
         if os.path.isdir(dir):
             for file in os.listdir(dir):
-                if file.endswith('.yaml'):
-                    os.remove(os.path.join(dir, file))
+                file_path = os.path.join(dir, file)
+                if os.path.isfile(file_path):
+                    os.remove(file_path)
 
     def __generate_yaml_dir_name(self, run_type: str, workload: str, odf_pvc: str, cdi_source: str='http', dest: str=None):
         if dest is None:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -75,8 +75,6 @@ class GoldenFiles:
             for run_type in environment_variables.run_types_list:
                 environment_variables.environment_variables_dict['run_type'] = run_type
                 for workload in environment_variables.environment_variables_dict['workloads']:
-                    if workload in _EXCLUDED_WORKLOADS:
-                        continue
                     cdi_sources = ['http', 's3'] if workload in _WINDOWS_WORKLOADS else ['http']
                     for cdi_source in cdi_sources:
                         environment_variables.environment_variables_dict['fedora_container_disk'] = 'quay.io/benchmark-runner/fedora-container-disk:43'
@@ -86,7 +84,6 @@ class GoldenFiles:
                         environment_variables.environment_variables_dict['storage_type'] = 'lso' if workload.endswith('_lso') else ''
                         environment_variables.environment_variables_dict['lso_node'] = 'pin-node-2' if workload.endswith('_lso') else ''
                         environment_variables.environment_variables_dict['lso_disk_id'] = 'test-disk-id-0000' if workload.endswith('_lso') else ''
-                        environment_variables.environment_variables_dict['workload'] = workload
                         template = TemplateOperations(workload)
                         srcdir = template.get_current_run_path()
                         self.__clear_directory_yaml(srcdir)

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files.py
@@ -76,6 +76,8 @@ class GoldenFiles:
             for run_type in environment_variables.run_types_list:
                 environment_variables.environment_variables_dict['run_type'] = run_type
                 for workload in environment_variables.environment_variables_dict['workloads']:
+                    if workload in _EXCLUDED_WORKLOADS:
+                        continue
                     cdi_sources = ['http', 's3'] if workload in _WINDOWS_WORKLOADS else ['http']
                     for cdi_source in cdi_sources:
                         environment_variables.environment_variables_dict['fedora_container_disk'] = 'quay.io/benchmark-runner/fedora-container-disk:43'
@@ -85,6 +87,7 @@ class GoldenFiles:
                         environment_variables.environment_variables_dict['storage_type'] = 'lso' if workload.endswith('_lso') else ''
                         environment_variables.environment_variables_dict['lso_node'] = 'pin-node-2' if workload.endswith('_lso') else ''
                         environment_variables.environment_variables_dict['lso_disk_id'] = 'test-disk-id-0000' if workload.endswith('_lso') else ''
+                        environment_variables.environment_variables_dict['workload'] = workload
                         template = TemplateOperations(workload)
                         srcdir = template.get_current_run_path()
                         self.__clear_directory_yaml(srcdir)


### PR DESCRIPTION
## Summary
- Fix `__clear_directory_yaml` to remove all files (not just `.yaml`) between workload generations
- Previously only `.yaml` files were cleared, leaving PS1/SQL/TCL scripts from Windows workloads in the shared `srcdir`
- These leaked into subsequent workloads' golden file directories (e.g. winstress PS1 files appearing in fio-vm directories)

## Root Cause
The golden file generator iterates over all workloads sharing the same `srcdir`. After generating Windows workload templates (winstress, winfio, winmssql), their PS1/SQL/TCL scripts remained in `srcdir` and appeared in the next workload's directory.

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Configured benchmark tests and golden-file generation to store run artifacts in temporary directories.
  * Improves test isolation and helps prevent generated files from affecting the local workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->