### PR TITLE
Fix ODF_CATALOG_IMAGE empty credential causing MissingPropertyException

### DIFF
--- a/benchmark_runner/common/ocp_resources/create_odf.py
+++ b/benchmark_runner/common/ocp_resources/create_odf.py
@@ -20,7 +20,7 @@ class CreateODF(CreateOCPResourceOperations):
         self.__resource_list = resource_list
         self.__worker_disk_ids = worker_disk_ids
         self.__worker_disk_prefix = worker_disk_prefix
-        self.__odf_catalog_image = odf_catalog_image
+        self.__odf_catalog_image = odf_catalog_image.strip() if odf_catalog_image else ''
 
     @logger_time_stamp
     def create_odf(self, upgrade_version: str):

--- a/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
+++ b/benchmark_runner/common/ocp_resources/odf/template/07_subscription_template.yaml
@@ -7,5 +7,5 @@ spec:
   channel: "stable-{{ odf_version }}"
   installPlanApproval: Automatic
   name: odf-operator
-  source: "{% if odf_catalog_image %}odf-catalog-source{% else %}redhat-operators{% endif %}"
+  source: "{% if odf_catalog_image and odf_catalog_image.strip() %}odf-catalog-source{% else %}redhat-operators{% endif %}"
   sourceNamespace: openshift-marketplace

--- a/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
+++ b/jenkins/PerfCI/02_PerfCI_Operators_Deployment/Jenkinsfile
@@ -149,7 +149,7 @@ END
                                                             -e CNV_VERSION='${CNV_VERSION}' \
                                                             -e LSO_VERSION='${LSO_VERSION}' \
                                                             -e ODF_VERSION='${ODF_VERSION}' \
-                                                            -e ODF_CATALOG_IMAGE='${ODF_CATALOG_IMAGE}' \
+                                                            -e ODF_CATALOG_IMAGE='${env.ODF_CATALOG_IMAGE ?: ''}' \
                                                             -e NUM_ODF_DISK='${NUM_ODF_DISK}' \
                                                             -e KUBEADMIN_PASSWORD='${KUBEADMIN_PASSWORD}' \
                                                             -e PROVISION_IP='${PROVISION_IP}' \


### PR DESCRIPTION
## Summary
- Fix `MissingPropertyException: No such property: ODF_CATALOG_IMAGE` in the Operators Deployment stage
- When the `perfci_odf_catalog_image` credential is empty, Jenkins does not create a Groovy binding variable, causing GString interpolation to fail
- Replace `${ODF_CATALOG_IMAGE}` with `${env.ODF_CATALOG_IMAGE ?: ''}` to safely read from the environment map with an empty string fallback

## Behavior
- Empty credential → passes `-e ODF_CATALOG_IMAGE=''` to container → template renders empty → skipped by `create_odf.py`
- Non-empty credential → passes the catalog image URL → creates custom ODF CatalogSource

🤖 Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Operators Deployment handling when the catalog image setting is unavailable or contains only whitespace.
  * Ensured deployments use a safe empty default instead of failing due to an unset or blank value.
  * Improved subscription source selection by ignoring invalid catalog image values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->