### PR TITLE
Add configurable ioThreads to Linux and Windows ODF VM workloads

### DIFF
--- a/benchmark_runner/common/template_operations/templates/fio/fio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/fio/fio_data_template.yaml
@@ -55,5 +55,7 @@ template_data:
       run_type:
         perf_ci:
           sockets: 2
+          io_threads: 2
         default:
           sockets: 2
+          io_threads: 2

--- a/benchmark_runner/common/template_operations/templates/fio/fio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/fio/fio_data_template.yaml
@@ -55,7 +55,7 @@ template_data:
       run_type:
         perf_ci:
           sockets: 2
-          io_threads: 2
+          supplementalPoolThreadCount: 8
         default:
           sockets: 2
-          io_threads: 2
+          supplementalPoolThreadCount: 2

--- a/benchmark_runner/common/template_operations/templates/fio/internal_data/fio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/fio/internal_data/fio_vm_template.yaml
@@ -97,6 +97,9 @@ spec:
           sockets: {{ sockets }}
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: {{ io_threads }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/fio/internal_data/fio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/fio/internal_data/fio_vm_template.yaml
@@ -99,7 +99,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -80,7 +80,9 @@ template_data:
           sockets: 32
           cores: 1
           vm_requests_memory: 32Gi
+          io_threads: 8
         default:
           sockets: 1
           cores: 2
           vm_requests_memory: 8Gi
+          io_threads: 8

--- a/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/hammerdb_data_template.yaml
@@ -80,9 +80,9 @@ template_data:
           sockets: 32
           cores: 1
           vm_requests_memory: 32Gi
-          io_threads: 8
+          supplementalPoolThreadCount: 8
         default:
           sockets: 1
           cores: 2
           vm_requests_memory: 8Gi
-          io_threads: 8
+          supplementalPoolThreadCount: 2

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
@@ -173,7 +173,7 @@ spec:
           cores: {{ cores }}
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mariadb_vm_template.yaml
@@ -171,6 +171,9 @@ spec:
         cpu:
           sockets: {{ sockets }}
           cores: {{ cores }}
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: {{ io_threads }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
@@ -147,7 +147,7 @@ spec:
           cores: {{ cores }}
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_mssql_vm_template.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: {{ sockets }}
           cores: {{ cores }}
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: {{ io_threads }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
@@ -139,7 +139,7 @@ spec:
           cores: {{ cores }}
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/hammerdb_postgres_vm_template.yaml
@@ -137,6 +137,9 @@ spec:
         cpu:
           sockets: {{ sockets }}
           cores: {{ cores }}
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: {{ io_threads }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -101,6 +101,9 @@ spec:
           sockets: {{ sockets }}
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: {{ io_threads }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/internal_data/vdbench_vm_template.yaml
@@ -103,7 +103,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         devices:
           disks:
             - disk:

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -60,7 +60,7 @@ template_data:
       run_type:
         perf_ci:
           sockets: 2
-          io_threads: 2
+          supplementalPoolThreadCount: 8
         default:
           sockets: 2
-          io_threads: 2
+          supplementalPoolThreadCount: 2

--- a/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/vdbench/vdbench_data_template.yaml
@@ -60,5 +60,7 @@ template_data:
       run_type:
         perf_ci:
           sockets: 2
+          io_threads: 2
         default:
           sockets: 2
+          io_threads: 2

--- a/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
@@ -97,7 +97,7 @@ spec:
             efi:
               secureBoot: false
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: {{ io_threads }}
         ioThreadsPolicy: supplementalPool
         machine:
           type: q35

--- a/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/internal_data/winfio_vm_template.yaml
@@ -97,7 +97,7 @@ spec:
             efi:
               secureBoot: false
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         ioThreadsPolicy: supplementalPool
         machine:
           type: q35

--- a/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
@@ -35,11 +35,13 @@ template_data:
       requests_memory: 4G
       requests_cpu: 8
       cores: 8
+      io_threads: 8
       storage: 76Gi
       data_disk_storage: 64Gi
     default:
       requests_memory: 4G
       requests_cpu: 1
       cores: 2
+      io_threads: 8
       storage: 76Gi
       data_disk_storage: 64Gi

--- a/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winfio/winfio_data_template.yaml
@@ -35,13 +35,13 @@ template_data:
       requests_memory: 4G
       requests_cpu: 8
       cores: 8
-      io_threads: 8
+      supplementalPoolThreadCount: 8
       storage: 76Gi
       data_disk_storage: 64Gi
     default:
       requests_memory: 4G
       requests_cpu: 1
       cores: 2
-      io_threads: 8
+      supplementalPoolThreadCount: 8
       storage: 76Gi
       data_disk_storage: 64Gi

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
@@ -97,7 +97,7 @@ spec:
             efi:
               secureBoot: false
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: {{ io_threads }}
         ioThreadsPolicy: supplementalPool
         machine:
           type: q35

--- a/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/internal_data/winmssql_vm_template.yaml
@@ -97,7 +97,7 @@ spec:
             efi:
               secureBoot: false
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         ioThreadsPolicy: supplementalPool
         machine:
           type: q35

--- a/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
@@ -31,7 +31,7 @@ template_data:
       database_requests_memory: 32G
       database_requests_cpu: 32
       cores: 32
-      io_threads: 8
+      supplementalPoolThreadCount: 8
       storage: 76Gi
     default:
       db_num_workers: 2
@@ -39,5 +39,5 @@ template_data:
       database_requests_memory: 16G
       database_requests_cpu: 16
       cores: 16
-      io_threads: 8
+      supplementalPoolThreadCount: 8
       storage: 76Gi

--- a/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winmssql/winmssql_data_template.yaml
@@ -31,6 +31,7 @@ template_data:
       database_requests_memory: 32G
       database_requests_cpu: 32
       cores: 32
+      io_threads: 8
       storage: 76Gi
     default:
       db_num_workers: 2
@@ -38,4 +39,5 @@ template_data:
       database_requests_memory: 16G
       database_requests_cpu: 16
       cores: 16
+      io_threads: 8
       storage: 76Gi

--- a/benchmark_runner/common/template_operations/templates/winstress/internal_data/winstress_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/internal_data/winstress_vm_template.yaml
@@ -98,7 +98,7 @@ spec:
             efi:
               secureBoot: false
         ioThreads:
-          supplementalPoolThreadCount: {{ io_threads }}
+          supplementalPoolThreadCount: {{ supplementalPoolThreadCount }}
         ioThreadsPolicy: supplementalPool
         machine:
           type: q35

--- a/benchmark_runner/common/template_operations/templates/winstress/internal_data/winstress_vm_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/internal_data/winstress_vm_template.yaml
@@ -98,7 +98,7 @@ spec:
             efi:
               secureBoot: false
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: {{ io_threads }}
         ioThreadsPolicy: supplementalPool
         machine:
           type: q35

--- a/benchmark_runner/common/template_operations/templates/winstress/winstress_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/winstress_data_template.yaml
@@ -23,6 +23,7 @@ template_data:
       cores: 16
       sockets: 1
       threads: 1
+      io_threads: 8
       storage: 76Gi
     default:
       requests_memory: 4G
@@ -30,4 +31,5 @@ template_data:
       cores: 2
       sockets: 1
       threads: 1
+      io_threads: 8
       storage: 76Gi

--- a/benchmark_runner/common/template_operations/templates/winstress/winstress_data_template.yaml
+++ b/benchmark_runner/common/template_operations/templates/winstress/winstress_data_template.yaml
@@ -23,7 +23,7 @@ template_data:
       cores: 16
       sockets: 1
       threads: 1
-      io_threads: 8
+      supplementalPoolThreadCount: 8
       storage: 76Gi
     default:
       requests_memory: 4G
@@ -31,5 +31,5 @@ template_data:
       cores: 2
       sockets: 1
       threads: 1
-      io_threads: 8
+      supplementalPoolThreadCount: 8
       storage: 76Gi

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/chaos_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/func_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
@@ -57,7 +57,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -70,7 +70,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
@@ -57,7 +57,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -70,7 +70,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 32
           cores: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -61,7 +61,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -74,7 +74,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
@@ -61,7 +61,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/perf_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -74,7 +74,7 @@ spec:
           threads: 1
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 2
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/release_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ephemeral_ODF_PVC_False/fio_vm.yaml
@@ -55,6 +55,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_fio_vm_ephemeral_ODF_PVC_True/fio_vm.yaml
@@ -68,6 +68,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_ephemeral_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -147,7 +147,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_lso_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -145,6 +145,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -113,6 +113,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_False/hammerdb_vm_mariadb.yaml
@@ -115,7 +115,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -126,6 +126,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mariadb_scale_ODF_PVC_True/hammerdb_vm_mariadb.yaml
@@ -128,7 +128,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_ephemeral_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -119,6 +119,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_lso_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -121,7 +121,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -87,6 +87,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_False/hammerdb_vm_mssql.yaml
@@ -89,7 +89,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -102,7 +102,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_mssql_scale_ODF_PVC_True/hammerdb_vm_mssql.yaml
@@ -100,6 +100,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_ephemeral_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -111,6 +111,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_lso_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -113,7 +113,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -81,7 +81,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_False/hammerdb_vm_postgres.yaml
@@ -79,6 +79,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -92,6 +92,9 @@ spec:
         cpu:
           sockets: 1
           cores: 2
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 8
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_hammerdb_vm_postgres_scale_ODF_PVC_True/hammerdb_vm_postgres.yaml
@@ -94,7 +94,7 @@ spec:
           cores: 2
         ioThreadsPolicy: supplementalPool
         ioThreads:
-          supplementalPoolThreadCount: 8
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ephemeral_ODF_PVC_False/vdbench_vm.yaml
@@ -59,6 +59,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:

--- a/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
+++ b/tests/unittest/benchmark_runner/common/template_operations/golden_files/test_ci_vdbench_vm_ephemeral_ODF_PVC_True/vdbench_vm.yaml
@@ -72,6 +72,9 @@ spec:
           sockets: 2
           cores: 1
           threads: 1
+        ioThreadsPolicy: supplementalPool
+        ioThreads:
+          supplementalPoolThreadCount: 2
         devices:
           disks:
             - disk:


### PR DESCRIPTION
## Summary
- Add `ioThreadsPolicy: supplementalPool` and configurable `io_threads` variable to all ODF VM workloads
- Linux workloads: `fio_vm`, `vdbench_vm`, `hammerdb_vm` (mariadb/mssql/postgres)
- Windows workloads: `winmssql_vm`, `winstress_vm`, `winfio_vm` (replaces previously hardcoded value)

## Default values
| Workload | io_threads |
|---|---|
| fio_vm | 2 |
| vdbench_vm | 2 |
| hammerdb_vm (all DB variants) | 8 |
| winmssql_vm | 8 |
| winstress_vm | 8 |
| winfio_vm | 8 |

## Configuration
Override at runtime via `WORKLOAD_CONFIG`:
```bash
WORKLOAD_CONFIG="{'io_threads': 4}"
```

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable supplemental I/O thread pools to fio, Vdbench, HammerDB, and Windows benchmark virtual machines.
  * Standard benchmark runs use two supplemental threads, while performance runs use eight.
  * Windows benchmark configurations now consistently apply their configured supplemental thread count.

* **Tests**
  * Updated expected virtual machine configurations across functional, performance, release, and test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->